### PR TITLE
feat: log if standalone exited or not

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -215,6 +215,7 @@ function initializeIpc() {
 
       console.log("Encounter a different version:", data);
       if (win == null) return;
+      console.log("standaloneExited", standaloneExited);
 
       const { differentAppProtocolVersionEncounter } = data;
       console.log(differentAppProtocolVersionEncounter);
@@ -313,6 +314,7 @@ function initializeIpc() {
 
         // ZIP 압축 해제
         console.log("Start to extract the zip archive", dlPath, "to", tempDir);
+        console.log("standaloneExited", standaloneExited);
 
         await extractZip(dlPath, {
           dir: tempDir,


### PR DESCRIPTION
스탠드얼론이 잘 종료되지 않아 업데이터가 의도한대로 동작하지 않는 경우(추정)를 확인하기 위해 `quitAllProcesses()`를 호출한 후와 압축을 풀기 전에 스탠드얼론이 종료되었는지를 확인하는 로그를 찍게 하였습니다.