### PR TITLE
리뷰어의 수를 명시합니다

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -9,3 +9,5 @@ reviewers:
   - riemannulus
   - moreal
   - x86chi
+
+numberOfReviewers: 0


### PR DESCRIPTION
문서에서 "numberOfReviewers" 의 기본 값이 0이라길래 적어두지 않았는데,

한 사람만 리뷰어로 지정이 되네요. 명시적으로 0이라고 적어둬야 모든 리뷰어가
지정됩니다. (예시: https://github.com/planetarium/auto-assign-test/pull/2)

참조한 문서: https://github.com/kentaro-m/auto-assign#single-reviewers-list