### PR TITLE
Feature/improve snapshot extract

### DIFF
--- a/__tests__/snapshot.spec.ts
+++ b/__tests__/snapshot.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../src/main/snapshot";
 import { BlockMetadata } from "src/interfaces/block-header";
 import { MixpanelInfo } from "../src/main/main";
+import { IExtractProgress } from "src/interfaces/ipc";
 
 const storePath = path.join(__dirname, "fixture", "store");
 const baseUrl = "https://download.nine-chronicles.com/partition-test";
@@ -183,9 +184,9 @@ describe("snapshot", function () {
     await extractSnapshot(
       snapshotPaths,
       integrationStore,
-      (progress: number) => {
-        if ((progress * 100) % 10 === 0) {
-          console.log(progress * 100);
+      (progress: IExtractProgress) => {
+        if ((progress.percent * 100) % 10 === 0) {
+          console.log(progress.percent * 100);
         }
       },
       dummyMixpanelInfo,

--- a/src/interfaces/ipc.ts
+++ b/src/interfaces/ipc.ts
@@ -17,6 +17,10 @@ export interface IDownloadProgress {
   totalBytes: number;
 }
 
+export interface IExtractProgress {
+  percent: number;
+}
+
 export interface IGameStartOptions {
   args: string[];
 }

--- a/src/main/monosnapshot.ts
+++ b/src/main/monosnapshot.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow } from "electron";
 import fs from "fs";
 import CancellationToken from "cancellationtoken";
-import { IDownloadProgress } from "../interfaces/ipc";
+import { IDownloadProgress, IExtractProgress } from "../interfaces/ipc";
 import { cancellableDownload, cancellableExtract, execute } from "../utils";
 import path from "path";
 import { BlockMetadata } from "src/interfaces/block-header";
@@ -66,7 +66,7 @@ export async function downloadSnapshot(
 export async function extractSnapshot(
   snapshotPath: string,
   storePath: string,
-  onProgress: (progress: number) => void,
+  onProgress: (progress: IExtractProgress) => void,
   token: CancellationToken
 ): Promise<void> {
   try {
@@ -113,7 +113,7 @@ export async function processSnapshot(
     await extractSnapshot(
       snapshotPath,
       storePath,
-      (progress: number) => {
+      (progress: IExtractProgress) => {
         win?.webContents.send("extract progress", progress);
       },
       token

--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../../generated/graphql";
 import useStores from "../../../hooks/useStores";
 import { PreloadProgress } from "../../../interfaces/i18n";
-import { IDownloadProgress } from "../../../interfaces/ipc";
+import { IDownloadProgress, IExtractProgress } from "../../../interfaces/ipc";
 import { useLocale } from "../../i18n";
 import preloadProgressViewStyle from "./PreloadProgressView.style";
 
@@ -49,7 +49,7 @@ const PreloadProgressView = observer(() => {
     }
 
     return locale(statusMessage[currentStep - 1]);
-  }
+  };
 
   const makeProgressMessage = () => {
     if (preloadEnded) {
@@ -104,9 +104,9 @@ const PreloadProgressView = observer(() => {
 
     ipcRenderer.on(
       "extract progress",
-      (event: IpcRendererEvent, progress: number) => {
+      (event: IpcRendererEvent, progress: IExtractProgress) => {
         setCurrentStep(4);
-        setProgress(progress * 100);
+        setProgress(progress.percent * 100);
       }
     );
 
@@ -130,7 +130,10 @@ const PreloadProgressView = observer(() => {
   }, []);
 
   useEffect(() => {
-    ipcRenderer.send("mixpanel-track-event", `Launcher/${getCurrentStepMessage()}`);
+    ipcRenderer.send(
+      "mixpanel-track-event",
+      `Launcher/${getCurrentStepMessage()}`
+    );
   }, [currentStep]);
 
   useEffect(() => {
@@ -190,9 +193,11 @@ const PreloadProgressView = observer(() => {
     }
   }, [preloadEnded]);
 
-  useEffect(
-    () => setProgressMessage(makeProgressMessage()),
-    [preloadEnded, currentStep, progress]);
+  useEffect(() => setProgressMessage(makeProgressMessage()), [
+    preloadEnded,
+    currentStep,
+    progress,
+  ]);
 
   const message =
     exceptionMessage === null ? progressMessage : exceptionMessage;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import fs from "fs";
 import axios from "axios";
 import stream from "stream";
 import { promisify } from "util";
-import { IDownloadProgress } from "./interfaces/ipc";
+import { IDownloadProgress, IExtractProgress } from "./interfaces/ipc";
 import CancellationToken from "cancellationtoken";
 import extractZip from "extract-zip";
 import { CancellableDownloadFailedError } from "./main/exceptions/cancellable-download-failed";
@@ -130,7 +130,7 @@ export async function cancellableDownload(
 export async function cancellableExtract(
   targetDir: string,
   outputDir: string,
-  onProgress: (progress: number) => void,
+  onProgress: (progress: IExtractProgress) => void,
   token: CancellationToken
 ): Promise<void> {
   try {
@@ -142,7 +142,9 @@ export async function cancellableExtract(
           zipfile.close();
         }
         const progress = zipfile.entriesRead / zipfile.entryCount;
-        onProgress(progress);
+        onProgress({
+          percent: progress,
+        });
       },
     });
     await fs.promises.unlink(targetDir);


### PR DESCRIPTION
This PR changes the serial extraction process of [extractSnapshot()](https://github.com/planetarium/9c-launcher/compare/development...area363:feature/improve-snapshot-extract?expand=1#diff-357b220fcedf41505a135fdb2e6df29cdd5965438183b2e4b7b5211ec5949624R225-R278) to a parallel extraction to reduce the amount of extraction time during preloading.

This will help especially when users clear cache and need to download the entire snapshot.

**< Test on local >**

**Serial Extraction:**
- #1: 37s
- #2: 35s
- #3: 37s

**Parallel Extraction:**
- #1: 24s
- #2: 22s
- #3: 22s