### PR TITLE
Clear Cache 버튼을 로그인 시점으로 옮김

### DIFF
--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -32,7 +32,6 @@ const ConfigurationView = observer(
           setProgress={setProgress}
         />
         <br />
-        <ClearCacheButton disabled={isDisable} />
         <br />
         {isDownloading || isExtracting ? (
           <LinearProgress variant="determinate" value={progress} />

--- a/src/renderer/views/login/LoginView.tsx
+++ b/src/renderer/views/login/LoginView.tsx
@@ -15,6 +15,7 @@ import { useDecreyptedPrivateKeyLazyQuery } from "../../../generated/graphql";
 import Alert from "../../components/Alert";
 import Snackbar from "@material-ui/core/Snackbar";
 import { AccountSelect } from "../../components/AccountSelect";
+import ClearCacheButton from "../../components/ClearCacheButton";
 
 const QUERY_CRYPTKEY = gql`
   query {
@@ -137,6 +138,8 @@ const LoginView = observer((props: IStoreContainer) => {
         {" "}
         Account Management{" "}
       </button>
+      <br />
+      <ClearCacheButton disabled={false} />
       <br />
       <button onClick={() => routerStore.push("/config")}> Config </button>
       <Snackbar


### PR DESCRIPTION
#97 의 일부입니다.
- https://app.zeplin.io/project/5ef61c53b40d8f799af82d71/screen/5ef61e615cd06ba03d708efc 에서 `Clear Cache` 버튼을 로그인 시점으로 옮깁니다.