### PR TITLE
fix: disable candidate monster when not edit mode

### DIFF
--- a/src/collection/components/CollectionItem/CollectionItem.tsx
+++ b/src/collection/components/CollectionItem/CollectionItem.tsx
@@ -20,7 +20,8 @@ const CollectionItem: React.FC<Props> = (props: Props) => {
     return <div className={`CollectionItemContainer TIER${Number(item.tier)}`} >
         <div>
           <img src={ArrowIcon} className={`arrow ${item.collectionPhase === CollectionPhase.CANDIDATE && isEdit ? 'visible' : 'hide'}`} />
-        <img className={`${item.collectionPhase > CollectionPhase.CANDIDATE && 'Outline'}`}
+        <img className={`${item.collectionPhase > CollectionPhase.CANDIDATE && 'Outline'} 
+            ${item.collectionPhase === CollectionPhase.CANDIDATE && !isEdit && 'Outline'}`}
             src={require(`../../common/resources/${monsterResources}.png`).default} />
         </div>
     </div>


### PR DESCRIPTION
fix style issue what monster activate when not edit mode