### PR TITLE
fix launcher message bug

### DIFF
--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -44,12 +44,12 @@ const PreloadProgressView = observer(() => {
   };
 
   const getCurrentStepMessage = () => {
-    if (currentStep < 1 || currentStep >= statusMessage.length) {
+    if (currentStep < 1 || currentStep > statusMessage.length) {
       return "Failed to get message for current step.";
     }
 
     return locale(statusMessage[currentStep - 1]);
-  }
+  };
 
   const makeProgressMessage = () => {
     if (preloadEnded) {
@@ -130,7 +130,10 @@ const PreloadProgressView = observer(() => {
   }, []);
 
   useEffect(() => {
-    ipcRenderer.send("mixpanel-track-event", `Launcher/${getCurrentStepMessage()}`);
+    ipcRenderer.send(
+      "mixpanel-track-event",
+      `Launcher/${getCurrentStepMessage()}`
+    );
   }, [currentStep]);
 
   useEffect(() => {
@@ -190,9 +193,11 @@ const PreloadProgressView = observer(() => {
     }
   }, [preloadEnded]);
 
-  useEffect(
-    () => setProgressMessage(makeProgressMessage()),
-    [preloadEnded, currentStep, progress]);
+  useEffect(() => setProgressMessage(makeProgressMessage()), [
+    preloadEnded,
+    currentStep,
+    progress,
+  ]);
 
   const message =
     exceptionMessage === null ? progressMessage : exceptionMessage;


### PR DESCRIPTION
This PR fixes the launcher message not appearing after 7/10 (`Downloading blocks`). [Line 47](https://github.com/planetarium/9c-launcher/compare/development...area363:fix/launcher-message?expand=1#diff-c03d8e6601e37f97e8cc05550dc71505c3059bd14b93579f5c97b1d47c70040aR47) is the actual change and the rest are automatic formatting when pushing to git.