### PR TITLE
스냅샷 다운로드 과정 개선

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -663,19 +663,14 @@ async function downloadSnapshot(
   options.properties.filename = "snapshot.zip";
   console.log(win);
   if (win != null) {
-    download(
+    const dl = await download(
       win,
       (electronStore.get("SNAPSHOT_DOWNLOAD_PATH") as string) + ".zip",
       options.properties
-    )
-      .then((dl) => {
-        win?.webContents.send("download complete", dl.getSavePath());
-        return dl.getSavePath();
-      })
-      .then((path) => extractSnapshot(path))
-      .then(() => {
-        standaloneNode = executeStandalone();
-      })
-      .then(() => win?.webContents.send("snapshot complete"));
+    );
+    win?.webContents.send("download complete", dl.getSavePath());
+    await extractSnapshot(dl.getSavePath());
+    standaloneNode = executeStandalone();
+    win?.webContents.send("snapshot complete");
   }
 }


### PR DESCRIPTION
블록체인 데이터를 지우기 위해 잡혀있는 락을 풀기 위해 `processkill`을 한 번 하는데 해당 명령어 실행 후에도 락이 잠시동안 잡혀있어서 기존에는 그냥 1초 기다린 후에 지웠습니다. 이걸 `retry`를 사용해 비교적 정확히 체인을 지웁니다.

추가로 다운로드받은 스냅샷 파일의 이름을 snapshot.zip으로 하여서 도중에 에러가 발생해 해당 파일이 지워지지 않았더라도 다음 실행에는 지워질 수 있도록 합니다.