### PR TITLE
Disable MUI Ripple Effect in TextButton

### DIFF
--- a/src/renderer/components/TextButton.ts
+++ b/src/renderer/components/TextButton.ts
@@ -5,6 +5,9 @@ const TextButton = styled(Button)({
   all: "unset",
   cursor: "pointer",
   fontSize: "inherit",
+  "& .MuiTouchRipple-root": {
+    display: "none",
+  },
 });
 
 export default TextButton;


### PR DESCRIPTION
<img width="798" alt="Screen Shot 2020-09-30 at 8 10 36 PM" src="https://user-images.githubusercontent.com/5278201/94678181-0ffacf00-0359-11eb-9fee-2bfd5971735f.png">

화면 전부를 대상으로 애니매이션이 전파되어서 스타일을 비활성했습니다.