### PR TITLE
api.graphql schema.graphql 업데이트

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -40,7 +40,7 @@ subscription NodeStatusSubscription {
   }
 }
 
-query DecreyptedPrivateKey($address: Address, $passphrase: String) {
+query DecreyptedPrivateKey($address: Address!, $passphrase: String!) {
   keyStore {
     decryptedPrivateKey(address: $address, passphrase: $passphrase)
   }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -38,7 +38,7 @@ scalar SByte
 
 type StandaloneQuery {
   keyStore: KeyStoreType
-  nodeStatus: NodeStatusType
+  nodeStatus: NodeStatusType!
   state(address: Address!, hash: ByteString): ByteString
 }
 
@@ -47,12 +47,12 @@ scalar ByteString
 scalar Address
 
 type KeyStoreType {
-  decryptedPrivateKey(address: Address, passphrase: String): ByteString
-  protectedPrivateKeys: [ProtectedPrivateKeyType]!
+  decryptedPrivateKey(address: Address!, passphrase: String!): ByteString!
+  protectedPrivateKeys: [ProtectedPrivateKeyType!]!
 }
 
 type ProtectedPrivateKeyType {
-  address: Address
+  address: Address!
 }
 
 type NodeStatusType {
@@ -65,19 +65,19 @@ type StandaloneMutation {
 }
 
 type KeyStoreMutation {
-  createPrivateKey(passphrase: String): ProtectedPrivateKeyType
-  revokePrivateKey(address: Address): ProtectedPrivateKeyType
+  createPrivateKey(passphrase: String!): ProtectedPrivateKeyType!
+  revokePrivateKey(address: Address!): ProtectedPrivateKeyType!
 }
 
 type StandaloneSubscription {
-  preloadProgress: PreloadStateType
   nodeStatus: NodeStatusType
+  preloadProgress: PreloadStateType
   tipChanged: TipChanged
 }
 
 type TipChanged {
   hash: ByteString
-  index: Long
+  index: Long!
 }
 
 type PreloadStateType {


### PR DESCRIPTION
planetarium/nekoyume-unity#2364 이후 변경된 GraphQL 타입을 적용합니다.
본 PR에서는 서브모듈을 업데이트하는 커밋을 포함하고 있지 않기 때문에 `npm run build-headless`로 빌드한 헤드리스와는 호환되지 않습니다.