### PR TITLE
react-hot-loader가 돌아가지 않던 문제 해결

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -96,4 +96,4 @@ function App() {
   );
 }
 
-export default hot(App);
+export default hot(module)(App);


### PR DESCRIPTION
- 이제 렌더러 쪽 작업할 때 react-hot-loader와 mobx간의 충돌이 사라져, 매번 새로고침을 하지 않아도 됩니다.