### PR TITLE
webpack hot reload 404 에러 수정

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ function createRenderConfig(isDev) {
     output: {
       filename: isDev ? "[name].js" : "[name].[hash].js",
       path: path.join(__dirname, "dist"),
+      publicPath: "/",
     },
 
     externals: {
@@ -136,6 +137,7 @@ function createRenderConfig(isDev) {
           contentBase: path.join(__dirname, "dist"),
           compress: true,
           port: 9000,
+          historyApiFallback: true,
         }
       : undefined,
   };


### PR DESCRIPTION
Ref: https://stackoverflow.com/questions/43209666/react-router-v4-cannot-get-url

Webpack에서 hot reload될때 not found 에러가 나던 문제를 해결합니다.