### PR TITLE
fix relaunch sequence

### DIFF
--- a/src/renderer/views/error/ErrorReinstallView.tsx
+++ b/src/renderer/views/error/ErrorReinstallView.tsx
@@ -16,9 +16,9 @@ const ErrorReinstallView = () => {
       window.confirm("This will close launcher. Are you sure to clear cache?")
     ) {
       ipcRenderer.sendSync("clear cache");
+      remote.app.relaunch();
+      remote.app.exit();
     }
-    remote.app.relaunch();
-    remote.app.exit();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
This change will restart launcher only if the user clicks the 'OK' button on the alert window.