### PR TITLE
NPM 의존성의 취약점을 해결합니다

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2336,185 +2336,6 @@
         }
       }
     },
-    "@graphql-toolkit/common": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@graphql-toolkit/common/-/common-0.10.7.tgz",
-      "integrity": "sha512-epcJvmIAo+vSEY76F0Dj1Ef6oeewT5pdMe1obHj7LHXN9V22O86aQzwdEEm1iG91qROqSw/apcDnSCMjuVeQVA==",
-      "dev": true,
-      "requires": {
-        "aggregate-error": "3.0.1",
-        "camel-case": "4.1.1",
-        "graphql-tools": "5.0.0",
-        "lodash": "4.17.15"
-      }
-    },
-    "@graphql-toolkit/core": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@graphql-toolkit/core/-/core-0.10.7.tgz",
-      "integrity": "sha512-LXcFLG7XcRJrPz/xD+0cExzLx/ptVynDM20650/FbmHbKOU50d9mSbcsrzAOq/3f4q3HrRDssvn0f6pPm0EHMg==",
-      "dev": true,
-      "requires": {
-        "@graphql-toolkit/common": "0.10.7",
-        "@graphql-toolkit/schema-merging": "0.10.7",
-        "aggregate-error": "3.0.1",
-        "globby": "11.0.0",
-        "import-from": "^3.0.0",
-        "is-glob": "4.0.1",
-        "lodash": "4.17.15",
-        "p-limit": "2.3.0",
-        "resolve-from": "5.0.0",
-        "tslib": "1.11.2",
-        "unixify": "1.0.0",
-        "valid-url": "1.0.9"
-      },
-      "dependencies": {
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-          "dev": true
-        },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
-        "globby": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-          "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
-            "slash": "^3.0.0"
-          }
-        },
-        "ignore": {
-          "version": "5.1.8",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        },
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        },
-        "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-toolkit/graphql-file-loader": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@graphql-toolkit/graphql-file-loader/-/graphql-file-loader-0.10.7.tgz",
-      "integrity": "sha512-6tUIuw/YBlm0VyVgXgMrOXsEQ+WpXVgr2NQwHNzmZo82kPGqImveq7A2D3gBWLyVTcinDScRcKJMxM4kCF5T0A==",
-      "dev": true,
-      "requires": {
-        "@graphql-toolkit/common": "0.10.7",
-        "tslib": "1.11.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-toolkit/json-file-loader": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@graphql-toolkit/json-file-loader/-/json-file-loader-0.10.7.tgz",
-      "integrity": "sha512-nVISrODqvn5LiQ4nKL5pz1Let/W1tuj2viEwrNyTS+9mcjaCE2nhV5MOK/7ZY0cR+XeA4N2u65EH1lQd63U3Cw==",
-      "dev": true,
-      "requires": {
-        "@graphql-toolkit/common": "0.10.7",
-        "tslib": "1.11.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-toolkit/schema-merging": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@graphql-toolkit/schema-merging/-/schema-merging-0.10.7.tgz",
-      "integrity": "sha512-VngxJbVdRfXYhdMLhL90pqN+hD/2XTZwhHPGvpWqmGQhT6roc98yN3xyDyrWFYYsuiY4gTexdmrHQ3d7mzitwA==",
-      "dev": true,
-      "requires": {
-        "@graphql-toolkit/common": "0.10.7",
-        "deepmerge": "4.2.2",
-        "graphql-tools": "5.0.0",
-        "tslib": "1.11.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
-          "dev": true
-        }
-      }
-    },
-    "@graphql-toolkit/url-loader": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@graphql-toolkit/url-loader/-/url-loader-0.10.7.tgz",
-      "integrity": "sha512-Ec3T4Zuo63LwG+RfK2ryz8ChPfncBf8fiSJ1xr68FtLDVznDNulvlNKFbfREE5koWejwsnJrjLCv6IX5IbhExg==",
-      "dev": true,
-      "requires": {
-        "@graphql-toolkit/common": "0.10.7",
-        "cross-fetch": "3.0.4",
-        "graphql-tools": "5.0.0",
-        "tslib": "1.11.2",
-        "valid-url": "1.0.9"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
-          "integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg==",
-          "dev": true
-        }
-      }
-    },
     "@graphql-tools/apollo-engine-loader": {
       "version": "6.0.10",
       "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-6.0.10.tgz",
@@ -4796,18 +4617,6 @@
       "requires": {
         "apollo-link": "^1.2.14",
         "tslib": "^1.9.3"
-      }
-    },
-    "apollo-upload-client": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/apollo-upload-client/-/apollo-upload-client-13.0.0.tgz",
-      "integrity": "sha512-lJ9/bk1BH1lD15WhWRha2J3+LrXrPIX5LP5EwiOUHv8PCORp4EUrcujrA3rI5hZeZygrTX8bshcuMdpqpSrvtA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "apollo-link": "^1.2.12",
-        "apollo-link-http-common": "^0.2.14",
-        "extract-files": "^8.0.0"
       }
     },
     "apollo-utilities": {
@@ -8125,12 +7934,6 @@
       "integrity": "sha512-9YLIBURXj4DJMFALxXw9K3Y3rwb5Fk0X5/8ipCzaN84+gKxoHK43tVKRNakCQbiEx07E8Uwhuq21BpUagFhZ8w==",
       "dev": true
     },
-    "deprecated-decorator": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
-      "dev": true
-    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -9088,9 +8891,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -10312,12 +10115,6 @@
         }
       }
     },
-    "extract-files": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-8.1.0.tgz",
-      "integrity": "sha512-PTGtfthZK79WUMk+avLmwx3NGdU8+iVFXC2NMGxKsn0MnihOG2lvumj+AZo8CTwTrwjXDgZ5tztbRlEdRjBonQ==",
-      "dev": true
-    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -11249,20 +11046,29 @@
       "integrity": "sha512-0TVyfOlCGhv/DBczQkJmwXOK6fjWkjzY3Pt7wY8i0gcYXq8aogG3weCsg48m72lywKSeOqedEHvVPOvZvSD51Q=="
     },
     "graphql-config": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-3.0.2.tgz",
-      "integrity": "sha512-efoimZ4F2wF2OwZJzPq2KdPjQs1K+UgJSfsHoHBBA0TwveGyQ/0kS3lUphhJg/JXIrZociuRkfjrk8JC4iPPJQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-3.0.3.tgz",
+      "integrity": "sha512-MBY0wEjvcgJtZUyoqpPvOE1e5qPI0hJaa1gKTqjonSFiCsNHX2lykNjpOPcodmAgH1V06ELxhGnm9kcVzqvi/g==",
       "dev": true,
       "requires": {
-        "@graphql-toolkit/common": "~0.10.6",
-        "@graphql-toolkit/core": "~0.10.6",
-        "@graphql-toolkit/graphql-file-loader": "~0.10.6",
-        "@graphql-toolkit/json-file-loader": "~0.10.6",
-        "@graphql-toolkit/schema-merging": "~0.10.6",
-        "@graphql-toolkit/url-loader": "~0.10.6",
+        "@graphql-tools/graphql-file-loader": "^6.0.0",
+        "@graphql-tools/json-file-loader": "^6.0.0",
+        "@graphql-tools/load": "^6.0.0",
+        "@graphql-tools/merge": "^6.0.0",
+        "@graphql-tools/url-loader": "^6.0.0",
+        "@graphql-tools/utils": "^6.0.0",
         "cosmiconfig": "6.0.0",
         "minimatch": "3.0.4",
-        "tslib": "^1.11.1"
+        "string-env-interpolation": "1.0.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+          "dev": true
+        }
       }
     },
     "graphql-request": {
@@ -11302,47 +11108,6 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.3.tgz",
       "integrity": "sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA=="
-    },
-    "graphql-tools": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-5.0.0.tgz",
-      "integrity": "sha512-5zn3vtn//382b7G3Wzz3d5q/sh+f7tVrnxeuhTMTJ7pWJijNqLxH7VEzv8VwXCq19zAzHYEosFHfXiK7qzvk7w==",
-      "dev": true,
-      "requires": {
-        "apollo-link": "^1.2.14",
-        "apollo-upload-client": "^13.0.0",
-        "deprecated-decorator": "^0.1.6",
-        "form-data": "^3.0.0",
-        "iterall": "^1.3.0",
-        "node-fetch": "^2.6.0",
-        "tslib": "^1.11.1",
-        "uuid": "^7.0.3"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-          "dev": true
-        }
-      }
     },
     "growl": {
       "version": "1.10.5",
@@ -13757,9 +13522,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -18056,10 +17821,13 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-index": {
       "version": "1.9.1",
@@ -18221,13 +17989,6 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
-    },
-    "shellwords": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true,
-      "optional": true
     },
     "side-channel": {
       "version": "1.0.2",
@@ -19193,16 +18954,16 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",


### PR DESCRIPTION
```
fixed 1314 of 1317 vulnerabilities in 2346 scanned packages
  2 vulnerabilities required manual review and could not be updated
  1 package update for 1 vulnerability involved breaking changes
  (use `npm audit fix --force` to install breaking changes;
or refer to `npm audit` for steps to fix these manually)
```

breaking change 되지 않는 모듈에 한해 버전을 올려서 빌드 후의 UI도 잘 렌더링 되었습니다.

<img width="912" alt="Screen Shot 2020-08-25 at 12 05 24 PM" src="https://user-images.githubusercontent.com/5278201/91118373-c79e2080-e6cb-11ea-8fba-f19920da8cda.png">
