### PR TITLE
Feature/divide snapshot download events

### DIFF
--- a/__tests__/snapshot.spec.ts
+++ b/__tests__/snapshot.spec.ts
@@ -18,6 +18,7 @@ const userDataPath = path.join(__dirname, "userData");
 const emptyStore = path.join(storePath, "empty");
 const nonEmptyStore = path.join(storePath, "non-empty");
 const integrationStore = path.join(storePath, "integration");
+const emptyMixpanelUUID = "";
 
 async function getMetadataFromFilename(filename: string) {
   const metadataPath = path.join(storePath, filename);
@@ -58,7 +59,9 @@ describe("snapshot", function () {
         emptyStore,
         baseUrl,
         userDataPath,
-        cancellation.token
+        cancellation.token,
+        null,
+        emptyMixpanelUUID
       );
 
       assert.equal(target.length, 16);
@@ -81,7 +84,9 @@ describe("snapshot", function () {
         nonEmptyStore,
         baseUrl,
         userDataPath,
-        cancellation.token
+        cancellation.token,
+        null,
+        emptyMixpanelUUID
       );
 
       assert.equal(target.length, 11);
@@ -102,7 +107,9 @@ describe("snapshot", function () {
         baseUrl,
         userDataPath,
         "latest.json",
-        cancellation.token
+        cancellation.token,
+        null,
+        emptyMixpanelUUID
       );
 
       let target = await getSnapshotDownloadTarget(
@@ -110,7 +117,9 @@ describe("snapshot", function () {
         emptyStore,
         baseUrl,
         userDataPath,
-        cancellation.token
+        cancellation.token,
+        null,
+        emptyMixpanelUUID
       );
 
       let result = await downloadSnapshot(
@@ -118,7 +127,9 @@ describe("snapshot", function () {
         target,
         userDataPath,
         (status) => {},
-        cancellation.token
+        cancellation.token,
+        null,
+        emptyMixpanelUUID
       );
 
       let snapshotZipList = readdirSync(userDataPath).filter(
@@ -140,7 +151,9 @@ describe("snapshot", function () {
       baseUrl,
       userDataPath,
       "latest.json",
-      cancellation.token
+      cancellation.token,
+      null,
+      emptyMixpanelUUID
     );
     let needSnapshot = validateMetadata(
       metadata,
@@ -156,7 +169,9 @@ describe("snapshot", function () {
       integrationStore,
       baseUrl,
       userDataPath,
-      cancellation.token
+      cancellation.token,
+      null,
+      emptyMixpanelUUID
     );
 
     let snapshotPaths = await downloadSnapshot(
@@ -164,7 +179,9 @@ describe("snapshot", function () {
       target,
       userDataPath,
       (status) => {},
-      cancellation.token
+      cancellation.token,
+      null,
+      emptyMixpanelUUID
     );
 
     await extractSnapshot(

--- a/__tests__/snapshot.spec.ts
+++ b/__tests__/snapshot.spec.ts
@@ -61,7 +61,8 @@ describe("snapshot", function () {
         userDataPath,
         cancellation.token,
         null,
-        emptyMixpanelUUID
+        emptyMixpanelUUID,
+        null
       );
 
       assert.equal(target.length, 16);
@@ -86,7 +87,8 @@ describe("snapshot", function () {
         userDataPath,
         cancellation.token,
         null,
-        emptyMixpanelUUID
+        emptyMixpanelUUID,
+        null
       );
 
       assert.equal(target.length, 11);
@@ -109,7 +111,8 @@ describe("snapshot", function () {
         "latest.json",
         cancellation.token,
         null,
-        emptyMixpanelUUID
+        emptyMixpanelUUID,
+        ""
       );
 
       let target = await getSnapshotDownloadTarget(
@@ -119,7 +122,8 @@ describe("snapshot", function () {
         userDataPath,
         cancellation.token,
         null,
-        emptyMixpanelUUID
+        emptyMixpanelUUID,
+        null
       );
 
       let result = await downloadSnapshot(
@@ -129,7 +133,8 @@ describe("snapshot", function () {
         (status) => {},
         cancellation.token,
         null,
-        emptyMixpanelUUID
+        emptyMixpanelUUID,
+        null
       );
 
       let snapshotZipList = readdirSync(userDataPath).filter(
@@ -153,7 +158,8 @@ describe("snapshot", function () {
       "latest.json",
       cancellation.token,
       null,
-      emptyMixpanelUUID
+      emptyMixpanelUUID,
+      null
     );
     let needSnapshot = validateMetadata(
       metadata,
@@ -171,7 +177,8 @@ describe("snapshot", function () {
       userDataPath,
       cancellation.token,
       null,
-      emptyMixpanelUUID
+      emptyMixpanelUUID,
+      null
     );
 
     let snapshotPaths = await downloadSnapshot(
@@ -181,7 +188,8 @@ describe("snapshot", function () {
       (status) => {},
       cancellation.token,
       null,
-      emptyMixpanelUUID
+      emptyMixpanelUUID,
+      null
     );
 
     await extractSnapshot(

--- a/__tests__/snapshot.spec.ts
+++ b/__tests__/snapshot.spec.ts
@@ -11,6 +11,7 @@ import {
   validateMetadata,
 } from "../src/main/snapshot";
 import { BlockMetadata } from "src/interfaces/block-header";
+import { MixpanelInfo } from "../src/main/main";
 
 const storePath = path.join(__dirname, "fixture", "store");
 const baseUrl = "https://download.nine-chronicles.com/partition-test";
@@ -18,6 +19,12 @@ const userDataPath = path.join(__dirname, "userData");
 const emptyStore = path.join(storePath, "empty");
 const nonEmptyStore = path.join(storePath, "non-empty");
 const integrationStore = path.join(storePath, "integration");
+
+const dummyMixpanelInfo: MixpanelInfo = {
+  mixpanel: null,
+  mixpanelUUID: "",
+  ip: null,
+};
 
 async function getMetadataFromFilename(filename: string) {
   const metadataPath = path.join(storePath, filename);
@@ -58,10 +65,8 @@ describe("snapshot", function () {
         emptyStore,
         baseUrl,
         userDataPath,
-        cancellation.token,
-        null,
-        null,
-        null
+        dummyMixpanelInfo,
+        cancellation.token
       );
 
       assert.equal(target.length, 16);
@@ -84,10 +89,8 @@ describe("snapshot", function () {
         nonEmptyStore,
         baseUrl,
         userDataPath,
-        cancellation.token,
-        null,
-        null,
-        null
+        dummyMixpanelInfo,
+        cancellation.token
       );
 
       assert.equal(target.length, 11);
@@ -108,10 +111,7 @@ describe("snapshot", function () {
         baseUrl,
         userDataPath,
         "latest.json",
-        cancellation.token,
-        null,
-        null,
-        null
+        cancellation.token
       );
 
       let target = await getSnapshotDownloadTarget(
@@ -119,10 +119,8 @@ describe("snapshot", function () {
         emptyStore,
         baseUrl,
         userDataPath,
-        cancellation.token,
-        null,
-        null,
-        null
+        dummyMixpanelInfo,
+        cancellation.token
       );
 
       let result = await downloadSnapshot(
@@ -130,10 +128,8 @@ describe("snapshot", function () {
         target,
         userDataPath,
         (status) => {},
-        cancellation.token,
-        null,
-        null,
-        null
+        dummyMixpanelInfo,
+        cancellation.token
       );
 
       let snapshotZipList = readdirSync(userDataPath).filter(
@@ -155,10 +151,7 @@ describe("snapshot", function () {
       baseUrl,
       userDataPath,
       "latest.json",
-      cancellation.token,
-      null,
-      null,
-      null
+      cancellation.token
     );
     let needSnapshot = validateMetadata(
       metadata,
@@ -174,10 +167,8 @@ describe("snapshot", function () {
       integrationStore,
       baseUrl,
       userDataPath,
-      cancellation.token,
-      null,
-      null,
-      null
+      dummyMixpanelInfo,
+      cancellation.token
     );
 
     let snapshotPaths = await downloadSnapshot(
@@ -185,10 +176,8 @@ describe("snapshot", function () {
       target,
       userDataPath,
       (status) => {},
-      cancellation.token,
-      null,
-      null,
-      null
+      dummyMixpanelInfo,
+      cancellation.token
     );
 
     await extractSnapshot(
@@ -199,6 +188,7 @@ describe("snapshot", function () {
           console.log(progress * 100);
         }
       },
+      dummyMixpanelInfo,
       cancellation.token
     );
     console.log("finish");

--- a/__tests__/snapshot.spec.ts
+++ b/__tests__/snapshot.spec.ts
@@ -18,7 +18,6 @@ const userDataPath = path.join(__dirname, "userData");
 const emptyStore = path.join(storePath, "empty");
 const nonEmptyStore = path.join(storePath, "non-empty");
 const integrationStore = path.join(storePath, "integration");
-const emptyMixpanelUUID = "";
 
 async function getMetadataFromFilename(filename: string) {
   const metadataPath = path.join(storePath, filename);
@@ -61,7 +60,7 @@ describe("snapshot", function () {
         userDataPath,
         cancellation.token,
         null,
-        emptyMixpanelUUID,
+        null,
         null
       );
 
@@ -87,7 +86,7 @@ describe("snapshot", function () {
         userDataPath,
         cancellation.token,
         null,
-        emptyMixpanelUUID,
+        null,
         null
       );
 
@@ -111,8 +110,8 @@ describe("snapshot", function () {
         "latest.json",
         cancellation.token,
         null,
-        emptyMixpanelUUID,
-        ""
+        null,
+        null
       );
 
       let target = await getSnapshotDownloadTarget(
@@ -122,7 +121,7 @@ describe("snapshot", function () {
         userDataPath,
         cancellation.token,
         null,
-        emptyMixpanelUUID,
+        null,
         null
       );
 
@@ -133,7 +132,7 @@ describe("snapshot", function () {
         (status) => {},
         cancellation.token,
         null,
-        emptyMixpanelUUID,
+        null,
         null
       );
 
@@ -158,7 +157,7 @@ describe("snapshot", function () {
       "latest.json",
       cancellation.token,
       null,
-      emptyMixpanelUUID,
+      null,
       null
     );
     let needSnapshot = validateMetadata(
@@ -177,7 +176,7 @@ describe("snapshot", function () {
       userDataPath,
       cancellation.token,
       null,
-      emptyMixpanelUUID,
+      null,
       null
     );
 
@@ -188,7 +187,7 @@ describe("snapshot", function () {
       (status) => {},
       cancellation.token,
       null,
-      emptyMixpanelUUID,
+      null,
       null
     );
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -41,7 +41,11 @@ import * as utils from "../utils";
 import * as partitionSnapshot from "./snapshot";
 import * as monoSnapshot from "./monosnapshot";
 import Headless from "./headless";
-import { HeadlessExitedError, HeadlessInitializeError, UndefinedProtectedPrivateKeyError } from "../errors";
+import {
+  HeadlessExitedError,
+  HeadlessInitializeError,
+  UndefinedProtectedPrivateKeyError,
+} from "../errors";
 import CancellationToken from "cancellationtoken";
 import { IDownloadProgress, IGameStartOptions } from "../interfaces/ipc";
 import { init as createMixpanel, Mixpanel } from "mixpanel";
@@ -546,7 +550,9 @@ function initializeIpc() {
         if (protectedPrivateKey === undefined) {
           event.returnValue = [
             undefined,
-            new UndefinedProtectedPrivateKeyError("ProtectedPrivateKey is undefined during unprotect private key.")
+            new UndefinedProtectedPrivateKeyError(
+              "ProtectedPrivateKey is undefined during unprotect private key."
+            ),
           ];
           return;
         }
@@ -630,16 +636,12 @@ async function initializeHeadless(): Promise<void> {
   console.log(`Initialize headless. (win: ${win?.getTitle})`);
 
   if (initializeHeadlessCts !== null) {
-    console.error(
-      "Cannot initialize headless while initializing headless.",
-    );
+    console.error("Cannot initialize headless while initializing headless.");
     return;
   }
 
   if (standalone.alive) {
-    console.error(
-      "Cannot initialize headless while headless is running.",
-    );
+    console.error("Cannot initialize headless while headless is running.");
     return;
   }
 
@@ -691,7 +693,9 @@ async function initializeHeadless(): Promise<void> {
             app.getPath("userData"),
             standalone,
             win,
-            initializeHeadlessCts.token
+            initializeHeadlessCts.token,
+            mixpanel,
+            mixpanelUUID
           );
 
           if (isProcessSuccess) break;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -131,6 +131,12 @@ let initializeHeadlessCts: {
   token: CancellationToken;
 } | null = null;
 
+export type MixpanelInfo = {
+  mixpanel: Mixpanel | null;
+  mixpanelUUID: string;
+  ip: string | null;
+};
+
 ipv4().then((value) => (ip = value));
 
 if (!app.requestSingleInstanceLock()) {
@@ -655,6 +661,12 @@ async function initializeHeadless(): Promise<void> {
 
   initializeHeadlessCts = CancellationToken.create();
 
+  const mixpanelInfo: MixpanelInfo = {
+    mixpanel: mixpanel,
+    mixpanelUUID: mixpanelUUID,
+    ip: ip,
+  };
+
   try {
     if (!utils.isDiskPermissionValid(BLOCKCHAIN_STORE_PATH)) {
       win?.webContents.send("go to error page", "no-permission");
@@ -693,10 +705,8 @@ async function initializeHeadless(): Promise<void> {
             app.getPath("userData"),
             standalone,
             win,
-            initializeHeadlessCts.token,
-            mixpanel,
-            mixpanelUUID,
-            ip
+            mixpanelInfo,
+            initializeHeadlessCts.token
           );
 
           if (isProcessSuccess) break;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -695,7 +695,8 @@ async function initializeHeadless(): Promise<void> {
             win,
             initializeHeadlessCts.token,
             mixpanel,
-            mixpanelUUID
+            mixpanelUUID,
+            ip
           );
 
           if (isProcessSuccess) break;

--- a/src/main/monosnapshot.ts
+++ b/src/main/monosnapshot.ts
@@ -10,6 +10,7 @@ import * as utils from "../utils";
 import { DownloadSnapshotFailedError } from "./exceptions/download-snapshot-failed";
 import { DownloadSnapshotMetadataFailedError } from "./exceptions/download-snapshot-metadata-failed";
 import { ExtractSnapshotFailedError } from "./exceptions/extract-snapshot-failed";
+import { MixpanelInfo } from "./main";
 
 export async function downloadMetadata(
   basePath: string,
@@ -23,16 +24,7 @@ export async function downloadMetadata(
   const savingPath = path.join(dir, "meta.json");
 
   try {
-    await cancellableDownload(
-      downloadPath,
-      savingPath,
-      (_) => {},
-      token,
-      downloadPath,
-      null,
-      null,
-      null
-    );
+    await cancellableDownload(downloadPath, savingPath, (_) => {}, token);
     token.throwIfCancelled();
 
     let meta = await fs.promises.readFile(savingPath, "utf-8");
@@ -62,16 +54,7 @@ export async function downloadSnapshot(
   const savingPath = path.join(dir, "snapshot.zip");
 
   try {
-    await cancellableDownload(
-      downloadPath,
-      savingPath,
-      onProgress,
-      token,
-      downloadPath,
-      null,
-      null,
-      null
-    );
+    await cancellableDownload(downloadPath, savingPath, onProgress, token);
     token.throwIfCancelled();
     console.log("Snapshot download complete. Directory: ", dir);
     return savingPath;
@@ -104,6 +87,7 @@ export async function processSnapshot(
   userDataPath: string,
   standalone: Headless,
   win: Electron.BrowserWindow,
+  mixpanelInfo: MixpanelInfo,
   token: CancellationToken
 ): Promise<boolean> {
   console.log(`Trying snapshot path: ${snapshotDownloadUrl}`);

--- a/src/main/monosnapshot.ts
+++ b/src/main/monosnapshot.ts
@@ -23,7 +23,16 @@ export async function downloadMetadata(
   const savingPath = path.join(dir, "meta.json");
 
   try {
-    await cancellableDownload(downloadPath, savingPath, (_) => {}, token);
+    await cancellableDownload(
+      downloadPath,
+      savingPath,
+      (_) => {},
+      token,
+      downloadPath,
+      null,
+      null,
+      null
+    );
     token.throwIfCancelled();
 
     let meta = await fs.promises.readFile(savingPath, "utf-8");
@@ -53,7 +62,16 @@ export async function downloadSnapshot(
   const savingPath = path.join(dir, "snapshot.zip");
 
   try {
-    await cancellableDownload(downloadPath, savingPath, onProgress, token);
+    await cancellableDownload(
+      downloadPath,
+      savingPath,
+      onProgress,
+      token,
+      downloadPath,
+      null,
+      null,
+      null
+    );
     token.throwIfCancelled();
     console.log("Snapshot download complete. Directory: ", dir);
     return savingPath;

--- a/src/main/snapshot.ts
+++ b/src/main/snapshot.ts
@@ -60,7 +60,7 @@ export const getSnapshotDownloadTarget = async (
   userDataPath: string,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string,
+  mixpanelUUID: string | null,
   ip: string | null
 ): Promise<Epoch[]> => {
   let localEpoch = getCurrentEpoch(storePath);
@@ -106,7 +106,7 @@ export async function downloadMetadata(
   downloadFileName: string,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string,
+  mixpanelUUID: string | null,
   ip: string | null
 ): Promise<BlockMetadata> {
   token.throwIfCancelled();
@@ -153,7 +153,7 @@ export async function downloadSnapshot(
   onProgress: (status: IDownloadProgress) => void,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string,
+  mixpanelUUID: string | null,
   ip: string | null
 ): Promise<string[]> {
   token.throwIfCancelled();
@@ -204,7 +204,7 @@ export async function downloadStateSnapshot(
   onProgress: (status: IDownloadProgress) => void,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string,
+  mixpanelUUID: string | null,
   ip: string | null
 ): Promise<string> {
   token.throwIfCancelled();
@@ -275,7 +275,7 @@ export async function processSnapshot(
   win: Electron.BrowserWindow,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string,
+  mixpanelUUID: string | null,
   ip: string | null
 ): Promise<boolean> {
   console.log(`Trying snapshot path: ${snapshotDownloadUrl}`);

--- a/src/main/snapshot.ts
+++ b/src/main/snapshot.ts
@@ -60,7 +60,8 @@ export const getSnapshotDownloadTarget = async (
   userDataPath: string,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string
+  mixpanelUUID: string,
+  ip: string | null
 ): Promise<Epoch[]> => {
   let localEpoch = getCurrentEpoch(storePath);
   let target: Epoch[] = [];
@@ -91,7 +92,8 @@ export const getSnapshotDownloadTarget = async (
       downloadTargetName,
       token,
       mixpanel,
-      mixpanelUUID
+      mixpanelUUID,
+      ip
     );
   }
 
@@ -104,7 +106,8 @@ export async function downloadMetadata(
   downloadFileName: string,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string
+  mixpanelUUID: string,
+  ip: string | null
 ): Promise<BlockMetadata> {
   token.throwIfCancelled();
   const savingPath = path.join(userDataPath, downloadFileName);
@@ -118,7 +121,8 @@ export async function downloadMetadata(
       token,
       downloadFileName,
       mixpanel,
-      mixpanelUUID
+      mixpanelUUID,
+      ip
     );
     token.throwIfCancelled();
 
@@ -149,7 +153,8 @@ export async function downloadSnapshot(
   onProgress: (status: IDownloadProgress) => void,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string
+  mixpanelUUID: string,
+  ip: string | null
 ): Promise<string[]> {
   token.throwIfCancelled();
   console.log("Downloading snapshot.");
@@ -177,7 +182,8 @@ export async function downloadSnapshot(
         token,
         downloadTargetName,
         mixpanel,
-        mixpanelUUID
+        mixpanelUUID,
+        ip
       );
       return savingPath;
     });
@@ -198,7 +204,8 @@ export async function downloadStateSnapshot(
   onProgress: (status: IDownloadProgress) => void,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string
+  mixpanelUUID: string,
+  ip: string | null
 ): Promise<string> {
   token.throwIfCancelled();
   const downloadTargetName = `state_latest.zip`;
@@ -212,7 +219,8 @@ export async function downloadStateSnapshot(
     token,
     downloadTargetName,
     mixpanel,
-    mixpanelUUID
+    mixpanelUUID,
+    ip
   );
   return savingPath;
 }
@@ -267,7 +275,8 @@ export async function processSnapshot(
   win: Electron.BrowserWindow,
   token: CancellationToken,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string
+  mixpanelUUID: string,
+  ip: string | null
 ): Promise<boolean> {
   console.log(`Trying snapshot path: ${snapshotDownloadUrl}`);
 
@@ -279,7 +288,8 @@ export async function processSnapshot(
     "latest.json",
     token,
     mixpanel,
-    mixpanelUUID
+    mixpanelUUID,
+    ip
   );
   const needSnapshot =
     localMetadata === null ||
@@ -292,7 +302,8 @@ export async function processSnapshot(
       userDataPath,
       token,
       mixpanel,
-      mixpanelUUID
+      mixpanelUUID,
+      ip
     );
     const snapshotPaths = await downloadSnapshot(
       snapshotDownloadUrl,
@@ -303,7 +314,8 @@ export async function processSnapshot(
       },
       token,
       mixpanel,
-      mixpanelUUID
+      mixpanelUUID,
+      ip
     );
     const stateSnapshotPath = await downloadStateSnapshot(
       snapshotDownloadUrl,
@@ -313,7 +325,8 @@ export async function processSnapshot(
       },
       token,
       mixpanel,
-      mixpanelUUID
+      mixpanelUUID,
+      ip
     );
     snapshotPaths.push(stateSnapshotPath);
     removeUselessStore(storePath);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,6 @@ import extractZip from "extract-zip";
 import { CancellableDownloadFailedError } from "./main/exceptions/cancellable-download-failed";
 import { CancellableExtractFailedError } from "./main/exceptions/cancellable-extract-failed";
 import { Mixpanel } from "mixpanel";
-import { v4 as ipv4 } from "public-ip";
 
 const pipeline = promisify(stream.pipeline);
 
@@ -105,11 +104,10 @@ export async function cancellableDownload(
   token: CancellationToken,
   downloadFileName: string,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string
+  mixpanelUUID: string,
+  ip: string | null
 ): Promise<void> {
   try {
-    let ip: string | null = null;
-    await ipv4().then((value) => (ip = value));
     mixpanel?.track(`Launcher/Downloading Snapshot/${downloadFileName}-start`, {
       distinct_id: mixpanelUUID,
       ip,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,6 @@ import CancellationToken from "cancellationtoken";
 import extractZip from "extract-zip";
 import { CancellableDownloadFailedError } from "./main/exceptions/cancellable-download-failed";
 import { CancellableExtractFailedError } from "./main/exceptions/cancellable-extract-failed";
-import { Mixpanel } from "mixpanel";
 
 const pipeline = promisify(stream.pipeline);
 
@@ -101,17 +100,9 @@ export async function cancellableDownload(
   url: string,
   downloadPath: string,
   onProgress: (arg0: IDownloadProgress) => void,
-  token: CancellationToken,
-  downloadFileName: string,
-  mixpanel: Mixpanel | null,
-  mixpanelUUID: string | null,
-  ip: string | null
+  token: CancellationToken
 ): Promise<void> {
   try {
-    mixpanel?.track(`Launcher/Downloading Snapshot/${downloadFileName}-start`, {
-      distinct_id: mixpanelUUID,
-      ip,
-    });
     const axiosCts = axios.CancelToken.source();
     token.onCancelled((_) => axiosCts.cancel());
 
@@ -131,13 +122,6 @@ export async function cancellableDownload(
       });
     });
     await pipeline(res.data, fs.createWriteStream(downloadPath));
-    mixpanel?.track(
-      `Launcher/Downloading Snapshot/${downloadFileName}-complete`,
-      {
-        distinct_id: mixpanelUUID,
-        ip,
-      }
-    );
   } catch (error) {
     throw new CancellableDownloadFailedError(url, downloadPath);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,7 +104,7 @@ export async function cancellableDownload(
   token: CancellationToken,
   downloadFileName: string,
   mixpanel: Mixpanel | null,
-  mixpanelUUID: string,
+  mixpanelUUID: string | null,
   ip: string | null
 ): Promise<void> {
   try {


### PR DESCRIPTION
This PR divides snapshot-download-events(including metadata) and sends the events to `Mixpanel` in the following format:

Start download: [`Launcher/Downloading Snapshot/${downloadFileName}-start`](https://github.com/planetarium/9c-launcher/compare/rc-v100039...area363:feature/divide-snapshot-download-events?expand=1#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R111-R114)

Finish download: [`Launcher/Downloading Snapshot/${downloadFileName}-complete`](https://github.com/planetarium/9c-launcher/compare/rc-v100039...area363:feature/divide-snapshot-download-events?expand=1#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R134-R140)