### PR TITLE
Fix MiningView Button Size and <p /> block margin

### DIFF
--- a/src/renderer/views/login/MiningView.style.ts
+++ b/src/renderer/views/login/MiningView.style.ts
@@ -14,7 +14,7 @@ const miningViewStyle = makeStyles({
   button: {
     borderRadius: "0",
     width: "150px",
-    height: "70px",
+    height: "60px",
     fontWeight: "bold",
     fontSize: "larger",
   },
@@ -28,16 +28,19 @@ const miningViewStyle = makeStyles({
   },
 
   buttonContainer: {
-    position: "relative",
-    bottom: "-5px",
+    position: "absolute",
+    bottom: "32px",
+    display: "flex",
+    justifyContent: "space-between",
   },
-
+  description: {
+    marginBottom: "0.5em",
+  },
   requirement: {
     fontSize: "small",
     color: "darkgray",
     margin: 0,
   },
-
   jade: {
     width: "100%",
   },

--- a/src/renderer/views/login/MiningView.tsx
+++ b/src/renderer/views/login/MiningView.tsx
@@ -35,7 +35,7 @@ const MiningView = observer(
       <Container className={classes.root}>
         <h1 className={classes.title}>{locale("채굴 기능을 켜시겠습니까?")}</h1>
         <img className={classes.jade} src={jade} />
-        <p>{locale("description")}</p>
+        <p className={classes.description}>{locale("description")}</p>
         {requirement.map((paragraph) => (
           <p key={paragraph} className={classes.requirement}>
             {paragraph}


### PR DESCRIPTION
## 수정 사항

1. 두개의 버튼을 묶는 컨테이너의 위치를 아래에서 `34px` 로 고정했고,  버튼의 가로 위치를 좌우 끝으로 고정했습니다.
2. 버튼의 세로 길이를 줄였습니다.
3. 설명과 요구 사양의 간격을 줄였습니다. 

## 스크린샷

| 수정 전 | 수정 후 |
| :--: | :--: |
| <img width="399" alt="Screen Shot 2020-09-23 at 4 10 14 PM" src="https://user-images.githubusercontent.com/5278201/93979537-6c3d7c00-fdb8-11ea-910b-209004447856.png"> | <img width="399" alt="Screen Shot 2020-09-23 at 4 05 48 PM" src="https://user-images.githubusercontent.com/5278201/93979607-88d9b400-fdb8-11ea-8e04-2c4136fbdee8.png"> |