### PR TITLE
Don't change path when dialog is canceled

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -470,7 +470,11 @@ function initializeIpc() {
     const directory = await dialog.showOpenDialog(win, {
       properties: ["openDirectory"],
     });
-    event.returnValue = directory.filePaths;
+    if (directory.canceled) {
+      event.returnValue = null;
+    } else {
+      event.returnValue = directory.filePaths;
+    }
   });
 
   ipcMain.on("relaunch standalone", async (event) => {

--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -57,7 +57,8 @@ const ConfigurationView = observer(() => {
   };
 
   const handleChangeDir = () => {
-    const directory = ipcRenderer.sendSync("select-directory") as string[];
+    const directory = ipcRenderer.sendSync("select-directory") as string[] | null;
+    if (directory === null) return;
     setRootChainPath(path.join(...directory));
   };
 


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/17797795/110291247-0e7fb200-802f-11eb-912e-09e7f6c19a0f.gif)

대화 상자가 취소되었을 때 루트 체인 경로가 비정상적으로 적용되는 문제를 해결했습니다.
