### PR TITLE
PreloadProgressView 를 observer 로 감싸야 됩니다

### DIFF
--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { observer } from "mobx-react";
 import mixpanel from "mixpanel-browser";
 import { ipcRenderer, IpcRendererEvent } from "electron";
 import useStores from "../../../hooks/useStores";
@@ -11,7 +12,7 @@ import {
 import preloadProgressViewStyle from "./PreloadProgressView.style";
 import { electronStore } from "../../../config";
 
-const PreloadProgressView = () => {
+const PreloadProgressView = observer(() => {
   const { accountStore, routerStore, standaloneStore } = useStores();
   const classes = preloadProgressViewStyle();
   const {
@@ -201,7 +202,7 @@ const PreloadProgressView = () => {
       )}
     </Container>
   );
-};
+});
 
 const statusMessage = [
   "Validating Snapshot",


### PR DESCRIPTION
[mobx-react 의 훅 레시피](https://mobx-react.js.org/recipes-context)에서 observer로 감싸는걸 가이드 하는데,

제가 이전에 타입을 교정하면서 미처 알지 못했네요.

<img width="800" alt="Screen Shot 2020-08-31 at 1 22 51 PM" src="https://user-images.githubusercontent.com/5278201/91683308-36c5ba00-eb8f-11ea-929b-18f56dd7f61a.png">