### PR TITLE
Fixed a bug on macOS

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -50,7 +50,7 @@ const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
 const standaloneExecutablePath = path.join(
   app.getAppPath(),
   "publish",
-  "NineChronicles.Standalone.Executable.exe"
+  "NineChronicles.Standalone.Executable"
 );
 const standaloneExecutableArgs = [
   `-V=${electronStore.get("AppProtocolVersion")}`,
@@ -441,7 +441,7 @@ async function initializeStandalone(): Promise<void> {
     console.error("Cannot initialize standalone while updater is running.");
     return;
   }
-  
+
   initializeStandaloneCts = CancellationToken.create();
 
   try {


### PR DESCRIPTION
This PR removes an extension(`.exe`) from `NineChronicles.Standalone.Executable`. (`NineChronicles.Standalone.Executable` is also valid executable name in Windows).