### PR TITLE
Align center the Label text

### DIFF
--- a/src/renderer/views/login/LoginView.style.ts
+++ b/src/renderer/views/login/LoginView.style.ts
@@ -19,6 +19,7 @@ const loginViewStyle = makeStyles({
   },
   revokeLink: {
     margin: "10px auto",
+    textAlign: "center",
     display: "block",
     width: "150px",
     color: "white",


### PR DESCRIPTION
영어일 때는 괜찮지만, 다른 언어에서는 좌측 정렬로 보였네요.

| 이전 | 이후 |
| :--: | :--: |
| <img width="274" alt="Screen Shot 2020-09-03 at 5 23 58 PM" src="https://user-images.githubusercontent.com/5278201/92094192-215ec300-ee0f-11ea-9889-b3e738d50aac.png"> | <img width="253" alt="Screen Shot 2020-09-03 at 5 24 06 PM" src="https://user-images.githubusercontent.com/5278201/92094246-2d4a8500-ee0f-11ea-91bc-a454fd74288c.png"> |
