### PR TITLE
지원언어에 중국어(간체) 추가

### DIFF
--- a/src/interfaces/i18n.ts
+++ b/src/interfaces/i18n.ts
@@ -35,7 +35,8 @@ export type OptionalLocale =
   | "th"
   | "id"
   | "ja"
-  | "es";
+  | "es"
+  | "zh-Hans";
 
 export type RequireLocale = "en" | "ko";
 

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -31,6 +31,7 @@ const supportedLocales = {
   "pt-BR": "Português (Brazil)",
   th: "ภาษาไทย",
   de: "Deutsch",
+  "zh-Hans": "中文 (简体)",
 } as Record<Locale, string>;
 
 type PageKey = keyof I18n;


### PR DESCRIPTION
아직 론처쪽 번역은 없지만, 유니티 플레이어쪽에선 중국어(간체)를 지원하고 있기 때문에 이를 지원언어에 추가합니다. (영어로 폴백되는 것까진 확인했습니다.)