### PR TITLE
Add build-headless npm script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17451,6 +17451,12 @@
         "aproba": "^1.1.1"
       }
     },
+    "run-script-os": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.1.tgz",
+      "integrity": "sha512-tM3mfchUIpo9WOFioO3eO/lTgRbtqcqBmSkkqfkjXmxn7vvhwykOXxOOKIXFP+ZConvLsS5KskM3yX+XBfDD4g==",
+      "dev": true
+    },
     "rxjs": {
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "server": "graphql-codegen && npx webpack-dev-server --env.NODE_ENV=development --env.target=render --hot",
     "start": "graphql-codegen && npx webpack --env.NODE_ENV=development --env.target=main && npx electron ./dist/.",
     "pack": "graphql-codegen && npm run build-prod && npx electron-packager ./dist --out ./pack --overwrite --icon=./src/resources/icon.ico",
-    "codegen": "graphql-codegen"
+    "codegen": "graphql-codegen",
+    "build-headless": "run-script-os",
+    "build-headless:windows": "dotnet publish nekoyume-unity/NineChronicles.Standalone.Executable/NineChronicles.Standalone.Executable.csproj -r win-x64 -o dist/publish --self-contained",
+    "build-headless:darwin": "dotnet publish nekoyume-unity/NineChronicles.Standalone.Executable/NineChronicles.Standalone.Executable.csproj -r osx-x64 -o dist/publish --self-contained"
   },
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",
@@ -98,6 +101,7 @@
     "pretty-quick": "^2.0.1",
     "react-hot-loader": "^4.12.21",
     "react-test-renderer": "^16.13.1",
+    "run-script-os": "^1.1.1",
     "sass-loader": "^8.0.2",
     "typescript": "^3.9.3",
     "webpack": "^4.43.0",


### PR DESCRIPTION
#38 이후 submodule이 들어감에 따라 *NineChronicles.Standalone.Executable* 프로젝트의 위치를 확정지을 수 있게 되었습니다.
따라서 빌드 당시에 수동으로 headless를 빌드하여 dist/publish에 넣을 필요없이 스크립트로 처리하게 합니다. 

`npm run build-headless`를 실행하여 사용할 수 있습니다. [run-script-os] 패키지를 통해 각각 실행환경에 따라서 `build-headless:windows`, `build-headless:darwin`으로 라우팅됩니다.


[run-script-os]: https://www.npmjs.com/package/run-script-os