### PR TITLE
`electron-dl` module 버전 ^3.0.2로 업데이트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8891,9 +8891,9 @@
       }
     },
     "electron-dl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/electron-dl/-/electron-dl-3.0.0.tgz",
-      "integrity": "sha512-TeBRv+vQgNVLGf/XLV4EYfYIBMI4TQcw84aDlM8xEm/1Lgxux3PUXDzaingivf+6jMvRojXSRPTHmiWI/6LrqQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/electron-dl/-/electron-dl-3.0.2.tgz",
+      "integrity": "sha512-pRgE9Jbhoo5z6Vk3qi+vIrfpMDlCp2oB1UeR96SMnsfz073jj0AZGQwp69EdIcEvlUlwBSGyJK8Jt6OB6JLn+g==",
       "requires": {
         "ext-name": "^5.0.0",
         "pupa": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bencodex": "^0.1.1",
     "buffer": "^5.6.0",
     "child-process-promise": "^2.2.1",
-    "electron-dl": "^3.0.0",
+    "electron-dl": "^3.0.2",
     "electron-is-dev": "^1.2.0",
     "electron-log": "^4.2.1",
     "electron-store": "^5.2.0",


### PR DESCRIPTION
Closes #199 

`electron-dl`의 3.0.2에서 추가된 기능을 통해 더이상 다운로드가 잘못 되었을 때 에러 다이얼로그가 강제로 출력되지 않습니다.