### PR TITLE
Check if the route has been moved for E2E Test

### DIFF
--- a/__tests__/main.spec.ts
+++ b/__tests__/main.spec.ts
@@ -38,7 +38,9 @@ describe("test", function () {
       throw Error("현재 경로를 가져오지 못했습니다");
 
     if (pathname.includes("/error"))
-      throw Error("오류 페이지로 이동이 되었습니다");
+      throw Error(
+        `오류 페이지로 이동이 되었습니다. 이동한 오류 페이지 경로는 "${pathname}" 입니다.`
+      );
 
     if (history.length === 0) {
       history.push(pathname);


### PR DESCRIPTION
경로 이동을 명시적으로 태스트 되도록 수정했습니다.

예시로, 틀린 비밀번호 입력한 경우 아래의 출력을 보게 됩니다.
```
  test
    √ 로그인 하기 (238ms)
    1) "after each" hook for "로그인 하기"

  1 passing (9s)
  1 failing

  1) test
       "after each" hook for "로그인 하기":
     Error: "/login"에서 다음 페이지로 이동에 실패했습니다.
```

이전에는 요소의(WebdriverIO.Element) 텍스트, 클릭 메서드를 확인해서 이동을 했는지 암시적으로 추측 했습니다.

그런데 클릭을 한 뒤여도 인증에 실패하는 등 아무런 반응이 없는 경우를 고려하지 못해서 수정했습니다.