### PR TITLE
package.json 실수를 고칩니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "pack-all:electron-builder": "run-script-os",
     "pack-all:electron-builder:windows": "npm run before-pack && npm run build-prod && npx electron-builder --windows",
     "pack-all:electron-builder:darwin": "npm run before-pack && npm run build-prod && npx electron-builder --mac",
-    "test": "mocha --require ts-node/register __tests__/**/*.spec.ts"
+    "test": "mocha --require ts-node/register __tests__/**/*.spec.ts",
     "hook:prettier": "pretty-quick --staged",
     "hook:tsc": "tsc --noEmit"
   },


### PR DESCRIPTION
병합 충돌을 #271 에서 해결하며 생긴 실수입니다.

콜론이 빠졌고, shellwords 라는 모듈의 의존성이 필요하지 않습니다