### PR TITLE
헤드리스 시작 도중 발생하는 에러 핸들링

### DIFF
--- a/src/errors/HeadlessExitedError.ts
+++ b/src/errors/HeadlessExitedError.ts
@@ -1,0 +1,8 @@
+class HeadlessExitedError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    Object.setPrototypeOf(this, HeadlessExitedError.prototype);
+  }
+}
+
+export default HeadlessExitedError;

--- a/src/errors/StandaloneExitedError.ts
+++ b/src/errors/StandaloneExitedError.ts
@@ -1,8 +1,0 @@
-class StandaloneExitedError extends Error {
-  constructor(msg: string) {
-    super(msg);
-    Object.setPrototypeOf(this, StandaloneExitedError.prototype);
-  }
-}
-
-export default StandaloneExitedError;

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,3 +1,3 @@
 export { default as FetchError } from "./FetchError";
-export { default as StandaloneExitedError } from "./StandaloneExitedError";
+export { default as HeadlessExitedError } from "./HeadlessExitedError";
 export { default as StandaloneInitializeError } from "./StandaloneInitializeError";

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -38,7 +38,7 @@ import mixpanel from "mixpanel-browser";
 import * as utils from "../utils";
 import * as snapshot from "./snapshot";
 import Standalone from "./standalone";
-import { StandaloneExitedError, StandaloneInitializeError } from "../errors";
+import { HeadlessExitedError, StandaloneInitializeError } from "../errors";
 import CancellationToken from "cancellationtoken";
 import { IDownloadProgress, IGameStartOptions } from "../interfaces/ipc";
 
@@ -580,8 +580,8 @@ async function initializeStandalone(): Promise<void> {
       error instanceof CancellationToken.CancellationError
     ) {
       console.error(`InitializeStandalone() halted: ${error}`);
-    } else if (error instanceof StandaloneExitedError) {
-      console.error("Standalone exited during initialization.");
+    } else if (error instanceof HeadlessExitedError) {
+      console.error("Headless exited during initialization.");
       win?.webContents.send("go to error page", "clear-cache");
     } else {
       win?.webContents.send("go to error page", "reinstall");

--- a/src/main/standalone.ts
+++ b/src/main/standalone.ts
@@ -2,7 +2,7 @@ import { ChildProcess } from "child_process";
 import { ipcMain } from "electron";
 import { electronStore, LOCAL_SERVER_URL } from "../config";
 import { retry } from "@lifeomic/attempt";
-import { FetchError, StandaloneExitedError } from "../errors";
+import { FetchError, HeadlessExitedError } from "../errors";
 import { execute, sleep } from "../utils";
 import fetch, { Response } from "electron-fetch";
 import { EventEmitter } from "ws";
@@ -170,8 +170,8 @@ class Standalone {
       if (!this.alive) {
         console.log("Standalone is not alive. Abort...");
         context.abort();
-        throw new StandaloneExitedError(
-          "Standalone is exited during fetching."
+        throw new HeadlessExitedError(
+          "Headless is exited during fetching."
         );
       }
 


### PR DESCRIPTION
시작 도중에 에러가 나서 헤드리스가 종료되는 경우 (제너시스가 맞지 않거나 스토리지가 깨지는 경우) 클리어 캐시 에러 페이지로 이동하는 로직을 추가합니다.