### PR TITLE
Use app.exit() instead app.quit()

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -242,7 +242,7 @@ function initializeIpc() {
 
       // 재시작
       app.relaunch();
-      app.quit();
+      app.exit();
 
       /*
       Electron이 제공하는 autoUpdater는 macOS에서는 무조건 코드사이닝 되어야 동작.


### PR DESCRIPTION
업데이트 후 아래 코드를 통해서 재시작합니다.

```typescript
app.relaunch();
app.quit();
```

하지만 `app.quit()`가 기대한 것과 같이 앱을 종료 시켜주지 않아서 `app.exit()`로 대체합니다.
