### PR TITLE
fix: correct private-key validation argument

### DIFF
--- a/src/main/headless/validation.ts
+++ b/src/main/headless/validation.ts
@@ -4,7 +4,7 @@ import { StandaloneSubcommand } from "./subcommand";
 export class Validation extends StandaloneSubcommand {
   public isValidPrivateKey(privateKeyHex: string): boolean {
     try {
-      this.execSync("validation", "private-key", `"${privateKeyHex}"`);
+      this.execSync("validation", "private-key", privateKeyHex);
       return true;
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
There was a bug to pass argument with `"` though it uses `execFileSync` function, since https://github.com/planetarium/9c-launcher/pull/597