### PR TITLE
Fix keystore path for Windows

### DIFF
--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -193,10 +193,11 @@ const ConfigurationView = observer(() => {
 });
 
 function handleOpenKeyStorePath() {
-  const home = remote.app.getPath("home");
-  const middlePath =
-    process.platform === "win32" ? "AppData\\roaming" : ".config";
-  let openpath = path.join(home, middlePath, "planetarium", "keystore");
+  const openpath = path.join(
+    remote.app.getPath("appData"),
+    "planetarium",
+    "keystore"
+  );
   console.log(`Open keystore folder. ${openpath}`);
   shell.showItemInFolder(openpath);
 }


### PR DESCRIPTION
설정창에서 키스토어 패스를 눌렀을 때 잘 열리는 것 확인했습니다.

----

Closes #446.