### PR TITLE
Add new Line between Button and Checkbox group

### DIFF
--- a/src/renderer/views/config/ConfigurationView.style.ts
+++ b/src/renderer/views/config/ConfigurationView.style.ts
@@ -63,6 +63,7 @@ const configurationViewStyle = makeStyles({
   },
   checkboxGroup: {
     marginTop: "6px",
+    display: "block",
   },
   checkboxHelper: {
     margin: 0,


### PR DESCRIPTION
<img width="315" alt="Screen Shot 2020-09-29 at 3 42 22 PM" src="https://user-images.githubusercontent.com/5278201/94522283-60473380-026a-11eb-8afa-7948ffedd3c1.png">

## 참고

체크박스 그룹이(MUI의 `<FormControl />`) 이미 div인데 `display: block`을 스타일로 추가해야 줄 바꿈이 되네요. 🤔 

버튼에 블록을 지정하면 아이콘과 글자가 줄바꿈 되었습니다.

<img width="216" alt="Screen Shot 2020-09-29 at 3 44 16 PM" src="https://user-images.githubusercontent.com/5278201/94522449-a43a3880-026a-11eb-8bdb-95d9fd921aee.png">
