### PR TITLE
fix(logging): handle if guid file not exists

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -449,9 +449,15 @@ function initializeIpc() {
         "planetarium",
         ".aws_sink_cloudwatch_guid"
       );
-      event.returnValue = await fs.promises.readFile(guidPath, {
-        encoding: "utf-8",
-      });
+
+      if (fs.existsSync(guidPath)) {
+        event.returnValue = await fs.promises.readFile(guidPath, {
+          encoding: "utf-8",
+        });
+      } else {
+        event.returnValue = null;
+      }
+
       return;
     }
 


### PR DESCRIPTION
It didn't handle the case which AWS Cloudwatch GUID file doesn't exist, until this pull request. And it causes empty page if there wasn't the file.

So it starts to handle the case and became to handle as null if it doesn't exist. And it will hide the field in the debug box like below picture, through below code.

```tsx
// src/renderer/views/layout/Layout.tsx

{awsSinkCloudwatchGuid !== null ? (
              <li>Client ID: {awsSinkCloudwatchGuid}</li>
            ) : (
              <></>
            )}
```

![image](https://user-images.githubusercontent.com/26626194/100691484-26122380-33cc-11eb-8238-f5758f5e85ce.png)

If there is:

![image](https://user-images.githubusercontent.com/26626194/100691630-74bfbd80-33cc-11eb-942a-216849608f9f.png)

You can test this by renaming or deleting `%LOCALAPPDATA%\planetarium\.aws_sink_cloudwatch_guid`.

