### PR TITLE
체인 경로가 존재하지 않으면 에러페이지로 이동하던 현상을 수정합니다

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -133,6 +133,12 @@ function initializeIpc() {
         console.log("Create directory for given blockchain path.");
         fs.mkdirSync(BLOCKCHAIN_STORE_PATH, { recursive: true });
       }
+    } catch (err) {
+      console.error("Error occurred while creating directory.", err);
+      if (err.code === "EACCES" || err.code === "EPERM") return false;
+    }
+
+    try {
       fs.accessSync(BLOCKCHAIN_STORE_PATH, fs.constants.F_OK);
       event.returnValue = true;
     } catch (err) {


### PR DESCRIPTION
Close #310 

- run dev 에서는 스탠드얼론이 먼저 뜨고, 스탠드얼론이 폴더를 생성하므로 에러페이지로 이동하지 않습니다.
- 배포 빌드에서는 스탠드얼론이 나중에 떠서 폴더가 생성되지 않은 상태이므로 에러페이지로 이동합니다.

따라서 위 두 경우를 모두 커버할 수 있게 폴더가 존재하지 않으면 폴더를 생성합니다.