### PR TITLE
업데이터 오류 수정 

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -498,7 +498,9 @@ function cleanUpLockfile() {
 }
 
 function execute(binaryPath: string, args: string[]) {
-  console.log(`Execute subprocess: ${binaryPath} ${args.join(" ")}`);
+  if (isDev) {
+    console.log(`Execute subprocess: ${binaryPath} ${args.join(" ")}`);
+  }
   let node = spawn(binaryPath, args);
   pids.push(node.pid);
 


### PR DESCRIPTION
#210 의 문제는, 업데이터에서 파일을 카피할때 이전 디렉토리에 `fs.stat()` 을 하는데, 새 배포본에 없던 디렉토리가 추가되면 `fs.stat()`이 `ENOENT` 를 내면서 죽는 것이 직접적인 문제였습니다.

~처음엔 이를 지역적으로 고칠까하다가, 손으로 `copyDir`를 직접 구현하고 있는게 여러가지로 계속 버그를 낼 것 같아 [ncp](https://www.npmjs.com/package/ncp) 를 사용하게 고쳐봤습니다.~
ncp는 파일을 복사하다 마는 것 같아 작전을 바꿔서, 손으로 예외처리를 추가하였습니다.

또한 하는 김에 #212 도 같이 고쳤습니다.