### PR TITLE
Use remote.shell to open folder

### DIFF
--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -1,6 +1,6 @@
 import path from "path";
 
-import { ipcRenderer, remote, shell } from "electron";
+import { ipcRenderer, remote } from "electron";
 import React from "react";
 import { observer } from "mobx-react";
 import {
@@ -195,7 +195,7 @@ const ConfigurationView = observer(() => {
 function handleOpenKeyStorePath() {
   const home = remote.app.getPath("home");
   const middlePath = process.platform === "win32" ? "AppData" : ".config";
-  shell.showItemInFolder(
+  remote.shell.showItemInFolder(
     path.join(home, middlePath, "planetarium", "keystore")
   );
 }


### PR DESCRIPTION
> 참조한 일렉트론 이슈 : https://github.com/electron/electron/issues/6514#issuecomment-233087305

윈도우 10 환경에서 폴더 탐색기를 띄우지 않은 오류를 해결합니다.

설정 페이지에서 일렉트론 API 중에 `.getPath`, `.app`가 `remote` 로 접근하는데, 동일하게 `remote`로 참조하면 작동하지 않을까 올려봅니다. (테스트 부탁드려요!)