### PR TITLE
add clear-cache when updating new version

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -275,7 +275,9 @@ function initializeIpc() {
         "Removed 'encounter different version' lockfile at ",
         lockfilePath
       );
-
+      // 정상적으로 새 버전이 받아지고 캐시 클리어
+      await utils.deleteBlockchainStoreSync(BLOCKCHAIN_STORE_PATH);
+      await initializeStandalone();
       // 재시작
       relaunch();
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -277,7 +277,6 @@ function initializeIpc() {
       );
       // 정상적으로 새 버전이 받아지고 캐시 클리어
       await utils.deleteBlockchainStoreSync(BLOCKCHAIN_STORE_PATH);
-      await initializeStandalone();
       // 재시작
       relaunch();
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -276,7 +276,7 @@ function initializeIpc() {
         lockfilePath
       );
       // 정상적으로 새 버전이 받아지고 캐시 클리어
-      await utils.deleteBlockchainStoreSync(BLOCKCHAIN_STORE_PATH);
+      utils.deleteBlockchainStoreSync(BLOCKCHAIN_STORE_PATH);
       // 재시작
       relaunch();
 


### PR DESCRIPTION
This addition clears cache only if the new version is valid and has been downloaded.
I haven't actually tested this out so I'd love anyone's feedback (I will be testing this tomorrow 11-13-2020)