### PR TITLE
npm run sign-apv 명령 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,24 @@ npm install
 npm run build  # 개발 빌드
 npm run build-headless  # 9C Headless (Standalone) 빌드 (.NET Core SDK 필요)
 npm run bundle-player  # 9C Unity Player 받기
+APV_SIGN_KEY=... APV_NO=... npm run sign-apv  # APV 서명 (planet 명령 필요)
 npm run build-prod  # 프로덕션 빌드
 ```
 
 ## 패키징 방법
 
 ```bash
-npm run pack-all
+APV_SIGN_KEY=... APV_NO=... npm run pack-all
 ```
+
+다음 환경 변수를 요구합니다. 누락됐을 경우 APV(앱 프로토콜 버전) 서명을 안 합니다.
+
+- `APV_SIGN_KEY`: APV 서명에 쓸 비밀키의 16진수 문자열
+  (프로덕션 빌드를 위한 서명용 비밀키는 동료에게 문의하세요)
+- `APV_NO`: APV 숫자
+  ([`Libplanet.Net.AppProtocolVersion.Version`][appprotocolversion.version])
+
+[appprotocolversion.version]: https://docs.libplanet.io/master/api/Libplanet.Net.AppProtocolVersion.html#Libplanet_Net_AppProtocolVersion_Version
 
 ## 로깅 위치
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "build-headless:windows": "dotnet publish nekoyume-unity/NineChronicles.Standalone.Executable/NineChronicles.Standalone.Executable.csproj -r win-x64 -o dist/publish --self-contained",
     "build-headless:darwin": "dotnet publish nekoyume-unity/NineChronicles.Standalone.Executable/NineChronicles.Standalone.Executable.csproj -r osx-x64 -o dist/publish --self-contained",
     "bundle-player": "npx ts-node scripts/downloadPlayer.ts",
-    "pack-all": "npm install && npm run build-headless && npm run bundle-player && npm run pack"
+    "sign-apv": "run-script-os",
+    "sign-apv:windows": "powershell -nop -ex bypass -noni -f scripts\\sign-apv.ps1 || (exit 0)",
+    "sign-apv:darwin": "scripts/sign-apv.sh || true",
+    "pack-all": "npm install && npm run build-headless && npm run bundle-player && npm run sign-apv && npm run pack"
   },
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",

--- a/scripts/sign-apv.ps1
+++ b/scripts/sign-apv.ps1
@@ -1,0 +1,60 @@
+#!/usr/bin/env pwsh
+if ("$env:APV_SIGN_KEY" -eq "") {
+  Write-Error "APV_SIGN_KEY is not configured." -ErrorAction Stop
+} elseif ("$env:APV_NO" -eq "") {
+  Write-Error "APV_NO is not configured." -ErrorAction Stop
+} elseif (-not (Get-Command planet -ErrorAction SilentlyContinue)) {
+  Write-Error "`
+The planet command does not exist.
+Please install Libplanet.Tools first:
+  dotnet tool install --global Libplanet.Tools" `
+    -ErrorAction Stop
+}
+
+$DefaultUrlBase = "https://download.nine-chronicles.com/v"
+
+if ("$env:APV_MACOS_URL" -eq "") {
+  $macOSBinaryUrl = "$DefaultUrlBase$env:APV_NO/macOS.tar.gz"
+} else {
+  $macOSBinaryUrl = $env:APV_MACOS_URL;
+}
+
+if ("$env:APV_WINDOWS_URL" -eq "") {
+  $windowsBinaryUrl = "$DefaultUrlBase$env:APV_NO/Windows.zip"
+} else {
+  $windowsBinaryUrl = $env:APV_WINDOWS_URL;
+}
+
+$passphrase = [Guid]::NewGuid().ToString()
+$keyId = (
+  "$(planet key import --passphrase="$passphrase" "$env:APV_SIGN_KEY")"
+).Split(" ")[0]
+$apv = "$(`
+  planet apv sign `
+    --passphrase="$passphrase" `
+    --extra macOSBinaryUrl="$macOSBinaryUrl" `
+    --extra WindowsBinaryUrl="$windowsBinaryUrl" `
+    --extra timestamp="$([DateTimeOffset]::UtcNow.ToString("o"))" `
+    "$keyId" `
+    "$env:APV_NO" `
+)"
+Write-Host "$apv"
+planet key remove --passphrase="$passphrase" "$keyId"
+planet apv analyze "$apv"
+
+$configPath = $MyInvocation.MyCommand.Definition `
+  | Split-Path -Parent `
+  | Split-Path -Parent `
+  | Join-Path -ChildPath "dist" -AdditionalChildPath "config.json"
+if (Test-Path "$configPath" -PathType Leaf) {
+  $config = Get-Content "$configPath" | ConvertFrom-Json
+} else {
+  $config = ConvertFrom-Json '{"AppProtocolVersion": null}'
+}
+
+if ($config.PSObject.Properties.Name.Contains("AppProtocolVersion")) {
+  $config.AppProtocolVersion = "$apv"
+} else {
+  $config | Add-Member AppProtocolVersion "$apv"
+}
+$config | ConvertTo-Json > "$configPath"

--- a/scripts/sign-apv.sh
+++ b/scripts/sign-apv.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [[ "$APV_SIGN_KEY" = "" ]]; then
+  echo "APV_SIGN_KEY is not configured." > /dev/stderr
+  exit 1
+elif [[ "$APV_NO" = "" ]]; then
+  echo "APV_NO is not configured." > /dev/stderr
+  exit 1
+elif ! command -v planet > /dev/null; then
+  {
+    echo "The planet command does not exist."
+    echo "Please install Libplanet.Tools first:"
+    echo "  dotnet tool install --global Libplanet.Tools"
+  } > /dev/stderr
+  exit 1
+fi
+
+default_url_base=https://download.nine-chronicles.com/v
+macos_url="${APV_MACOS_URL:-$default_url_base$APV_NO/macOS.tar.gz}"
+windows_url="${APV_WINDOWS_URL:-$default_url_base$APV_NO/Windows.zip}"
+
+passphrase="$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 32 | head -n 1)"
+key_id="$(planet key import --passphrase="$passphrase" "$APV_SIGN_KEY" \
+          | awk '{print $1}')"
+apv="$( \
+  planet apv sign \
+    --passphrase="$passphrase" \
+    --extra macOSBinaryUrl="$macos_url" \
+    --extra WindowsBinaryUrl="$windows_url" \
+    --extra timestamp="$(date --iso-8601=sec)" \
+    "$key_id" \
+    "$APV_NO"
+)"
+echo "$apv"
+planet key remove --passphrase="$passphrase" "$key_id"
+planet apv analyze "$apv"
+
+config_path="$(dirname "$0")/../dist/config.json"
+node -e '
+var configString = process.argv[1];
+var config = configString.trim() ? JSON.parse(configString) : {};
+config.AppProtocolVersion = process.argv[2]
+console.log(JSON.stringify(config, null, 2));
+' "$(cat "$config_path" 2> /dev/null || echo '{}')" "$apv" > "$config_path"


### PR DESCRIPTION
`npm run sign-apv` 명령을 통해 APV 서명을 할 수 있게 했습니다. 또는 `npm run pack-all`을 할 때도 APV 서명이 이뤄집니다. 자세한 것은 *README.md*에 추가된 내용을 참고해 주세요.