### PR TITLE
fix events of github flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,14 @@ jobs:
     steps:
       # 클론
       - uses: actions/checkout@v2
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         with:
           submodules: false
           lfs: false
       - uses: actions/checkout@v2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: ${{ github.pull_request.head.sha }}
+          ref: ${{ github.pull_request_target.head.sha }}
           submodules: false
           lfs: false
       # Node.js 설치
@@ -50,15 +50,15 @@ jobs:
     steps:
       # 클론
       - uses: actions/checkout@v2
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         with:
           submodules: recursive
           ssh-key: ${{ secrets.SUBMODULE_PULL_KEY }}
           lfs: false
       - uses: actions/checkout@v2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: ${{ github.pull_request.head.sha }}
+          ref: ${{ github.pull_request_target.head.sha }}
           submodules: recursive
           ssh-key: ${{ secrets.SUBMODULE_PULL_KEY }}
           lfs: false
@@ -74,8 +74,8 @@ jobs:
               chmod +x github-commenter
             fi
             export GITHUB_REPO="${GITHUB_REPOSITORY#*/}"
-            if [[ "${{ github.event_name }}" = "pull_request" ]]; then
-              pr_no=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+            if [[ "${{ github.event_name }}" = "pull_request_target" ]]; then
+              pr_no=$(jq --raw-output .pull_request_target.number "$GITHUB_EVENT_PATH")
               ./github-commenter \
                 --type pr \
                 --number "$pr_no"
@@ -128,7 +128,7 @@ jobs:
         run: npm run codegen
       - name: Type Check
         run: npx tsc --noEmit
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
       # 빌드
       - run: npm run build-prod
       # 이전 릴리스 버전으로부터 config.json 복사
@@ -173,7 +173,7 @@ jobs:
       - if: runner.os != 'Windows'
         run: tar cvfz ../../pack-dist/macOS.tar.gz *
         working-directory: pack/Nine Chronicles-darwin-x64/
-      - if: github.event_name != 'pull_request'
+      - if: github.event_name != 'pull_request_target'
         uses: actions/upload-artifact@v2
         with:
           path: pack-dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: ["*"]
     tags: ["*"]
-  pull_request: []
+  pull_request_target: []
 
 jobs:
   # APV 서명

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -1,5 +1,5 @@
 name: E2E Test
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   run-test:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,15 +12,15 @@ jobs:
     steps:
       # 클론
       - uses: actions/checkout@v2
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         with:
           submodules: true
           ssh-key: ${{ secrets.SUBMODULE_PULL_KEY }}
           lfs: false
       - uses: actions/checkout@v2
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         with:
-          ref: ${{ github.pull_request.head.sha }}
+          ref: ${{ github.pull_request_target.head.sha }}
           submodules: true
           ssh-key: ${{ secrets.SUBMODULE_PULL_KEY }}
           lfs: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: pull_request
 on:
   push:
     branches: []
-  pull_request:
+  pull_request_target:
     branches: []
 
 jobs:


### PR DESCRIPTION
As this repository became public, there was a problem that the `Repository Secrets` could not be accessed by `Pull Request` made based on the forked repository.
As a workaround, we considered using `Organization Secrets` and using `pull_request_target` event instead of `pull_request` event, and chose the latter.