### PR TITLE
fix(mixpanel): correct reading installer mixpanel uuid

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -465,7 +465,9 @@ function initializeIpc() {
   ipcMain.on("get-installer-mixpanel-uuid", async (event) => {
     let guidPath = path.join(app.getAppPath(), ".installer_mixpanel_uuid");
     if (process.platform === "win32" && fs.existsSync(guidPath)) {
-      event.returnValue = await fs.promises.readFile(guidPath).toString();
+      event.returnValue = await fs.promises.readFile(guidPath, {
+        encoding: "utf-8",
+      });
     } else {
       event.returnValue = null;
     }


### PR DESCRIPTION
It fixes it returned `[object Promise]` instead installer mixpanel UUID. It has been being since #361.
