### PR TITLE
Add workflow to check submodule's submodule commit hash

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,34 @@
+name: pull_request
+on:
+  push: []
+  pull_request: []
+
+jobs:
+  # 서브모듈 확인
+  check-submodule:
+    runs-on: ubuntu-latest
+    steps:
+      # 클론
+      - uses: actions/checkout@v2
+        if: github.event_name != 'pull_request'
+        with:
+          submodules: true
+          ssh-key: ${{ secrets.SUBMODULE_PULL_KEY }}
+          lfs: false
+      - uses: actions/checkout@v2
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.pull_request.head.sha }}
+          submodules: true
+          ssh-key: ${{ secrets.SUBMODULE_PULL_KEY }}
+          lfs: false
+      # Node.js 설치
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "14"
+      # Lib9c 확인
+      - name: Check Lib9c
+        run: npx ts-node scripts/checkSubmodule.ts Lib9c
+      # Shared 확인
+      - name: Check NineChronicles.RPC.Shared
+        run: npx ts-node scripts/checkSubmodule.ts NineChronicles.RPC.Shared

--- a/scripts/checkSubmodule.ts
+++ b/scripts/checkSubmodule.ts
@@ -1,0 +1,78 @@
+import { exec } from "child_process";
+import path from "path";
+import { promisify } from "util";
+
+type Sha = string;
+
+const execWithPromise = promisify(exec);
+
+enum Submodules {
+  lib9c = "Lib9c",
+  shared = "NineChronicles.RPC.Shared",
+}
+
+async function getSubmoduleHash(
+  submodulePath: string,
+  subSubmodulePath: string
+): Promise<Sha> {
+  const { stdout, stderr } = await execWithPromise(
+    `git submodule status ${subSubmodulePath}`,
+    {
+      cwd: path.join(__dirname, "..", submodulePath),
+    }
+  );
+  return stdout.trim();
+}
+
+async function checkLib9c(): Promise<boolean> {
+  const sha1 = await getSubmoduleHash(
+    "nekoyume-unity",
+    "./nekoyume/Assets/_Scripts/Lib9c/Lib9c"
+  );
+  const sha2 = await getSubmoduleHash("NineChronicles.Standalone", "./Lib9c");
+
+  return sha1 === sha2;
+}
+
+async function checkShared(): Promise<boolean> {
+  const sha1 = await getSubmoduleHash(
+    "nekoyume-unity",
+    "./nekoyume/Assets/_Scripts/NineChronicles.RPC.Shared"
+  );
+  const sha2 = await getSubmoduleHash(
+    "NineChronicles.Standalone",
+    "./NineChronicles.RPC.Shared"
+  );
+
+  return sha1 === sha2;
+}
+
+async function checkSubmodule(name: string): Promise<boolean> {
+  switch (name) {
+    case Submodules.lib9c:
+      return await checkLib9c();
+
+    case Submodules.shared:
+      return await checkShared();
+
+    default:
+      throw new Error(
+        `checkSubmodule.ts: Argument should be either ${Submodules.shared} or ${Submodules.shared}`
+      );
+  }
+}
+
+async function main(): Promise<void> {
+  if (process.argv.length !== 1) {
+    throw new Error("checkSubmodule.ts: One argument (submodule) is required.");
+  }
+
+  const result = await checkSubmodule(process.argv[0]);
+  if (!result) {
+    throw new Error(
+      `checkSubmodule.ts: Failed while checking ${process.argv[0]}`
+    );
+  }
+}
+
+main().catch((e) => console.error(e));


### PR DESCRIPTION
깃허브 액션을 이용해 서브모듈들이 사용하는 서브모듈인 `Lib9c`와 `NineChronicles.RPC.Shared`의 커밋 해시가 일치하는지 확인합니다.