### PR TITLE
introduce clear cache exception

### DIFF
--- a/src/main/exceptions/clear-cache-exception.ts
+++ b/src/main/exceptions/clear-cache-exception.ts
@@ -1,0 +1,5 @@
+export class ClearCacheException extends Error {
+  constructor() {
+    super(`Clear cache requested.`);
+  }
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -181,7 +181,7 @@ function initializeApp() {
   });
 
   app.on("quit", (event) => {
-    quitAllProcesses(null);
+    quitAllProcesses();
   });
 
   app.on("activate", (event) => {
@@ -220,7 +220,7 @@ async function update(
     throw e;
   }
 
-  await quitAllProcesses(null);
+  await quitAllProcesses();
 
   if (win === null) {
     console.log("Stop update process because win is null.");
@@ -507,7 +507,7 @@ function initializeIpc() {
   });
 
   ipcMain.on("relaunch standalone", async (event) => {
-    await relaunchHeadless(null);
+    await relaunchHeadless();
     event.returnValue = true;
   });
 
@@ -784,7 +784,7 @@ async function initializeHeadless(): Promise<void> {
     console.log("Register exit handler.");
     standalone.once("exit", async () => {
       console.error("Headless exited by self.");
-      await relaunchHeadless(null);
+      await relaunchHeadless();
     });
   } catch (error) {
     console.error(`Error occurred during initializeHeadless(). ${error}`);
@@ -904,12 +904,12 @@ function loadInstallerMixpanelUUID(): string {
   }
 }
 
-async function relaunchHeadless(reason: string | null) {
+async function relaunchHeadless(reason: string = "default") {
   await stopHeadlessProcess(reason);
   initializeHeadless();
 }
 
-async function quitAllProcesses(reason: string | null) {
+async function quitAllProcesses(reason: string = "default") {
   await stopHeadlessProcess(reason);
   if (gameNode === null) return;
   let pid = gameNode.pid;
@@ -917,7 +917,7 @@ async function quitAllProcesses(reason: string | null) {
   gameNode = null;
 }
 
-async function stopHeadlessProcess(reason: string | null): Promise<void> {
+async function stopHeadlessProcess(reason: string = "default"): Promise<void> {
   console.log("Cancelling initializeHeadless()");
   initializeHeadlessCts?.cancel(reason);
   while (initializeHeadlessCts !== null) await utils.sleep(100);

--- a/src/main/monosnapshot.ts
+++ b/src/main/monosnapshot.ts
@@ -60,7 +60,7 @@ export async function downloadSnapshot(
     console.log("Snapshot download complete. Directory: ", dir);
     return savingPath;
   } catch (error) {
-    if (String(error) === "Error: Clear cache requested.") {
+    if (token.reason === "clear-cache") {
       throw new ClearCacheException();
     } else {
       throw new DownloadSnapshotFailedError(downloadPath, savingPath);
@@ -82,7 +82,7 @@ extractTarget: [ ${snapshotPath} ]`);
     await cancellableExtract(snapshotPath, storePath, onProgress, token);
     console.log("Snapshot extract complete.");
   } catch (error) {
-    if (String(error) === "Error: Clear cache requested.") {
+    if (token.reason === "clear-cache") {
       throw new ClearCacheException();
     } else {
       throw new ExtractSnapshotFailedError(snapshotPath);

--- a/src/main/monosnapshot.ts
+++ b/src/main/monosnapshot.ts
@@ -11,6 +11,7 @@ import { DownloadSnapshotFailedError } from "./exceptions/download-snapshot-fail
 import { DownloadSnapshotMetadataFailedError } from "./exceptions/download-snapshot-metadata-failed";
 import { ExtractSnapshotFailedError } from "./exceptions/extract-snapshot-failed";
 import { MixpanelInfo } from "./main";
+import { ClearCacheException } from "./exceptions/clear-cache-exception";
 
 export async function downloadMetadata(
   basePath: string,
@@ -59,7 +60,11 @@ export async function downloadSnapshot(
     console.log("Snapshot download complete. Directory: ", dir);
     return savingPath;
   } catch (error) {
-    throw new DownloadSnapshotFailedError(downloadPath, savingPath);
+    if ((error = "Error: Clear cache requested.")) {
+      throw new ClearCacheException();
+    } else {
+      throw new DownloadSnapshotFailedError(downloadPath, savingPath);
+    }
   }
 }
 
@@ -77,7 +82,11 @@ extractTarget: [ ${snapshotPath} ]`);
     await cancellableExtract(snapshotPath, storePath, onProgress, token);
     console.log("Snapshot extract complete.");
   } catch (error) {
-    throw new ExtractSnapshotFailedError(snapshotPath);
+    if ((error = "Error: Clear cache requested.")) {
+      throw new ClearCacheException();
+    } else {
+      throw new ExtractSnapshotFailedError(snapshotPath);
+    }
   }
 }
 

--- a/src/main/monosnapshot.ts
+++ b/src/main/monosnapshot.ts
@@ -60,7 +60,7 @@ export async function downloadSnapshot(
     console.log("Snapshot download complete. Directory: ", dir);
     return savingPath;
   } catch (error) {
-    if ((error = "Error: Clear cache requested.")) {
+    if (String(error) === "Error: Clear cache requested.") {
       throw new ClearCacheException();
     } else {
       throw new DownloadSnapshotFailedError(downloadPath, savingPath);
@@ -82,7 +82,7 @@ extractTarget: [ ${snapshotPath} ]`);
     await cancellableExtract(snapshotPath, storePath, onProgress, token);
     console.log("Snapshot extract complete.");
   } catch (error) {
-    if ((error = "Error: Clear cache requested.")) {
+    if (String(error) === "Error: Clear cache requested.") {
       throw new ClearCacheException();
     } else {
       throw new ExtractSnapshotFailedError(snapshotPath);

--- a/src/main/snapshot.ts
+++ b/src/main/snapshot.ts
@@ -188,7 +188,7 @@ export async function downloadSnapshot(
     });
     savingPaths = await Promise.all(downloadPromise);
   } catch (error) {
-    if ((error = "Error: Clear cache requested.")) {
+    if (String(error) === "Error: Clear cache requested.") {
       throw new ClearCacheException();
     } else {
       throw new DownloadSnapshotFailedError(basePath, savingPaths.join(", "));
@@ -278,7 +278,7 @@ export async function extractSnapshot(
       });
     }
   } catch (error) {
-    if ((error = "Error: Clear cache requested.")) {
+    if (String(error) === "Error: Clear cache requested.") {
       throw new ClearCacheException();
     } else {
       throw new ExtractSnapshotFailedError(snapshotPaths[index]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,6 @@ import CancellationToken from "cancellationtoken";
 import extractZip from "extract-zip";
 import { CancellableDownloadFailedError } from "./main/exceptions/cancellable-download-failed";
 import { CancellableExtractFailedError } from "./main/exceptions/cancellable-extract-failed";
-import { ClearCacheException } from "./main/exceptions/clear-cache-exception";
 
 const pipeline = promisify(stream.pipeline);
 
@@ -124,11 +123,7 @@ export async function cancellableDownload(
     });
     await pipeline(res.data, fs.createWriteStream(downloadPath));
   } catch (error) {
-    if (token.reason === "clear-cache") {
-      throw new ClearCacheException();
-    } else {
-      throw new CancellableDownloadFailedError(url, downloadPath);
-    }
+    throw new CancellableDownloadFailedError(url, downloadPath);
   }
 }
 
@@ -152,14 +147,10 @@ export async function cancellableExtract(
     });
     await fs.promises.unlink(targetDir);
   } catch (error) {
-    if (token.reason === "clear-cache") {
-      throw new ClearCacheException();
-    } else {
-      console.error(
-        `Unexpected error occurred during extracting ${targetDir} to ${outputDir}. ${error}`
-      );
-      throw new CancellableExtractFailedError(targetDir, outputDir);
-    }
+    console.error(
+      `Unexpected error occurred during extracting ${targetDir} to ${outputDir}. ${error}`
+    );
+    throw new CancellableExtractFailedError(targetDir, outputDir);
   }
 }
 


### PR DESCRIPTION
This PR adds a `clear cache exception` to prevent the `clear-cache` method from navigating to the `snapshot download failed` page.

In order to implement this feature, a new parameter called `reason` has been added to the [quitAllProcesses()](https://github.com/planetarium/9c-launcher/compare/rc-v100041...area363:feature/add-clear-cache-exception?expand=1#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R912) method in order to add a cancellation reason to the [cancellationToken](https://github.com/planetarium/9c-launcher/compare/rc-v100041...area363:feature/add-clear-cache-exception?expand=1#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R922). If the cancellation reason is `clear-cache`, [cancellableDownload()](https://github.com/planetarium/9c-launcher/compare/rc-v100041...area363:feature/add-clear-cache-exception?expand=1#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R922) and [cancellableExtract()](https://github.com/planetarium/9c-launcher/compare/rc-v100041...area363:feature/add-clear-cache-exception?expand=1#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R155-R162) methods will throw a [ClearCacheException](https://github.com/planetarium/9c-launcher/compare/rc-v100041...area363:feature/add-clear-cache-exception?expand=1#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R922) error, which will [do nothing](https://github.com/planetarium/9c-launcher/compare/rc-v100041...area363:feature/add-clear-cache-exception?expand=1#diff-7adaa52a2eacb085ba5e07e6683a61fb3601547dc00b51fd50fbaf685e13fe96R922) to the frontend 