### PR TITLE
스냅샷 압축을 풀고 난 후 마이닝 설정 유지

### DIFF
--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -23,7 +23,7 @@ enum PreloadProgressPhase {
 }
 
 const PreloadProgressView = observer((props: IStoreContainer) => {
-  const { routerStore, standaloneStore } = props;
+  const { accountStore, routerStore, standaloneStore } = props;
   const classes = preloadProgressViewStyle();
   const {
     data: preloadProgressSubscriptionResult,
@@ -107,10 +107,20 @@ const PreloadProgressView = observer((props: IStoreContainer) => {
 
   const startPreloading = () => {
     mixpanel.track("Launcher/IBD Start");
-    standaloneStore.runStandalone().catch((error) => {
-      console.log(error);
-      routerStore.push("/error");
-    });
+    standaloneStore
+      .runStandalone()
+      .then(() => {
+        if (accountStore.isLogin && accountStore.privateKey !== "") {
+          return standaloneStore.setMining(
+            !standaloneStore.NoMiner,
+            accountStore.privateKey
+          );
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+        routerStore.push("/error");
+      });
   };
 
   React.useEffect(() => {
@@ -207,4 +217,8 @@ const getProgress = (
   return total === 0 ? 0 : Math.round((current / total) * 100);
 };
 
-export default inject("routerStore", "standaloneStore")(PreloadProgressView);
+export default inject(
+  "accountStore",
+  "routerStore",
+  "standaloneStore"
+)(PreloadProgressView);


### PR DESCRIPTION
#203 

압축을 풀 때 스탠드얼론을 종료하기 때문에 기존에는 마이닝 여부를 설정해 두었어도 다시 풀리게 됩니다.

스탠드얼론을 다시 키는 부분에 다시 마이닝을 켜 주어 위 사례를 막습니다.