### PR TITLE
Relaunch headless when it exited with unexpected error

### DIFF
--- a/src/main/headless.ts
+++ b/src/main/headless.ts
@@ -214,13 +214,14 @@ class Headless {
 
   private exitedHandler(code: number | null): void {
     console.error(`Standalone exited with exit code: ${code}`);
+
+    NODESTATUS.Node = null;
+    NODESTATUS.ExitCode = code;
+    
     if (!NODESTATUS.QuitRequested) {
       console.error("Headless exited unexpectedly.");
       eventEmitter.emit("exit");
     }
-
-    NODESTATUS.Node = null;
-    NODESTATUS.ExitCode = code;
   }
 
   private retriableFetch(addr: string, body: string): Promise<boolean> {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -626,6 +626,20 @@ async function initializeHeadless(): Promise<void> {
   */
   console.log(`Initialize headless. (win: ${win?.getTitle})`);
 
+  if (initializeHeadlessCts !== null) {
+    console.error(
+      "Cannot initialize headless while initializing headless.",
+    );
+    return;
+  }
+
+  if (standalone.alive) {
+    console.error(
+      "Cannot initialize headless while headless is running.",
+    );
+    return;
+  }
+
   if (lockfile.checkSync(lockfilePath)) {
     console.error(
       "Cannot initialize headless while updater is running.\n",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -722,9 +722,9 @@ async function initializeHeadless(): Promise<void> {
     }
 
     console.log("Register exit handler.");
-    standalone.once("exit", () => {
+    standalone.once("exit", async () => {
       console.error("Headless exited by self.");
-      win?.webContents.send("go to error page", "relaunch");
+      await relaunchHeadless();
     });
   } catch (error) {
     console.error(`Error occurred during initializeHeadless(). ${error}`);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -494,8 +494,7 @@ function initializeIpc() {
   });
 
   ipcMain.on("relaunch standalone", async (event) => {
-    await stopStandaloneProcess();
-    initializeHeadless();
+    await relaunchHeadless();
     event.returnValue = true;
   });
 
@@ -728,7 +727,7 @@ async function initializeHeadless(): Promise<void> {
       win?.webContents.send("go to error page", "relaunch");
     });
   } catch (error) {
-    console.error(`Error occurred during initializeStandalone(). ${error}`);
+    console.error(`Error occurred during initializeHeadless(). ${error}`);
     if (
       error instanceof HeadlessInitializeError ||
       error instanceof CancellationToken.CancellationError
@@ -845,19 +844,24 @@ function loadInstallerMixpanelUUID(): string {
   }
 }
 
+async function relaunchHeadless() {
+  await stopHeadlessProcess();
+  initializeHeadless();
+}
+
 async function quitAllProcesses() {
-  await stopStandaloneProcess();
+  await stopHeadlessProcess();
   if (gameNode === null) return;
   let pid = gameNode.pid;
   process.kill(pid, "SIGINT");
   gameNode = null;
 }
 
-async function stopStandaloneProcess(): Promise<void> {
-  console.log("Cancelling initializeStandalone()");
+async function stopHeadlessProcess(): Promise<void> {
+  console.log("Cancelling initializeHeadless()");
   initializeHeadlessCts?.cancel();
   while (initializeHeadlessCts !== null) await utils.sleep(100);
-  console.log("initializeStandalone() cancelled.");
+  console.log("initializeHeadless() cancelled.");
   await standalone.kill();
 }
 


### PR DESCRIPTION
This patch let headless to relaunch when headless is exited with unexpected error. Additionally it prevents duplicated initialize process.