### PR TITLE
add offset argument to topmostblock query

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -24,7 +24,7 @@ query NodeStatus {
   }
 }
 
-query TopmostBlocks($limit: Int = 500, $offset: Int = 500, $miner: Address = null) {
+query TopmostBlocks($limit: Int = 500, $offset: Int = 100, $miner: Address = null) {
   nodeStatus {
     topmostBlocks(limit: $limit, offset: $offset, miner: $miner) {
       id

--- a/src/api.graphql
+++ b/src/api.graphql
@@ -24,9 +24,9 @@ query NodeStatus {
   }
 }
 
-query TopmostBlocks($limit: Int = 500, $miner: Address = null) {
+query TopmostBlocks($limit: Int = 500, $offset: Int = 500, $miner: Address = null) {
   nodeStatus {
-    topmostBlocks(limit: $limit, miner: $miner) {
+    topmostBlocks(limit: $limit, offset: $offset, miner: $miner) {
       id
       hash
       index

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -641,6 +641,9 @@ type NodeStatusType {
     # The number of blocks to get.
     limit: Int!
 
+    # The number of blocks to skip from chain tip.
+    offset: Int!
+
     # List only blocks mined by the given address.  (List everything if omitted.)
     miner: Address
   ): [BlockHeader]!


### PR DESCRIPTION
This PR adds an `offset` argument for `topmostblocks` query so that the launcher will show relatively confirmed blocks mined instead of blocks that are highly likely to be reorged. The initial offset is set to 100(`confirmation: 2`) but I'm open to other values for this argument value.

Also, this should be merged after https://github.com/planetarium/NineChronicles.Headless/pull/542 is merged.