### PR TITLE
Remove all temporary files made during updating

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -325,6 +325,18 @@ function initializeIpc() {
         console.log("The zip archive", dlPath, "has extracted to", tempDir);
         win?.webContents.send("update copying progress");
         await copyDir(tempDir, extractPath);
+        console.log("Copied extracted files from", tempDir, "to", extractPath);
+        try {
+          await fs.promises.rmdir(tempDir, { recursive: true });
+          console.log("Removed all temporary files from", tempDir);
+        } catch (e) {
+          console.warn(
+            "Failed to remove temporary files from",
+            tempDir,
+            "\n",
+            e
+          );
+        }
         win?.webContents.send("update copying complete");
       } else if (process.platform == "darwin") {
         // .tar.{gz,bz2} 해제


### PR DESCRIPTION
On Windows, the updater extracts files into a temporary directory first, and then copies them into the installation path.  After everything is finished, these temporary files should be removed then.  Even if any errors happen, these are ignored as it's a optional process (everything in the system temporary folder is automatically and eventually cleaned up).