### PR TITLE
bundle-player 에서 서브모듈 git ref 보는 대신 커밋을 보게끔

### DIFF
--- a/scripts/downloadPlayer.ts
+++ b/scripts/downloadPlayer.ts
@@ -34,7 +34,7 @@ function getCurrentPlatform(): Platform {
 
 async function getPlayerCommit(): Promise<Sha> {
   const { stdout, stderr } = await execWithPromise("git rev-parse HEAD", {
-    cwd: "nekoyume-unity",
+    cwd: path.join(__dirname, "..", "nekoyume-unity"),
   });
   return stdout.trim();
 }


### PR DESCRIPTION
`npm run` 으로 실행 가능한 `bundle-player` 명령에서, `nekoyume-unity` 저장소가 detached 되어있지 않으면 제대로 동작하지 않아서 매번 체크아웃해야 했는데, `git rev-parse` 를 돌리게 고쳐서 이를 해결합니다.