### PR TITLE
chore: invite @boscohyun into auto-assign reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -8,5 +8,6 @@ reviewers:
   - riemannulus
   - moreal
   - area363
+  - boscohyun
 
 numberOfReviewers: 0


### PR DESCRIPTION
This pull request invites @boscohyun into auto-assign reviewers list to make the bot to add him to reviewers automatically.