### PR TITLE
feat(mixpanel): sync installer distinct_id with launcher distinct_id 

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -464,6 +464,15 @@ function initializeIpc() {
 
     event.returnValue = "Not supported platform.";
   });
+
+  ipcMain.on("get-installer-mixpanel-uuid", async (event) => {
+    let guidPath = path.join(app.getAppPath(), ".installer_mixpanel_uuid");
+    if (process.platform === "win32" && fs.existsSync(guidPath)) {
+      event.returnValue = await fs.promises.readFile(guidPath).toString();
+    } else {
+      event.returnValue = null;
+    }
+  });
 }
 
 async function initializeStandalone(): Promise<void> {
@@ -569,14 +578,6 @@ async function initializeStandalone(): Promise<void> {
   } finally {
     initializeStandaloneCts = null;
   }
-
-  ipcMain.on("get installer mixpanel uuid", async (event) => {
-    event.returnValue = (
-      await fs.promises.readFile(
-        path.join(app.getAppPath(), ".installer_mixpanel_uuid")
-      )
-    ).toString();
-  });
 }
 
 function createWindow(): BrowserWindow {

--- a/src/renderer/views/login/LoginView.tsx
+++ b/src/renderer/views/login/LoginView.tsx
@@ -66,9 +66,11 @@ const LoginView = observer(
         accountStore.setPrivateKey(privateKey);
         accountStore.toggleLogin();
         const installerUUID = ipcRenderer.sendSync(
-          "get installer mixpanel uuid"
-        ) as string;
-        mixpanel.alias(accountStore.selectedAddress, installerUUID);
+          "get-installer-mixpanel-uuid"
+        ) as string | null;
+        if (installerUUID !== null) {
+          mixpanel.alias(accountStore.selectedAddress, installerUUID);
+        }
         mixpanel.identify(accountStore.selectedAddress);
         mixpanel.track("Launcher/Login");
         routerStore.push("/login/mining");


### PR DESCRIPTION
- planetarium/nekoyume-unity#2810 가 정리되면 열겠습니다.

인스톨러에서 만들어 사용한 GUID를 읽어 주소(0x..)와 alias로 연결합니다. planetarium/nekoyume-unity#2810을 참조해주세요. 
