### PR TITLE
비밀번호 보기 기능을 추가합니다

### DIFF
--- a/src/renderer/components/VisibilityAdornment.tsx
+++ b/src/renderer/components/VisibilityAdornment.tsx
@@ -1,12 +1,10 @@
-import React from "react";
+import React, { MouseEvent } from "react";
 
 import { InputAdornment, IconButton } from "@material-ui/core";
 import { Visibility, VisibilityOff } from "@material-ui/icons";
 
-import { ClickEvent } from "../../types/events";
-
 interface VisibilityAdornmentProps {
-  onClick: (e: ClickEvent) => void;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
   show: boolean;
 }
 

--- a/src/renderer/views/account/CreateAccountView.tsx
+++ b/src/renderer/views/account/CreateAccountView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, ChangeEvent, MouseEvent } from "react";
 import mixpanel from "mixpanel-browser";
 import { observer, inject } from "mobx-react";
 import {
@@ -18,8 +18,6 @@ import VisibilityAdornment from "../../components/VisibilityAdornment";
 
 import { ExecutionResult } from "react-apollo";
 import { IStoreContainer } from "../../../interfaces/store";
-
-import { ChangeEvent, ClickEvent } from "../../../types/events";
 
 import {
   useCreatePrivateKeyMutation,
@@ -50,19 +48,19 @@ const CreateAccountView: React.FC<ICreateAccountProps> = observer(
 
     const classes = createAccountViewStyle();
 
-    const handlePasswordChange = (e: ChangeEvent) => {
+    const handlePasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
       setPassword(e.target.value);
     };
 
-    const handlePasswordConfirmChange = (e: ChangeEvent) => {
+    const handlePasswordConfirmChange = (e: ChangeEvent<HTMLInputElement>) => {
       setPasswordConfirm(e.target.value);
     };
 
-    const handleShowPassword = (e: ClickEvent) => {
+    const handleShowPassword = (e: MouseEvent<HTMLButtonElement>) => {
       setShowPassword(!showPassword);
     };
 
-    const handleShowPasswordConfirm = (e: ClickEvent) => {
+    const handleShowPasswordConfirm = (e: MouseEvent<HTMLButtonElement>) => {
       setShowPasswordConfirm(!showPasswordConfirm);
     };
 

--- a/src/renderer/views/login/LoginView.tsx
+++ b/src/renderer/views/login/LoginView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, MouseEvent } from "react";
 import mixpanel from "mixpanel-browser";
 import { IStoreContainer } from "../../../interfaces/store";
 import { LoginFormEvent } from "../../../interfaces/event";
@@ -24,8 +24,6 @@ import VisibilityAdornment from "../../components/VisibilityAdornment";
 
 import loginViewStyle from "./LoginView.style";
 import { useLocale } from "../../i18n";
-
-import { ClickEvent } from "../../../types/events";
 
 const LoginView = observer(
   ({ accountStore, routerStore, standaloneStore }: IStoreContainer) => {
@@ -71,14 +69,12 @@ const LoginView = observer(
       });
     };
 
-    const handleRevokeAccount = (
-      e: React.MouseEvent<HTMLAnchorElement & HTMLSpanElement, MouseEvent>
-    ) => {
+    const handleRevokeAccount = (e: MouseEvent<HTMLAnchorElement>) => {
       e.preventDefault();
       routerStore.push("/account/revoke");
     };
 
-    const handleShowPassword = (e: ClickEvent) => {
+    const handleShowPassword = (e: MouseEvent<HTMLButtonElement>) => {
       setShowPassword(!showPassword);
     };
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,4 +1,0 @@
-import React from "react";
-
-export type ChangeEvent = React.ChangeEvent<HTMLInputElement>;
-export type ClickEvent = React.MouseEvent<HTMLButtonElement>;


### PR DESCRIPTION
계정 생성과 로그인 페이지의 비밀번호 입력 필드의 텍스트를 볼 수 있게 끔 오른쪽에 버튼을 추가했습니다.

| Create Account | Login |
| :--: | :--: |
| <img alt="Screen Shot 2020-09-02 at 3 52 15 PM" src="https://user-images.githubusercontent.com/5278201/91946215-29006800-ed3a-11ea-8a65-37b2c77047e3.png"> | <img alt="Screen Shot 2020-09-02 at 4 22 43 PM" src="https://user-images.githubusercontent.com/5278201/91946280-2d2c8580-ed3a-11ea-8672-bbe1f9192c19.png"> |

### 참고한 자료

[Input Adornments, Text Field React component - Material-UI](https://material-ui.com/components/text-fields/#input-adornments)