### PR TITLE
Fix the gold sync

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -178,17 +178,6 @@ query CollectionSheetWithState($address: Address!) {
   }
 }
 
-query GoldAndCollectionLevel($address: Address!) {
-  stateQuery {
-    agent(address: $address) {
-      gold
-    }
-    monsterCollectionState(agentAddress: $address) {
-      level
-    }
-  }
-}
-
 query MinerAddress {
   minerAddress
 }
@@ -203,6 +192,11 @@ query GetTip {
 
 query StateQueryMonsterCollection($agentAddress: Address!) {
   stateQuery{
+
+    agent(address: $agentAddress) {
+      gold
+    }
+
     monsterCollectionState(agentAddress: $agentAddress) {
       expiredBlockIndex
       level

--- a/src/collection/pages/main/main.tsx
+++ b/src/collection/pages/main/main.tsx
@@ -55,7 +55,7 @@ const Main: React.FC = () => {
   }] = useCollectionSheetWithStateLazyQuery({
     variables: {
       address: agentAddress,
-    },
+    }
   });
   const { data: minerAddress, loading: minerAddressLoading } = useMinerAddressQuery();
   const [
@@ -88,11 +88,6 @@ const Main: React.FC = () => {
   }, [nodeStatus, collectionState, collectionStateQuery])
 
   const applyCollectionLevel = (level: number) => {
-    if (openLoading) {
-      setOpenLoading(false);
-      setEdit(false);
-    }
-
     setCollectionLevel(level);
     setIsCollecting(level > 0);
     setCurrentTier(level);
@@ -177,6 +172,11 @@ const Main: React.FC = () => {
   }, [minerAddress]);
 
   useEffect(() => {
+    if (openLoading) {
+      setOpenLoading(false);
+      setEdit(false);
+    }
+
     if (collectionLevel === 0) {
       setCart((state) => state.map(x => ({
         tier: x.tier,
@@ -343,7 +343,7 @@ const Main: React.FC = () => {
           <div className={"MainCartContainer"}>
             <Cart
               cartList={tempCartList}
-              totalGold={Number(collectionStatus?.monsterCollectionStatus.fungibleAssetValue.quantity || sheetQuery.stateQuery.agent?.gold) + depositedGold}
+              totalGold={Number(collectionStateQuery?.stateQuery.agent?.gold ?? 0) + depositedGold}
               onCancel={handleCancel}
               onSubmit={handleSubmit}
               onRemove={removeCart}

--- a/src/collection/pages/main/main.tsx
+++ b/src/collection/pages/main/main.tsx
@@ -35,8 +35,8 @@ const getCollectionPhase = (level: number, collectionLevel: number): CollectionP
 const Main: React.FC = () => {
   const [agentAddress, setAgentAddress] = useState<string>("");
   const [collectionLevel, setCollectionLevel] = useState<number>(0);
-  const [cartList, setCart] = useState<CollectionItemModel[]>([]);
-  const [tempCartList, setTempCart] = useState<CollectionItemModel[]>([]);
+  const [cartList, setCartList] = useState<CollectionItemModel[]>([]);
+  const [tempCartList, setTempCartList] = useState<CollectionItemModel[]>([]);
   const [collectionSheet, setCollectionSheet] = useState<CollectionSheetItem[]>([]);
   const [openConfirmation, setOpenConfirmation] = useState<boolean>(false);
   const [openLoading, setOpenLoading] = useState<boolean>(false);
@@ -124,10 +124,10 @@ const Main: React.FC = () => {
     )
       return;
 
-    setCart(() => []);
+    setCartList(() => []);
     setCollectionSheet(() => []);
     sheetQuery!.stateQuery.monsterCollectionSheet!.orderedList!.map((x) => {
-      setCart((state) =>
+      setCartList((state) =>
         state.concat({
           tier: x!.level,
           collectionPhase: getCollectionPhase(
@@ -160,7 +160,7 @@ const Main: React.FC = () => {
   }, [sheetQuery, collectionLevel]);
 
   useEffect(() => {
-    setTempCart(cartList);
+    setTempCartList(cartList);
   }, [cartList]);
 
   useEffect(() => {
@@ -173,7 +173,7 @@ const Main: React.FC = () => {
     setOpenLoading(false);
 
     if (collectionLevel === 0) {
-      setCart((state) => state.map(x => ({
+      setCartList((state) => state.map(x => ({
         tier: x.tier,
         value: x.value,
         collectionPhase: getCollectionPhase(x.tier, 0),
@@ -209,21 +209,21 @@ const Main: React.FC = () => {
   const addCart = (item: CollectionItemModel) => {
     if (item.collectionPhase != CollectionPhase.CANDIDATE) return;
 
-    setTempCart((state) =>
+    setTempCartList((state) =>
       state.map((x) =>
         x.tier === item.tier - 1
           ? ({ ...x, collectionPhase: CollectionPhase.COLLECTED } as CollectionItemModel)
           : x
       )
     );
-    setTempCart((state) =>
+    setTempCartList((state) =>
       state.map((x) =>
         x.tier === item.tier
           ? ({ ...x, collectionPhase: CollectionPhase.LATEST } as CollectionItemModel)
           : x
       )
     );
-    setTempCart((state) =>
+    setTempCartList((state) =>
       state.map((x) =>
         x.tier === item.tier + 1
           ? ({ ...x, collectionPhase: CollectionPhase.CANDIDATE } as CollectionItemModel)
@@ -235,31 +235,26 @@ const Main: React.FC = () => {
   const removeCart = (item: CollectionItemModel) => {
     if (item.collectionPhase != CollectionPhase.LATEST) return;
 
-    if (hasRewards) {
-      alert("There are rewards to be received. Please try again after receiving the reward.");
-      return;
-    }
-
     if (lockup && item.tier <= collectionLevel) {
       alert("Locked-up monsters can be removed after about 1 month (201,600 blocks).");
       return;
     }
 
-    setTempCart((state) =>
+    setTempCartList((state) =>
       state.map((x) =>
         x.tier === item.tier - 1
           ? ({ ...x, collectionPhase: CollectionPhase.LATEST } as CollectionItemModel)
           : x
       )
     );
-    setTempCart((state) =>
+    setTempCartList((state) =>
       state.map((x) =>
         x.tier === item.tier
           ? ({ ...x, collectionPhase: CollectionPhase.CANDIDATE } as CollectionItemModel)
           : x
       )
     );
-    setTempCart((state) =>
+    setTempCartList((state) =>
       state.map((x) =>
         x.tier === item.tier + 1
           ? ({ ...x, collectionPhase: CollectionPhase.LOCKED } as CollectionItemModel)
@@ -285,6 +280,12 @@ const Main: React.FC = () => {
       return;
     }
 
+    if (cartList.findIndex(c => c.collectionPhase === CollectionPhase.CANDIDATE) ===
+      tempCartList.findIndex(c => c.collectionPhase === CollectionPhase.CANDIDATE)) {
+      alert("Please add or remove at least one monster.");
+      return;
+    }
+
     setOpenConfirmation(true);
   };
 
@@ -299,7 +300,7 @@ const Main: React.FC = () => {
 
   const handleCancel = () => {
     setEdit(false)
-    setTempCart(cartList);
+    setTempCartList(cartList);
   }
 
   const handleConfirmSubmit = () => {

--- a/src/renderer/components/AccountInfo/AccountInfo.stories.tsx
+++ b/src/renderer/components/AccountInfo/AccountInfo.stories.tsx
@@ -4,7 +4,7 @@ import { Story, Meta } from '@storybook/react';
 import AccountInfoContainer, { Props } from './AccountInfoContainer';
 import { Provider } from 'mobx-react';
 import AccountStore from '../../stores/account';
-import { GoldAndCollectionLevelDocument, CollectionSheetDocument, CollectionStatusDocument, CollectionStateDocument, NodeStatusSubscriptionDocument } from '../../../generated/graphql';
+import { CollectionSheetDocument, CollectionStatusDocument, CollectionStateDocument, NodeStatusSubscriptionDocument } from '../../../generated/graphql';
 
 export default {
   title: 'Renderer/Components/AccountInfo',
@@ -19,52 +19,18 @@ accountStore.addAddress(address);
 accountStore.setSelectedAddress(address);
 
 const Template: Story<Props> = (props) => <Provider accountStore={accountStore}>
-  <AccountInfoContainer {...props}/>
-  </Provider>;
+  <AccountInfoContainer {...props} />
+</Provider>;
 
 export const Primary = Template.bind({});
 Primary.args = {
-  onOpenWindow: () => {},
-  onReward: () => {},
+  onOpenWindow: () => { },
+  onReward: () => { },
   minedBlock: 500
 }
 Primary.parameters = {
   apolloClient: {
     mocks: [
-      {
-        request: {
-          query: GoldAndCollectionLevelDocument,
-          variables: {
-            address: address,
-          },
-        },
-        result: {
-          data: {
-            stateQuery: {
-              agent: {
-                gold: "102720",
-                collectionLevel: 3,
-                __typename: "AgentStateType"
-              },
-              __typename: "StateQuery"
-            }
-          },
-        },
-        newData: () => {
-          return {
-          data: {
-            stateQuery: {
-              agent: {
-                gold: "102720",
-                collectionLevel: 3,
-                __typename: "AgentStateType"
-              },
-              __typename: "StateQuery"
-            }
-          },
-          }
-        },
-      },
       {
         request: {
           query: CollectionSheetDocument
@@ -116,53 +82,55 @@ Primary.parameters = {
             }
           }
         },
-        newData: () => {return {
-          data: {
-            stateQuery: {
-              collectionSheet: {
-                orderedList: [
-                  {
-                    level: 1,
-                    requiredGold: 500,
-                    __typename: "CollectionRowType"
-                  },
-                  {
-                    level: 2,
-                    requiredGold: 1800,
-                    __typename: "CollectionRowType"
-                  },
-                  {
-                    level: 3,
-                    requiredGold: 7200,
-                    __typename: "CollectionRowType"
-                  },
-                  {
-                    level: 4,
-                    requiredGold: 54000,
-                    __typename: "CollectionRowType"
-                  },
-                  {
-                    level: 5,
-                    requiredGold: 270000,
-                    __typename: "CollectionRowType"
-                  },
-                  {
-                    level: 6,
-                    requiredGold: 480000,
-                    __typename: "CollectionRowType"
-                  },
-                  {
-                    level: 7,
-                    requiredGold: 3000000,
-                    __typename: "CollectionRowType"
-                  }
-                ],
-                __typename: "CollectionSheetType"
-              },
-              __typename: "StateQuery"
+        newData: () => {
+          return {
+            data: {
+              stateQuery: {
+                collectionSheet: {
+                  orderedList: [
+                    {
+                      level: 1,
+                      requiredGold: 500,
+                      __typename: "CollectionRowType"
+                    },
+                    {
+                      level: 2,
+                      requiredGold: 1800,
+                      __typename: "CollectionRowType"
+                    },
+                    {
+                      level: 3,
+                      requiredGold: 7200,
+                      __typename: "CollectionRowType"
+                    },
+                    {
+                      level: 4,
+                      requiredGold: 54000,
+                      __typename: "CollectionRowType"
+                    },
+                    {
+                      level: 5,
+                      requiredGold: 270000,
+                      __typename: "CollectionRowType"
+                    },
+                    {
+                      level: 6,
+                      requiredGold: 480000,
+                      __typename: "CollectionRowType"
+                    },
+                    {
+                      level: 7,
+                      requiredGold: 3000000,
+                      __typename: "CollectionRowType"
+                    }
+                  ],
+                  __typename: "CollectionSheetType"
+                },
+                __typename: "StateQuery"
+              }
             }
           }
-        }},
+        },
       },
       {
         request: {
@@ -170,6 +138,14 @@ Primary.parameters = {
         },
         result: {
           data: {
+            stateQuery: {
+              agent: {
+                gold: "102720",
+                collectionLevel: 3,
+                __typename: "AgentStateType"
+              },
+              __typename: "StateQuery"
+            },
             monsterCollectionState: {
               address: "",
               end: "",
@@ -183,21 +159,30 @@ Primary.parameters = {
             },
           },
         },
-        newData: () => { return {
-          data: {
-            monsterCollectionState: {
-              address: "",
-              end: "",
-              expiredBlockIndex: "",
-              claimableBlockIndex: 100,
-              level: 4,
-              rewardLevel: "",
-              receivedBlockIndex: "",
-              startedBlockIndex: "",
-              __typename: "MonsterCollectionStateType"
+        newData: () => {
+          return {
+            data: {
+              stateQuery: {
+                agent: {
+                  gold: "102720",
+                  collectionLevel: 3,
+                  __typename: "AgentStateType"
+                },
+                __typename: "StateQuery"
+              },
+              monsterCollectionState: {
+                address: "",
+                end: "",
+                expiredBlockIndex: "",
+                claimableBlockIndex: 100,
+                level: 4,
+                rewardLevel: "",
+                receivedBlockIndex: "",
+                startedBlockIndex: "",
+                __typename: "MonsterCollectionStateType"
+              },
             },
-          },
-        }
+          }
         }
       },
       {
@@ -213,15 +198,16 @@ Primary.parameters = {
             }
           }
         },
-        newData: () => { return {
-          data: {
-            nodeStatus: {
-              bootstrapEnded: true,
-              preloadEnded: true,
-              __typename: "NodeStatusType"
+        newData: () => {
+          return {
+            data: {
+              nodeStatus: {
+                bootstrapEnded: true,
+                preloadEnded: true,
+                __typename: "NodeStatusType"
+              }
             }
           }
-        }
         }
       },
       {
@@ -240,18 +226,20 @@ Primary.parameters = {
             }
           },
         },
-        newData: () => {return {
-          data: {
-            collectionStatus: {
-              canReceive: true,
-              __typename: "CollectionStatusType",
-              fungibleAssetValue: {
-                quantity: 102740,
-                __typename: "FungibleAssetValueType"
+        newData: () => {
+          return {
+            data: {
+              collectionStatus: {
+                canReceive: true,
+                __typename: "CollectionStatusType",
+                fungibleAssetValue: {
+                  quantity: 102740,
+                  __typename: "FungibleAssetValueType"
+                }
               }
             }
           }
-        }},
+        },
       }
     ]
   }

--- a/src/renderer/components/AccountInfo/AccountInfoContainer.tsx
+++ b/src/renderer/components/AccountInfo/AccountInfoContainer.tsx
@@ -36,6 +36,7 @@ const AccountInfoContainer: React.FC<Props> = (props: Props) => {
   const [isCollecting, setIsCollecting] = useState<boolean>(false);
   const [canClaim, setCanClaim] = useState<boolean>(false);
   const [collectionLevel, setCollectionLevel] = useState<number>(0);
+  const [receivedBlockIndex, setReceivedBlockIndex] = useState<number>(0);
   const {
     refetch: sheetRefetch,
   } = useCollectionSheetQuery();
@@ -124,11 +125,17 @@ const AccountInfoContainer: React.FC<Props> = (props: Props) => {
 
   useEffect(() => {
     setCollectionLevel(Number(collectionState?.monsterCollectionState?.level ?? 0));
+    setReceivedBlockIndex(collectionState?.monsterCollectionState?.receivedBlockIndex ?? 0);
   }, [collectionState])
 
   useEffect(() => {
     setCollectionLevel(Number(collectionStateQuery?.stateQuery.monsterCollectionState?.level ?? 0));
+    setReceivedBlockIndex(collectionStateQuery?.stateQuery.monsterCollectionState?.receivedBlockIndex ?? 0);
   }, [collectionStateQuery])
+
+  useEffect(() => {
+    setClaimLoading(false);
+  }, [receivedBlockIndex]);
 
   const applyCanClaim = (rewardInfos: (MonsterCollectionRewardInfoType | null)[] | null | undefined) => {
     setCanClaim(rewardInfos != undefined && rewardInfos?.length > 0);
@@ -140,13 +147,9 @@ const AccountInfoContainer: React.FC<Props> = (props: Props) => {
 
   useEffect(() => {
     applyCanClaim(collectionStatusQuery?.monsterCollectionStatus?.rewardInfos);
-  }, [collectionStatusQuery])
+  }, [collectionStatusQuery]);
 
-  useEffect(() => {
-    setClaimLoading(false);
-  }, [canClaim]);
-
-  const handleAcion = async (collectTx: string) => {
+  const handleAcion = () => {
     setOpenDialog(false);
     setClaimLoading(true);
   };

--- a/src/renderer/components/AccountInfo/AccountInfoContainer.tsx
+++ b/src/renderer/components/AccountInfo/AccountInfoContainer.tsx
@@ -7,7 +7,6 @@ import {
   useCollectionSheetQuery,
   useCollectionStateSubscription,
   useCollectionStatusSubscription,
-  useGoldAndCollectionLevelQuery,
   useStateQueryMonsterCollectionQuery,
   useGetTipQuery,
   useCollectionStatusQueryQuery,
@@ -37,13 +36,6 @@ const AccountInfoContainer: React.FC<Props> = (props: Props) => {
   const [isCollecting, setIsCollecting] = useState<boolean>(false);
   const [canClaim, setCanClaim] = useState<boolean>(false);
   const [collectionLevel, setCollectionLevel] = useState<number>(0);
-  const { data: goldAndLevel, refetch: goldAndLevelRefetch, stopPolling }
-    = useGoldAndCollectionLevelQuery({
-      variables: {
-        address: accountStore.selectedAddress,
-      },
-      pollInterval: 1000 * 3
-    });
   const {
     refetch: sheetRefetch,
   } = useCollectionSheetQuery();
@@ -131,10 +123,6 @@ const AccountInfoContainer: React.FC<Props> = (props: Props) => {
   }, [collectionStateQuery, collectionState, tip]);
 
   useEffect(() => {
-    if (goldAndLevel?.stateQuery.agent != null) stopPolling();
-  }, [goldAndLevel])
-
-  useEffect(() => {
     setCollectionLevel(Number(collectionState?.monsterCollectionState?.level ?? 0));
   }, [collectionState])
 
@@ -165,7 +153,6 @@ const AccountInfoContainer: React.FC<Props> = (props: Props) => {
 
   if (accountStore.isLogin
     && nodeStatus?.nodeStatus?.preloadEnded
-    && goldAndLevel?.stateQuery.agent != null
     && avatarAddressQuery != null
     && accountStore.isMiningConfigEnded) {
     const mcStatus = collectionStatus?.monsterCollectionStatus;
@@ -178,11 +165,7 @@ const AccountInfoContainer: React.FC<Props> = (props: Props) => {
               ? () => { }
               : onOpenWindow}
           canClaimReward={mcStatus?.rewardInfos != null && mcStatus.rewardInfos.length > 0}
-          goldLabel={
-            mcStatus?.fungibleAssetValue.quantity
-              ? Number(mcStatus.fungibleAssetValue.quantity)
-              : Number(goldAndLevel?.stateQuery.agent?.gold)
-          }
+          goldLabel={Number(collectionStateQuery?.stateQuery.agent?.gold)}
           collectionLabel={depositedGold}
           remainText={getRemain(remainMin)}
           isCollecting={isCollecting}


### PR DESCRIPTION
This PR fixes the gold synchronization bug in monster collection related UI. To accomplish this, I removed `GoldAndCollectionLevel` and unified `gold` field to `collectionStateQuery` mainly polled.