### PR TITLE
npm run bundle-player 다운로드 오류 시 부가 정보 표시

### DIFF
--- a/scripts/downloadPlayer.ts
+++ b/scripts/downloadPlayer.ts
@@ -165,9 +165,10 @@ async function bundlePlayerBinary(
       f,
       options.downloadProgress
     );
-  } catch {
+  } catch (e) {
     throw new Error(
-      `Failed to download the player executable from ${playerCommit}.`
+      `Failed to download the player executable from ${playerCommit}.` +
+        (e.statusCode == null ? "" : ` [status code: ${e.statusCode}]`)
     );
   } finally {
     f.close();


### PR DESCRIPTION
HTTP 응답 코드도 함께 표시합니다.

```
$ npm run bundle-player

> NineChronicles@0.1.0 bundle-player /Users/dahlia/Projects/9c-launcher
> npx ts-node scripts/downloadPlayer.ts

Error: Failed to download the player executable from c1ccbb8f30f0b2eefdadba8ee4cc47f78c32e9bd. [status code: 403]
    at /Users/dahlia/Projects/9c-launcher/scripts/downloadPlayer.ts:169:11
    at Generator.throw (<anonymous>)
    at rejected (/Users/dahlia/Projects/9c-launcher/scripts/downloadPlayer.ts:6:65)
```