### PR TITLE
지원언어 목록이 제대로 반영되지 않던 버그 수정

### DIFF
--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -17,7 +17,7 @@ const context = createContext<LocaleContext>({
   locale: "en",
 });
 
-const supportedLocales = {
+export const supportedLocales = {
   //  ko: "한국어",
   en: "English",
   es: "Español",
@@ -38,8 +38,7 @@ type PageKey = keyof I18n;
 
 export function useLocale<Page extends I18n[PageKey]>(pageName: PageKey) {
   const { locale } = useContext(context);
-
-  const selectedLocale = locale.startsWith("en") ? "en" : locale;
+  const selectedLocale = locale in supportedLocales ? locale : "en";
 
   const page = pages[pageName];
   return {

--- a/src/renderer/stores/game.ts
+++ b/src/renderer/stores/game.ts
@@ -1,5 +1,6 @@
 import { observable, action, computed } from "mobx";
 import { ipcRenderer, IpcRendererEvent } from "electron";
+import { supportedLocales } from "../i18n";
 import {
   RPC_LOOPBACK_HOST,
   RPC_SERVER_PORT,
@@ -20,6 +21,10 @@ export default class GameStore {
     });
     this._genesisBlockPath = electronStore.get("GenesisBlockPath") as string;
     this._language = electronStore.get("Locale") as string;
+
+    if (!(this._language in supportedLocales)) {
+      this._language = "en";
+    }
   }
 
   @computed


### PR DESCRIPTION
#419 에서 한국어를 지원언어 목록에서 제외했지만, 화면 로케일이나 Unity 실행시 언어는 이 지원언어 목록을 참고하고 있지 않아 실제론 아무 효과가 없었습니다.

그래서 지원언어 목록에 해당하는지를 보고, 아닌 경우엔 `"en"`을 사용하게 관련 코드를 수정했습니다.