### PR TITLE
config.json에서 mixpanel 옵션 false로 줄 시 화면 안뜨던 문제 해결

### DIFF
--- a/src/preload/mixpanel.ts
+++ b/src/preload/mixpanel.ts
@@ -10,15 +10,9 @@ export default function initializeMixpanel() {
     return;
   }
 
-  if (electronStore.get("Mixpanel") === true) {
-    mixpanel.init(token);
-  } else {
-    console.debug("Mixpanel is disabled by config");
-    return;
-  }
-
-  if (isDev) {
-    console.debug("Mixpanel is disabled in development mode.");
+  mixpanel.init(token);
+  if (isDev || electronStore.get("Mixpanel") !== true) {
+    console.debug("Mixpanel is disabled.");
     mixpanel.disable();
   }
 }


### PR DESCRIPTION
false로 주면 화면이 안뜨는 문제가 있었는데, 다른 곳에서 mixpanel을 사용할 때 생기는 문제여서 아얘 init을 안하기보다는 하고 나서 disable하게 바꿨습니다.