### PR TITLE
체인이 뒤쳐져 있을때 스탠드얼론을 재시작합니다

### DIFF
--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -110,6 +110,10 @@ const PreloadProgressView = observer(() => {
         console.error("No any peers. Redirect to relaunch page.");
         gotoErrorPage("relaunch");
         break;
+      case 0x02:
+        console.error("Chain is too low. Automatically relaunch.");
+        ipcRenderer.send("relaunch standalone");
+        break;
     }
   }, [nodeExceptionSubscriptionResult?.nodeException?.code]);
 


### PR DESCRIPTION
런처를 종료하지 않고 스탠드얼론 레벨에서 재시작합니다. #447 이 선행 PR이므로 먼저 머지되어야 합니다.

+ https://github.com/planetarium/NineChronicles.Standalone/pull/153