### PR TITLE
config.json에 블록체인 경로를 입력할 수 있게 합니다

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,10 @@ export const electronStore = new Store<IElectronStore>({
       type: "boolean",
       default: false,
     },
+    BlockchainStoreDirParent: {
+      type: "string",
+      default: "",
+    },
     BlockchainStoreDirName: {
       type: "string",
       default: "9c",

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -10,5 +10,6 @@ export interface IElectronStore {
   IceServerStrings: string[];
   PeerStrings: string[];
   NoTrustedStateValidators: boolean;
+  BlockchainStoreDirParent: string;
   BlockchainStoreDirName: string;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -46,7 +46,9 @@ let standaloneExited: boolean = false;
 
 const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
 const blockchainStorePath = path.join(
-  BLOCKCHAIN_STORE_PATH,
+  electronStore.get("BlockchainStoreDirParent") === ""
+    ? BLOCKCHAIN_STORE_PATH
+    : electronStore.get("BlockchainStoreDirParent"),
   electronStore.get("BlockchainStoreDirName")
 );
 


### PR DESCRIPTION
`BlockchainStoreDirParent` 속성을 추가하여 블록체인이 저장될 경로를 입력합니다. 해당 필드가 비어있으면 기존의 `BLOCKCHAIN_STORE_PATH`를 그대로 사용합니다.

최종 경로는 `BlockchainStoreDirParent`/`BlockchainStoreDirName` 이 되고, 존재하지 않는 경로라면 자동으로 생성합니다.