### PR TITLE
Adjust for DelayedRenderer

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -248,6 +248,7 @@ subscription CurrentGold {
   monsterCollectionStatus {
     fungibleAssetValue {
       quantity
+      currency
     }
   }
 }
@@ -257,6 +258,7 @@ subscription CollectionStatus {
     lockup
     fungibleAssetValue {
       quantity
+      currency
     }
     rewardInfos {
       itemId
@@ -270,6 +272,7 @@ query CollectionStatusQuery {
     lockup
     fungibleAssetValue {
       quantity
+      currency
     }
     rewardInfos {
       itemId

--- a/src/collection/pages/main/main.tsx
+++ b/src/collection/pages/main/main.tsx
@@ -11,13 +11,13 @@ import LoadingDialog from "../../components/LoadingDialog/LoadingDialog";
 import {
   useCollectMutation,
   useGetTipQuery,
-  useStagedTxQuery,
   useMinerAddressQuery,
   useCollectionSheetWithStateLazyQuery,
   useCollectionStatusSubscription,
   useCollectionStatusQueryQuery,
   useCollectionStateSubscription,
   useStateQueryMonsterCollectionQuery,
+  MonsterCollectionStatusType,
 } from "../../../generated/graphql";
 import { CollectionItemModel } from "../../models/collection";
 import ExpectedStatusBoard from "../../components/ExpectedStatusBoard/ExpectedStatusBoard";
@@ -98,9 +98,9 @@ const Main: React.FC = () => {
     setCurrentTier(level);
   };
 
-  const applyCollectionStatus = (status) => {
-    setLockup(status?.lockup);
-    setHasRewards(status?.rewardInfos!.length > 0);
+  const applyCollectionStatus = (status: MonsterCollectionStatusType | undefined | null) => {
+    setLockup(status?.lockup ?? false);
+    setHasRewards((status?.rewardInfos?.length ?? 0) > 0);
   }
 
   useEffect(() => {


### PR DESCRIPTION
This PR fixes 2 issues

1. The previous implementation is incompatible with `DelayedRenderer`, as only whether the tx was staged or not would determine subsequent processing. So we remove it and modify it to explicitly poll for states.
2. If the monster collection is canceled, it will return to a state similar to the one it was not created from scratch. But the integrated `useEffect()`s are out of sync with this behavior, as they override the previous state if either side has it. To solve this, separate `useEffect()`s and modify them to follow a separate state.