### PR TITLE
게임 실행 버튼 프리로드 화면에 넣기

### DIFF
--- a/src/renderer/views/lobby/PreloadView.tsx
+++ b/src/renderer/views/lobby/PreloadView.tsx
@@ -22,6 +22,7 @@ import {
   usePreloadProgressSubscriptionSubscription,
 } from "../../../generated/graphql";
 import preloadViewStyle from "./PreloadView.style";
+import LobbyView from "./LobbyView";
 
 enum PreloadProgressPhase {
   ActionExecutionState,
@@ -47,11 +48,11 @@ const PreloadView = observer((props: IStoreContainer) => {
     "Connecting to the network..."
   );
 
+  const [isPreloadEnded, setPreloadStats] = React.useState(false);
+
   React.useEffect(() => {
     const isEnded = nodeStatusSubscriptionResult?.nodeStatus?.preloadEnded;
-    if (isEnded) {
-      routerStore.push("/lobby");
-    }
+    setPreloadStats(isEnded === undefined ? false : isEnded);
   }, [nodeStatusSubscriptionResult?.nodeStatus?.preloadEnded]);
 
   React.useEffect(() => {
@@ -135,10 +136,16 @@ const PreloadView = observer((props: IStoreContainer) => {
           <ListItemText primary="Nine Chronicles Player Guide" />
         </ListItem>
       </List>
-      {!!preloadProgress && <LinearProgressWithLabel value={progress} />}
-      <Typography align="center" display="block" variant="caption">
-        {statusMessage}
-      </Typography>
+      {!isPreloadEnded ? (
+        <>
+          {!!preloadProgress && <LinearProgressWithLabel value={progress} />}
+          <Typography align="center" display="block" variant="caption">
+            {statusMessage}
+          </Typography>
+        </>
+      ) : (
+        <LobbyView {...props} />
+      )}
     </Container>
   );
 });


### PR DESCRIPTION
프리로드가 끝나면 게임 실행 버튼이 나옵니다.
<img width="912" alt="스크린샷 2020-07-08 오후 3 47 21" src="https://user-images.githubusercontent.com/16367497/86886693-582b9c00-c132-11ea-898e-54aa51b45caa.png">
<img width="912" alt="스크린샷 2020-07-08 오후 3 47 26" src="https://user-images.githubusercontent.com/16367497/86886703-5e217d00-c132-11ea-91de-eaa9e49a3172.png">
