### PR TITLE
Enlarge password masking letters

### DIFF
--- a/src/renderer/styles/common.scss
+++ b/src/renderer/styles/common.scss
@@ -30,3 +30,8 @@ button:disabled {
   background-color: $color4;
   color: $color3;
 }
+
+input[type="password"] {
+  -webkit-text-stroke-width: 0.2em;
+  letter-spacing: 0.3em;
+}


### PR DESCRIPTION
기본 폰트의 마스킹 문자가 작아 수정합니다.

| 수정 전 | 수정 후 |
| :--: | :--: |
| <img alt="Screen Shot 2020-09-03 at 10 14 28 AM" src="https://user-images.githubusercontent.com/5278201/92060731-7d095c00-edcf-11ea-9624-11d3994682f0.png"> | <img alt="Screen Shot 2020-09-03 at 10 14 14 AM" src="https://user-images.githubusercontent.com/5278201/92060739-81ce1000-edcf-11ea-93e2-01f0d6711185.png">|

