### PR TITLE
CI에서 패키지 만들 때 MonoBleedingEdge 폴더 삭제하지 않도록

### DIFF
--- a/scripts/downloadPlayer.ts
+++ b/scripts/downloadPlayer.ts
@@ -178,7 +178,7 @@ async function bundlePlayerBinary(
   await DECOMPRESSOR[platform](tmpPath, bundleInto);
   const unnecessaryDirs = // 론처 v1의 잔재들
     platform == "Windows"
-      ? ["Nine Chronicles.exe", "MonoBleedingEdge", "qt-runtime"]
+      ? ["Nine Chronicles.exe", "qt-runtime"]
       : ["Nine Chronicles.app"];
   for (const unnecessaryDir of unnecessaryDirs) {
     try {


### PR DESCRIPTION
#182 참고. 관련 대화: <https://planetariumhq.slack.com/archives/CCBRB031P/p1595317167203400>.