### PR TITLE
Enables remote config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -102,6 +102,10 @@ export const electronStore = new Store<IElectronStore>({
     DataProviderUrl: {
       type: "string",
       default: undefined
+    },
+    ConfigVersion: {
+      type: "number",
+      default: 0
     }
   },
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,11 @@
 import Store from "electron-store";
 import path from "path";
-import { IElectronStore } from "./interfaces/config";
+import { IConfig } from "./interfaces/config";
 
 const { app } =
   process.type === "browser" ? require("electron") : require("electron").remote;
 
-export const electronStore = new Store<IElectronStore>({
+export const configStore = new Store<IConfig>({
   cwd: app.getAppPath(),
   schema: {
     AppProtocolVersion: {
@@ -160,9 +160,9 @@ const getLocalApplicationDataPath = (): string => {
 };
 
 export const blockchainStoreDirParent =
-  electronStore.get("BlockchainStoreDirParent") === ""
+  configStore.get("BlockchainStoreDirParent") === ""
     ? path.join(getLocalApplicationDataPath(), "planetarium")
-    : electronStore.get("BlockchainStoreDirParent");
+    : configStore.get("BlockchainStoreDirParent");
 
 export const REQUIRED_DISK_SPACE = 2 * 1000 * 1000 * 1000;
 export const SNAPSHOT_SAVE_PATH = app.getPath("userData");
@@ -181,7 +181,7 @@ export const CUSTOM_SERVER: boolean =
   RpcServerPort().notDefault;
 export const BLOCKCHAIN_STORE_PATH = path.join(
   blockchainStoreDirParent,
-  electronStore.get("BlockchainStoreDirName")
+  configStore.get("BlockchainStoreDirName")
 );
 export const MIXPANEL_TOKEN = "80a1e14b57d050536185c7459d45195a";
 export const TRANSIFEX_TOKEN = "1/9ac6d0a1efcda679e72e470221e71f4b0497f7ab";

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -1,4 +1,5 @@
 export interface IElectronStore {
+  ConfigVersion: number;
   AppProtocolVersion: string;
   SnapshotPaths: string[];
   GenesisBlockPath: string;

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -1,4 +1,4 @@
-export interface IElectronStore {
+export interface IConfig {
   ConfigVersion: number;
   AppProtocolVersion: string;
   SnapshotPaths: string[];

--- a/src/main/headless/headless.ts
+++ b/src/main/headless/headless.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, execFileSync } from "child_process";
 import { ipcMain } from "electron";
 import { dirname, basename } from "path";
-import { electronStore, CUSTOM_SERVER, LOCAL_SERVER_URL } from "../../config";
+import { configStore, CUSTOM_SERVER, LOCAL_SERVER_URL } from "../../config";
 import { retry } from "@lifeomic/attempt";
 import { FetchError, HeadlessExitedError } from "../../errors";
 import { execute, sleep } from "../../utils";
@@ -85,7 +85,7 @@ class Headless {
       console.log("Connecting to the custom headless server...");
       console.log(
         "If the connection is not successful, check if the headless server " +
-          `is executed with the following options:${argsString}`
+        `is executed with the following options:${argsString}`
       );
     } else {
       console.log(
@@ -120,7 +120,7 @@ class Headless {
 
   public async setMining(mine: boolean): Promise<boolean> {
     console.log(`Setting mining: ${mine}`);
-    electronStore.set("NoMiner", !mine);
+    configStore.set("NoMiner", !mine);
     const body = JSON.stringify({
       Mine: mine,
     });
@@ -243,8 +243,7 @@ class Headless {
 
         if (await this.needRetry(response)) {
           console.log(
-            `Failed to fetch standalone (${addr}). Retrying... ${
-              context.attemptNum
+            `Failed to fetch standalone (${addr}). Retrying... ${context.attemptNum
             }/${context.attemptsRemaining + context.attemptNum}`
           );
           throw new Error("Retry required.");

--- a/src/preload/sentry.ts
+++ b/src/preload/sentry.ts
@@ -1,5 +1,5 @@
 import isDev from "electron-is-dev";
-import { electronStore } from "../config";
+import { configStore } from "../config";
 import { version } from "../../package.json";
 
 const { init } =
@@ -15,7 +15,7 @@ export function initializeSentry() {
     console.debug("Sentry is disabled in development mode.");
     return;
   }
-  if (electronStore.get("Sentry") === true) {
+  if (configStore.get("Sentry") === true) {
     console.debug("Sentry is enabled in production mode.");
     init({
       dsn: dsn,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,7 +15,7 @@ import { Provider } from "mobx-react";
 import AccountStore from "./stores/account";
 import { IStoreContainer } from "../interfaces/store";
 import { RouterStore, syncHistoryWithStore } from "mobx-react-router";
-import { LOCAL_SERVER_URL, electronStore } from "../config";
+import { LOCAL_SERVER_URL, configStore } from "../config";
 import GameStore from "./stores/game";
 import Root from "./Root";
 import StandaloneStore from "./stores/standaloneStore";

--- a/src/renderer/i18n/index.tsx
+++ b/src/renderer/i18n/index.tsx
@@ -1,7 +1,7 @@
 import { tx } from "@transifex/native";
 import { useLanguages } from "@transifex/react";
 import React, { createContext, useEffect, useState } from "react";
-import { electronStore, TRANSIFEX_TOKEN } from "../../config";
+import { configStore, TRANSIFEX_TOKEN } from "../../config";
 
 interface LocaleContext {
   locale: string;
@@ -14,10 +14,10 @@ const context = createContext<LocaleContext>({
 const { Provider } = context;
 
 export function LocaleProvider({ children }: React.PropsWithChildren<{}>) {
-  const [locale, setLocale] = useState(() => electronStore.get("Locale"));
+  const [locale, setLocale] = useState(() => configStore.get("Locale"));
 
   useEffect(() => {
-    const unsubscribe = electronStore.onDidChange("Locale", (v) =>
+    const unsubscribe = configStore.onDidChange("Locale", (v) =>
       setLocale(v ?? "en")
     );
     return unsubscribe;
@@ -32,7 +32,7 @@ export function LocaleProvider({ children }: React.PropsWithChildren<{}>) {
 
     validateLocale(locale).then((valid) => valid || setLocale("en"));
 
-    electronStore.set("Locale", locale);
+    configStore.set("Locale", locale);
   }, [locale]);
 
   return <Provider value={{ locale }}>{children}</Provider>;

--- a/src/renderer/stores/game.ts
+++ b/src/renderer/stores/game.ts
@@ -1,6 +1,6 @@
 import { observable, action, computed } from "mobx";
 import { ipcRenderer, IpcRendererEvent } from "electron";
-import { RPC_SERVER_HOST, RPC_SERVER_PORT, electronStore } from "../../config";
+import { RPC_SERVER_HOST, RPC_SERVER_PORT, configStore } from "../../config";
 
 export default class GameStore {
   @observable
@@ -16,13 +16,13 @@ export default class GameStore {
     ipcRenderer.on("game closed", (event: IpcRendererEvent) => {
       this._isGameStarted = false;
     });
-    this._genesisBlockPath = electronStore.get("GenesisBlockPath") as string;
-    this._language = electronStore.get("Locale") as string;
-    this._appProtocolVersion = electronStore.get(
+    this._genesisBlockPath = configStore.get("GenesisBlockPath") as string;
+    this._language = configStore.get("Locale") as string;
+    this._appProtocolVersion = configStore.get(
       "AppProtocolVersion"
     ) as string;
 
-    electronStore.onDidChange(
+    configStore.onDidChange(
       "Locale",
       (value) => (this._language = value ?? "en")
     );
@@ -43,7 +43,7 @@ export default class GameStore {
     const awsSinkGuid: string = ipcRenderer.sendSync(
       "get-aws-sink-cloudwatch-guid"
     );
-    const dataProviderUrl = electronStore.get("DataProviderUrl");
+    const dataProviderUrl = configStore.get("DataProviderUrl");
 
     ipcRenderer.send("launch game", {
       args: [

--- a/src/renderer/stores/standaloneStore.ts
+++ b/src/renderer/stores/standaloneStore.ts
@@ -1,5 +1,5 @@
 import { observable, action } from "mobx";
-import { electronStore } from "../../config";
+import { configStore } from "../../config";
 
 export default class StandaloneStore {
   @observable
@@ -12,7 +12,7 @@ export default class StandaloneStore {
   public IsSetPrivateKeyEnded: boolean;
 
   constructor() {
-    this.NoMiner = electronStore.get("NoMiner") as boolean;
+    this.NoMiner = configStore.get("NoMiner") as boolean;
     this.Ready = false;
     this.IsSetPrivateKeyEnded = false;
   }

--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -17,7 +17,7 @@ import {
 } from "@material-ui/core";
 import { FolderOpen, Close } from "@material-ui/icons";
 import useStores from "../../../hooks/useStores";
-import { electronStore, blockchainStoreDirParent } from "../../../config";
+import { configStore, blockchainStoreDirParent } from "../../../config";
 import { SettingsFormEvent } from "../../../interfaces/event";
 import configurationViewStyle from "./ConfigurationView.style";
 import { T, useLanguages, useLocale } from "@transifex/react";
@@ -46,19 +46,19 @@ const ConfigurationView = observer(() => {
   const handleSubmit = (event: SettingsFormEvent) => {
     event.preventDefault();
     const chainDir = event.target.chain.value;
-    electronStore.set("BlockchainStoreDirParent", rootChainPath);
-    electronStore.set("BlockchainStoreDirName", chainDir);
+    configStore.set("BlockchainStoreDirParent", rootChainPath);
+    configStore.set("BlockchainStoreDirName", chainDir);
 
     const localeName =
       languages.find((v) => v.localized_name === event.target.select.value)
         ?.code ?? "en";
-    electronStore.set("Locale", localeName);
+    configStore.set("Locale", localeName);
 
     const agreeAnalytic = event.target.analytic.checked;
-    electronStore.set("Mixpanel", agreeAnalytic);
+    configStore.set("Mixpanel", agreeAnalytic);
 
     const isEnableSentry = event.target.sentry.checked;
-    electronStore.set("Sentry", isEnableSentry);
+    configStore.set("Sentry", isEnableSentry);
 
     remote.app.relaunch();
     remote.app.exit();
@@ -121,7 +121,7 @@ const ConfigurationView = observer(() => {
             fullWidth
             name="chain"
             className={classes.textField}
-            defaultValue={electronStore.get("BlockchainStoreDirName")}
+            defaultValue={configStore.get("BlockchainStoreDirName")}
           />
           <FormLabel className={classes.newLine}>
             <T _str="Select Language" _tags={transifexTags} />
@@ -156,7 +156,7 @@ const ConfigurationView = observer(() => {
                 control={
                   <Checkbox
                     className={classes.checkbox}
-                    defaultChecked={electronStore.get("Sentry")}
+                    defaultChecked={configStore.get("Sentry")}
                     color="default"
                     name="sentry"
                   />
@@ -167,7 +167,7 @@ const ConfigurationView = observer(() => {
                 control={
                   <Checkbox
                     className={classes.checkbox}
-                    defaultChecked={electronStore.get("Mixpanel")}
+                    defaultChecked={configStore.get("Mixpanel")}
                     color="default"
                     name="analytic"
                   />

--- a/src/renderer/views/layout/Layout.tsx
+++ b/src/renderer/views/layout/Layout.tsx
@@ -9,7 +9,7 @@ import useStores from "../../../hooks/useStores";
 import { observer } from "mobx-react";
 
 import { T } from "@transifex/react";
-import { electronStore } from "../../../config";
+import { configStore } from "../../../config";
 import AccountInfoContainer from "../../components/AccountInfo/AccountInfoContainer";
 import InfoIcon from "../../components/InfoIcon";
 
@@ -42,12 +42,11 @@ export const Layout: React.FC = observer(({ children }) => {
       "clipboard"
     ) as HTMLTextAreaElement)!;
     const stringValue = `
-      APV: ${electronStore.get("AppProtocolVersion") as string} 
+      APV: ${configStore.get("AppProtocolVersion") as string} 
       Address: ${accountStore.selectedAddress} 
       Debug: ${accountStore.isLogin} / ${topmostBlocksResult.loading}
-      Mined blocks: ${minedBlocks?.length} (out of recent ${
-      topmostBlocks?.length
-    } blocks)
+      Mined blocks: ${minedBlocks?.length} (out of recent ${topmostBlocks?.length
+      } blocks)
       ${awsSinkCloudwatchGuid !== null && `Client ID: ${awsSinkCloudwatchGuid}`}
     `;
     clipboardElement.value = stringValue;
@@ -68,7 +67,7 @@ export const Layout: React.FC = observer(({ children }) => {
       <nav className="hero">
         <AccountInfoContainer
           minedBlock={Number(minedBlocks?.length)}
-          onReward={() => {}}
+          onReward={() => { }}
           onOpenWindow={() => {
             ipcRenderer.invoke("open collection page");
           }}
@@ -119,9 +118,8 @@ export const Layout: React.FC = observer(({ children }) => {
             </Button>
           </li>
         </ul>
-        <div className="LauncherLayoutVersion">{`v${
-          (electronStore.get("AppProtocolVersion") as string).split("/")[0]
-        }`}</div>
+        <div className="LauncherLayoutVersion">{`v${(configStore.get("AppProtocolVersion") as string).split("/")[0]
+          }`}</div>
         <div
           id={"LauncherClientIcon"}
           className={`LauncherClientIcon ${infoButtonState ? "activate" : ""}`}

--- a/src/renderer/views/lobby/PreloadView.tsx
+++ b/src/renderer/views/lobby/PreloadView.tsx
@@ -16,7 +16,7 @@ import MenuBookIcon from "@material-ui/icons/MenuBook";
 import GrainIcon from "@material-ui/icons/Grain";
 import preloadViewStyle from "./PreloadView.style";
 import LobbyView from "./LobbyView";
-import { electronStore } from "../../../config";
+import { configStore } from "../../../config";
 import { YouTubeInternal } from "../../../interfaces/refs";
 
 import { T, useT } from "@transifex/react";
@@ -31,7 +31,7 @@ const PreloadView = observer((props: IStoreContainer) => {
     height: "220",
     playerVars: {
       autoplay: 1,
-      mute: electronStore.get("MuteTeaser") ? 1 : 0,
+      mute: configStore.get("MuteTeaser") ? 1 : 0,
     },
   };
 
@@ -49,7 +49,7 @@ const PreloadView = observer((props: IStoreContainer) => {
   const handleLaunch = useCallback(() => {
     const player = youtubeRef.current?.internalPlayer;
     if (player === undefined) throw Error("YouTube Player not found");
-    if (videoOpts.playerVars?.mute === 0) electronStore.set("MuteTeaser", true);
+    if (videoOpts.playerVars?.mute === 0) configStore.set("MuteTeaser", true);
     player.pauseVideo();
   }, [youtubeRef]);
 

--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -2,7 +2,7 @@ import { Container, Typography, CircularProgress } from "@material-ui/core";
 import { observer } from "mobx-react";
 import { ipcRenderer, IpcRendererEvent } from "electron";
 import React, { useState, useEffect } from "react";
-import { electronStore } from "../../../config";
+import { configStore } from "../../../config";
 import {
   useNodeExceptionSubscription,
   useNodeStatusSubscriptionSubscription,
@@ -59,7 +59,7 @@ const PreloadProgressView = observer(() => {
 
   const makeProgressMessage = () => {
     if (preloadEnded) {
-      return electronStore.get("PeerStrings").length > 0
+      return configStore.get("PeerStrings").length > 0
         ? completedMessage
         : noPeerMessage;
     } else {


### PR DESCRIPTION
This PR enables config loads from a remote location (`https://download.nine-chronicles.com/9c-launcher-config.json`). furthermore, it adds `ConfigVersion` to opt-out of this feature by a user.

And, I renamed symbols related to the launcher configuration. (it's too confusing 😅 ) too.