### PR TITLE
bundle-player 가 실패하면 빌드가 실패하도록 합니다.

### DIFF
--- a/scripts/downloadPlayer.ts
+++ b/scripts/downloadPlayer.ts
@@ -175,20 +175,6 @@ async function bundlePlayerBinary(
     await options.beforeDecompress(tmpPath, bundleInto);
   }
   await DECOMPRESSOR[platform](tmpPath, bundleInto);
-  const unnecessaryDirs = // 론처 v1의 잔재들
-    platform == "Windows"
-      ? ["Nine Chronicles.exe", "qt-runtime"]
-      : ["Nine Chronicles.app"];
-  for (const unnecessaryDir of unnecessaryDirs) {
-    try {
-      await fs.promises.rmdir(path.join(bundleInto, unnecessaryDir), {
-        recursive: true,
-      });
-    } catch (e) {
-      if (e.code === "ENOENT") continue;
-      throw e;
-    }
-  }
   await fs.promises.rmdir(tmpdir, { recursive: true });
 }
 


### PR DESCRIPTION
#243 과 같은 바이너리가 나오지 않도록 Unity Player 다운로드가 실패하면 빌드가 실패하도록 합니다.