### PR TITLE
패스워드 틀림 문구 교정

### DIFF
--- a/src/renderer/i18n/index.json
+++ b/src/renderer/i18n/index.json
@@ -244,8 +244,8 @@
     "Retype Password": {
       "en": "Retype Password"
     },
-    "Password is not equal.": {
-      "en": "Password is not equal."
+    "Password does not match.": {
+      "en": "Password does not match."
     },
     "Done": {
       "en": "Done"

--- a/src/renderer/views/account/reset/RegisterPrivateKeyView.tsx
+++ b/src/renderer/views/account/reset/RegisterPrivateKeyView.tsx
@@ -84,7 +84,9 @@ export const RegisterPrivateKeyView: React.FC<IRegisterPrivateKeyViewProps> = in
           label={locale("Retype Password")}
           type="password"
           onChange={makeHandlePasswordChange(setSecondPassword)}
-          helperText={!passwordMatched ? locale("Password is not equal.") : ""}
+          helperText={
+            !passwordMatched ? locale("Password does not match.") : ""
+          }
         />
         <br />
         <Button onClick={handleSubmit}>{locale("Done")}</Button>


### PR DESCRIPTION
커뮤니티 번역 기여자가 "password is not equal." 을 "password does not match" 로 바꾸셨는데 더 어울려 보여 적용합니다.