### PR TITLE
No need to reset the hover style

### DIFF
--- a/src/renderer/styles/common.scss
+++ b/src/renderer/styles/common.scss
@@ -31,10 +31,6 @@ button:disabled:not(.settings-icon) {
   color: $color3;
 }
 
-button.settings-icon:hover {
-  all: unset;
-}
-
 input[type="password"] {
   -webkit-text-stroke-width: 0.2em;
   letter-spacing: 0.3em;


### PR DESCRIPTION
버튼 비활성화 된 상태에서 포인터가 갔을 때, 설정 버튼의 `:hover` 스타일을 초기화 해야 된다고 생각했습니다.

observer 로 감싸기(#340) 이전의 부작용으로 설정 페이지에도 버튼이 활성화되어 생각한 착각입니다.

| 이전 `:hover` | 이후 `:hover` |
| :-: | :-: |
|<img width="148" alt="Screen Shot 2020-09-11 at 7 21 39 PM" src="https://user-images.githubusercontent.com/5278201/92918124-1b4d8f80-f46a-11ea-8049-36c536488ac7.png"> | <img width="182" alt="Screen Shot 2020-09-11 at 7 28 18 PM" src="https://user-images.githubusercontent.com/5278201/92918139-1dafe980-f46a-11ea-82b8-fc59a1c24881.png"> |
