### PR TITLE
E2E 테스트 코드를 수정합니다

### DIFF
--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -1,11 +1,7 @@
 import path from "path";
 
-import { Application, SpectronWebContents } from "spectron";
+import { Application } from "spectron";
 import electron from "electron";
-
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
-import assert from "assert";
 
 import "dotenv/config";
 
@@ -14,8 +10,6 @@ process.env.ELECTRON_IS_DEV = 0;
 const { PASSWORD } = process.env;
 
 if (PASSWORD === undefined) throw Error("failed to load password from .env");
-
-chai.use(chaiAsPromised);
 
 describe("test", function () {
   this.timeout(10000);


### PR DESCRIPTION
#284 에서 미쳐 고치지 못한 오류를 해결했습니다.

1. 실행 버튼을 못 집는 경우를 예외 처리했습니다. : 73c3d48
2. 마지막 라인에 await 를 붙였습니다. 비동기 메서드가 가장 아래 라인에 있어 수정했습니다. : 6239468
3. 프리로드 대기 시간을 명시했습니다. 이전에는 기본값인 1초만 기다리고 끝냈습니다. : 90d47e8