### PR TITLE
헤드리스가 메세지를 오랫동안 받지 못했을 때 재시작합니다

### DIFF
--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -119,6 +119,12 @@ const PreloadProgressView = observer(() => {
         console.error("Chain's tip is stale. Automatically relaunch.");
         ipcRenderer.send("relaunch standalone");
         break;
+      case 0x04:
+        console.error(
+          "Haven't received any messages for some time. Automatically relaunch."
+        );
+        ipcRenderer.send("relaunch standalone");
+        break;
       case 0x05:
         console.error("Action Timeout. Automatically relaunch.");
         ipcRenderer.send("relaunch standalone");


### PR DESCRIPTION
기존에는 `Swarm`만 재시작 키는 방식이었는데, 소켓이 제대로 닫히지 않는 것 같아 해당 상황에서 헤드리스 어플리케이션 자체를 재시작합니다.