### PR TITLE
비밀번호 설정 버튼을 누르면 Revoke 페이지로 가는 실수를 고쳤습니다

### DIFF
--- a/src/renderer/views/login/LoginView.tsx
+++ b/src/renderer/views/login/LoginView.tsx
@@ -94,7 +94,7 @@ const LoginView = observer(
 
     const handleResetPassword = (e: MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
-      routerStore.push("/account/revoke");
+      routerStore.push("/account/reset/input/private-key");
     };
 
     const handleShowPassword = (e: MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
비밀번호 설정 버튼을 누르면 계정 무효화 `revoke account` 페이지로 가는 실수를 고쳤습니다.

`RegisterPrivateKeyView`가 비밀번호를 재설정하는 역할이 이름과<sup>**RegisterPrivateKey**</sup> 일치하기 않아서 바로 이해하기 어려웠습니다. `ResetPasswordView` 로 바꾸면 어떨까 싶네요.