### PR TITLE
Windows에서 npm run configure-apv 오작동 고침

### DIFF
--- a/scripts/configureApv.ts
+++ b/scripts/configureApv.ts
@@ -15,7 +15,11 @@ async function configureApv(configPath: string, apv: string): Promise<void> {
 
 async function main(): Promise<void> {
   const argv = process.argv.slice();
-  if (argv[0].endsWith("ts-node") && argv[1] == __filename) {
+  if (
+    (path.basename(argv[0]) === "ts-node" ||
+      argv[0].endsWith("\\ts-node\\dist\\bin.js")) &&
+    path.basename(argv[1]) == path.basename(__filename)
+  ) {
     argv.shift();
     argv[0] = "npm run configure-apv";
   }


### PR DESCRIPTION
[config.json의 `AppProtocolVersion` 필드가 엉뚱한 값이 들어가는 버그][1]를 고칩니다.

[1]: https://planetariumhq.slack.com/archives/CCBRB031P/p1595480910429300