### PR TITLE
웹팩에서 다루는 파일 형식을 정리합니다

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ function createRenderConfig(isDev) {
     target: "electron-renderer", // any other target value makes react-hot-loader stop working
 
     resolve: {
-      extensions: [".js", ".jsx", ".ts", ".tsx", ".json"],
+      extensions: [".js", ".ts", ".tsx", ".json"],
     },
 
     mode: isDev ? DEVELOPMENT : PRODUCTION,
@@ -59,7 +59,7 @@ function createRenderConfig(isDev) {
         },
 
         {
-          test: /\.(js|jsx|ts|tsx)$/,
+          test: /\.tsx?$/,
           exclude: /node_modules/,
           use: {
             loader: "babel-loader",


### PR DESCRIPTION
resolve.extensions:
현재 다루는 (모듈 포함해서) 파일 형식 중에 jsx 는 쓰이지 않습니다.

\.tsx? : 기술한 프리셋이나 플러그인으로 전처리하는 대상은 TS와 TSX만 포함됩니다.