### PR TITLE
Password strength policy

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 /nekoyume-unity/
 /node_modules/
 package-lock.json
+tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -3939,12 +3939,6 @@
       "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
-    "@types/zxcvbn": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@types/zxcvbn/-/zxcvbn-4.4.0.tgz",
-      "integrity": "sha512-GQLOT+SN20a+AI51y3fAimhyTF4Y0RG+YP3gf91OibIZ7CJmPFgoZi+ZR5a+vRbS01LbQosITWum4ATmJ1Z6Pg==",
-      "dev": true
-    },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "subscriptions-transport-ws": "^0.9.16",
     "tmp-promise": "^3.0.2",
     "url-loader": "^4.1.0",
-    "zxcvbn": "^4.4.2"
+    "zxcvbn": "4.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.10.1",
@@ -124,7 +124,6 @@
     "@types/ws": "^7.2.6",
     "@types/xml2js": "^0.4.5",
     "@types/youtube": "0.0.39",
-    "@types/zxcvbn": "^4.4.0",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "babel-jest": "^26.0.1",

--- a/src/interfaces/i18n.ts
+++ b/src/interfaces/i18n.ts
@@ -1,3 +1,5 @@
+import { ZXCVBNFeedbackWarning } from "zxcvbn";
+
 export default interface I18n {
   intro: Intro;
   menu: Menu;
@@ -118,11 +120,16 @@ export interface CreateAccount {
   "계정 생성을 마치기 위해 비밀번호를 설정해주세요.": Description;
 }
 
-export interface RetypePassword {
+export interface RetypePassword extends ZXCVBNFeedbackWarningLocale {
   비밀번호: LocaleRecord;
   "비밀번호 (확인)": LocaleRecord;
   확인: LocaleRecord;
 }
+
+type ZXCVBNFeedbackWarningLocale = Record<
+  Exclude<ZXCVBNFeedbackWarning, "">,
+  LocaleRecord
+>;
 
 export interface CopyPrivateKey {
   title: Description;

--- a/src/renderer/components/RetypePasswordForm.tsx
+++ b/src/renderer/components/RetypePasswordForm.tsx
@@ -61,6 +61,12 @@ const RetypePasswordForm = ({ onSubmit }: RetypePasswordFormProps) => {
     onSubmit(password);
   };
 
+  function strengthHint(password: string) {
+    const { warning } = zxcvbn(password).feedback;
+    if (warning === "") return "";
+    return locale(warning);
+  }
+
   return (
     <form noValidate autoComplete="off" onSubmit={handleSubmit}>
       <FormControl
@@ -121,11 +127,6 @@ const RetypePasswordForm = ({ onSubmit }: RetypePasswordFormProps) => {
 };
 
 export default RetypePasswordForm;
-
-function strengthHint(password: string) {
-  const result = zxcvbn(password);
-  return result.feedback.warning;
-}
 
 const createStyle = makeStyles({
   formControl: {

--- a/src/renderer/i18n/pages.json
+++ b/src/renderer/i18n/pages.json
@@ -756,6 +756,66 @@
       "th": "เสร็จสิ้น",
       "id": "selesai",
       "ja": "完了"
+    },
+    "Straight rows of keys are easy to guess": {
+      "ko": "키보드에서 \"asdf\"와 같이 한 줄에 나열된 문자를 그대로 쓰면 추측되기 쉽습니다",
+      "en": "Straight rows of keys like \"asdf\" are easy to guess"
+    },
+    "Short keyboard patterns are easy to guess": {
+      "ko": "짧은 키보드 패턴은 추측하기 쉽습니다",
+      "en": "Short keyboard patterns are easy to guess"
+    },
+    "Use a longer keyboard pattern with more turns": {
+      "ko": "\"asdf sdf zxcv mnb\" 같이 더 많은 반복과 긴 키보드 패턴을 권장합니다",
+      "en": "Use a longer keyboard pattern with more turns like \"asdf sdf zxcv mnb\""
+    },
+    "Repeats like \"aaa\" are easy to guess": {
+      "ko": "\"aaa\" 같이 반복된 문자는 추측하기 쉽습니다",
+      "en": "Repeats like \"aaa\" are easy to guess"
+    },
+    "Repeats like \"abcabcabc\" are only slightly harder to guess than \"abc\"": {
+      "ko": "\"abcabcabc\"와 같은 반복은 \"abc\"보다 별로 나을 것이 없습니다",
+      "en": "Repeats like \"abcabcabc\" are only slightly harder to guess than \"abc\""
+    },
+    "Sequences like abc or 6543 are easy to guess": {
+      "ko": "abc 나 6543 같은 연속은 추측하기 쉽습니다",
+      "en": "Sequences like abc or 6543 are easy to guess"
+    },
+    "Recent years are easy to guess": {
+      "ko": "최근의 연도는 추측하기 쉽습니다",
+      "en": "Recent years are easy to guess"
+    },
+    "Dates are often easy to guess": {
+      "ko": "날짜는 대개 추측하기 쉽습니다",
+      "en": "Dates are often easy to guess"
+    },
+    "This is a top-10 common password": {
+      "ko": "가장 흔한 비밀번호 10가지 중 하나입니다",
+      "en": "This is a top-10 common password"
+    },
+    "This is a top-100 common password": {
+      "ko": "가장 흔한 100가지 중 하나입니다",
+      "en": "This is a top-100 common password"
+    },
+    "This is a very common password": {
+      "ko": "매우 흔한 비밀번호입니다",
+      "en": "This is a very common password"
+    },
+    "This is similar to a commonly used password": {
+      "ko": "흔히 쓰이는 비밀번호와 유사합니다",
+      "en": "This is similar to a commonly used password"
+    },
+    "A word by itself is easy to guess": {
+      "ko": "한 단어만으론 추측하기 쉽습니다",
+      "en": "A word by itself is easy to guess"
+    },
+    "Names and surnames by themselves are easy to guess": {
+      "ko": "성명만으로는 추측하기 쉽습니다",
+      "en": "Names and surnames by themselves are easy to guess"
+    },
+    "Common names and surnames are easy to guess": {
+      "ko": "흔한 이름과 성은 추측하기 쉽습니다",
+      "en": "Common names and surnames are easy to guess"
     }
   },
   "copyPrivateKey": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,8 +38,10 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    "paths": {
+      "zxcvbn": ["typings/zxcvbn.d.ts"]
+    },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/typings/zxcvbn.d.ts
+++ b/typings/zxcvbn.d.ts
@@ -1,0 +1,225 @@
+// Type definitions for zxcvbn 4.4
+// Project: https://github.com/dropbox/zxcvbn#readme
+// Definitions by: Matt Traynham <https://github.com/mtraynham>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export default zxcvbn;
+
+declare function zxcvbn(password: string, userInputs?: string[]): ZXCVBNResult;
+
+interface ZXCVBNResult {
+  /**
+   * estimated guesses needed to crack password
+   */
+  guesses: number;
+
+  /**
+   * order of magnitude of result.guesses
+   */
+  guesses_log10: number;
+
+  /**
+   * dictionary of back-of-the-envelope crack time
+   * estimations, in seconds, based on a few scenarios.
+   */
+  crack_times_seconds: ZXCVBNAttackTime;
+
+  /**
+   * same keys as result.crack_times_seconds,
+   * with friendlier display string values:
+   * "less than a second", "3 hours", "centuries", etc.
+   */
+  crack_times_display: ZXCVBNAttackTime;
+
+  /**
+   * Integer from 0-4 (useful for implementing a strength bar):
+   * 0 too guessable: risky password. (guesses < 10^3)
+   * 1 very guessable: protection from throttled online attacks. (guesses < 10^6)
+   * 2 somewhat guessable: protection from unthrottled online attacks. (guesses < 10^8)
+   * 3 safely unguessable: moderate protection from offline slow-hash scenario. (guesses < 10^10)
+   * 4 very unguessable: strong protection from offline slow-hash scenario. (guesses >= 10^10)
+   */
+  score: ZXCVBNScore;
+
+  /**
+   * verbal feedback to help choose better passwords. set when score <= 2.
+   */
+  feedback: ZXCVBNFeedback;
+
+  /**
+   * the list of patterns that zxcvbn based the
+   * guess calculation on.
+   */
+  sequence: ZXCVBNSequence[];
+
+  /**
+   * how long it took zxcvbn to calculate an answer,
+   * in milliseconds.
+   */
+  calc_time: number;
+}
+
+type ZXCVBNScore = 0 | 1 | 2 | 3 | 4;
+
+interface ZXCVBNAttackTime {
+  /**
+   * online attack on a service that ratelimits password auth attempts.
+   */
+  online_throttling_100_per_hour: string | number;
+
+  /**
+   * online attack on a service that doesn't ratelimit,
+   * or where an attacker has outsmarted ratelimiting.
+   */
+  online_no_throttling_10_per_second: string | number;
+
+  /**
+   * offline attack. assumes multiple attackers,
+   * proper user-unique salting, and a slow hash function
+   * w/ moderate work factor, such as bcrypt, scrypt, PBKDF2.
+   */
+  offline_slow_hashing_1e4_per_second: string | number;
+
+  /**
+   * offline attack with user-unique salting but a fast hash
+   * function like SHA-1, SHA-256 or MD5. A wide range of
+   * reasonable numbers anywhere from one billion - one trillion
+   * guesses per second, depending on number of cores and machines.
+   * ballparking at 10B/sec.
+   */
+  offline_fast_hashing_1e10_per_second: string | number;
+}
+
+interface ZXCVBNFeedback {
+  /**
+   * explains what's wrong, eg. 'this is a top-10 common password'.
+   * not always set -- sometimes an empty string
+   */
+  warning: ZXCVBNFeedbackWarning;
+
+  /**
+   * a possibly-empty list of suggestions to help choose a less
+   * guessable password. eg. 'Add another word or two'
+   */
+  suggestions: string[];
+}
+
+export type ZXCVBNFeedbackWarning =
+  | "Straight rows of keys are easy to guess"
+  | "Short keyboard patterns are easy to guess"
+  | "Use a longer keyboard pattern with more turns"
+  | 'Repeats like "aaa" are easy to guess'
+  | 'Repeats like "abcabcabc" are only slightly harder to guess than "abc"'
+  | "Sequences like abc or 6543 are easy to guess"
+  | "Recent years are easy to guess"
+  | "Dates are often easy to guess"
+  | "This is a top-10 common password"
+  | "This is a top-100 common password"
+  | "This is a very common password"
+  | "This is similar to a commonly used password"
+  | "A word by itself is easy to guess"
+  | "Names and surnames by themselves are easy to guess"
+  | "Common names and surnames are easy to guess"
+  | "";
+
+interface ZXCVBNSequence {
+  /**
+   * if sequence is ascending.
+   */
+  ascending: boolean;
+
+  /**
+   * the base number of guesses.
+   */
+  base_guesses: number;
+
+  /**
+   * the base match to relate to.
+   */
+  base_matches: string;
+
+  /**
+   * the base token to relate to.
+   */
+  base_token: string;
+
+  /**
+   * the dictionary this sequence was found in.
+   */
+  dictionary_name: string;
+
+  /**
+   * estimated guesses needed to crack sequence.
+   */
+  guesses: number;
+
+  /**
+   * order of magnitude of guesses.
+   */
+  guesses_log10: number;
+
+  /**
+   * sequence index.
+   */
+  i: number;
+
+  /**
+   * sequence section number.
+   */
+  j: number;
+
+  /**
+   * is part of l33t speak.
+   */
+  l33t: boolean;
+
+  /**
+   * how many variations of l33t speak.
+   */
+  l33t_variations: number;
+
+  /**
+   * the word that was matched in dictionary.
+   */
+  matched_word: string;
+
+  /**
+   * what type of pattern the sequence contains.
+   */
+  pattern: string;
+
+  /**
+   * the rank of the sequence in the dictionary.
+   */
+  rank: number;
+
+  /**
+   * how many times the sequence is repeated.
+   */
+  repeat_count: number;
+
+  /**
+   * is reveresed.
+   */
+  reversed: boolean;
+
+  /**
+   * what type of sequence it is.
+   */
+  sequence_name: string;
+
+  /**
+   * how much space the sequence has left.
+   */
+  sequence_space: number;
+
+  /**
+   * the token the sequence is based off.
+   */
+  token: string;
+
+  /**
+   * uppercase variations of the token.
+   */
+  uppercase_variations: number;
+}


### PR DESCRIPTION
## Check password is blank after trimmed

몇가지 상호작용이 설계되지 않아 보완했습니다.

### 폼 전송 버튼이 비활성화 된 경우
- 두 입력 필드가 비어 있을 경우 비활성 합니다. 처음 마운트 되었을 때 폼이 비활성되지 않았던 문제가 있어서 추가했습니다.
- 두 입력 필드의 문자열이 맞지 않음.

### 오류 상태

#### 비밀번호 필드
- 앞뒤 공백을 지웠을 때 문자가 비었을 경우

#### 비밀번호 확인 필드
- 두 입력 필드가 비어 있지 않고 앞뒤 공백을 지웠을 때 문자가 비어 있다. 또는 두 입력 필드의 문자열이 맞지 않는다.

## 비밀번호 강도 힌트 다국어 적용

[zxcvbn/src/feedback.coffee#L35-L99](https://github.com/dropbox/zxcvbn/blob/master/src/feedback.coffee#L35-L99)를 참고해서 문구를 추가했습니다.

## 스크린샷

<img width="500" alt="Screen Shot 2020-09-22 at 5 17 00 PM" src="https://user-images.githubusercontent.com/5278201/93968973-c41eb780-fda5-11ea-9b00-3c7a9eaf274d.png">

---

close #365 