### PR TITLE
헤드리스가 스스로 종료되었을 때 처리를 추가합니다

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -570,7 +570,7 @@ async function initializeStandalone(): Promise<void> {
 
     console.log("Register exit handler.");
     standalone.once("exit", () => {
-      console.error("Standalone exited by self.");
+      console.error("Headless exited by self.");
       win?.webContents.send("go to error page", "relaunch");
     });
   } catch (error) {

--- a/src/main/standalone.ts
+++ b/src/main/standalone.ts
@@ -156,7 +156,7 @@ class Standalone {
   private exitedHandler(code: number | null): void {
     console.error(`Standalone exited with exit code: ${code}`);
     if (!NODESTATUS.QuitRequested) {
-      console.error("Standalone exited unexpectedly.");
+      console.error("Headless exited unexpectedly.");
       eventEmitter.emit("exit");
     }
 


### PR DESCRIPTION
기존에는 헤드리스가 론처가 의도하지 않았는데 종료되었을 때 어떠한 처리도 하지 않아 정상적으로 작동하는 것 처럼 보이지만 멈춰 있었는데, 처리를 추가해 에러 페이지로 이동하게 합니다.

**#507 이 먼저 머지되어야 합니다.**