### PR TITLE
스냅샷 적용시 발생하던 EBUSY 해결

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -562,7 +562,7 @@ function extractSnapshot(snapshotPath: string) {
 extractPath: [ ${blockchainStorePath} ],
 extractTarget: [ ${snapshotPath} ]`);
   try {
-    extractZip(snapshotPath, {
+    return extractZip(snapshotPath, {
       dir: blockchainStorePath,
       onEntry: (_, zipfile) => {
         const progress = zipfile.entriesRead / zipfile.entryCount;


### PR DESCRIPTION
Closes #219 

압축 풀기가 완전히 끝난 다음에 노드를 실행하게끔 조정합니다.