### PR TITLE
Separate settings into app settings and user settings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,110 +5,113 @@ import { IConfig } from "./interfaces/config";
 const { app } =
   process.type === "browser" ? require("electron") : require("electron").remote;
 
+const schema: any = {
+  AppProtocolVersion: {
+    type: "string",
+    default:
+      "2001/019101FEec7ed4f918D396827E1277DEda1e20D4/MEQCIBlLqJk+INI.EHa2EvdUl.7LIZoOXRm3+9GF0fQPakw8AiBE2wbRGSnohWgDHm1gSU+iSpVv7sxKQFHcrfKFTD72dg==/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTU0Omh0dHBzOi8vZG93bmxvYWQubmluZS1jaHJvbmljbGVzLmNvbS92MjAwMS9XaW5kb3dzLnppcHUxNDptYWNPU0JpbmFyeVVybHU1NTpodHRwczovL2Rvd25sb2FkLm5pbmUtY2hyb25pY2xlcy5jb20vdjIwMDEvbWFjT1MudGFyLmd6dTk6dGltZXN0YW1wdTIwOjIwMjAtMDYtMzBUMDU6NDg6MTFaZQ==",
+  },
+  SnapshotPaths: {
+    type: "array",
+    default: [],
+  },
+  GenesisBlockPath: {
+    type: "string",
+    default: "",
+  },
+  MinimumDifficulty: {
+    type: "integer",
+    default: 5000000,
+  },
+  StoreType: {
+    type: "string",
+    default: "rocksdb",
+  },
+  NoMiner: {
+    type: "boolean",
+    default: true,
+  },
+  TrustedAppProtocolVersionSigners: {
+    type: "array",
+    default: [
+      "02a5e2811a9bfa4eec274e806debd622c53702bce39a809918563a4cf34189ff85",
+    ],
+  },
+  IceServerStrings: {
+    type: "array",
+    default: [
+      "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478",
+      "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us2.planetarium.dev:3478",
+      "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us3.planetarium.dev:3478",
+    ],
+  },
+  PeerStrings: {
+    type: "array",
+    default: [],
+  },
+  BlockchainStoreDirParent: {
+    type: "string",
+    default: "",
+  },
+  BlockchainStoreDirName: {
+    type: "string",
+    default: "9c",
+  },
+  Locale: {
+    type: "string",
+    default: app.getLocale(),
+  },
+  Workers: {
+    type: "integer",
+    default: 20,
+  },
+  Confirmations: {
+    type: "integer",
+    default: 0,
+  },
+  HeadlessArgs: {
+    type: "array",
+    default: [],
+  },
+  Mixpanel: {
+    type: "boolean",
+    default: true,
+  },
+  Sentry: {
+    type: "boolean",
+    default: true,
+  },
+  MuteTeaser: {
+    type: "boolean",
+    default: false,
+  },
+  AwsAccessKey: {
+    type: "string",
+    default: undefined,
+  },
+  AwsSecretKey: {
+    type: "string",
+    default: undefined,
+  },
+  AwsRegion: {
+    type: "string",
+    default: undefined,
+  },
+  DataProviderUrl: {
+    type: "string",
+    default: undefined
+  },
+  ConfigVersion: {
+    type: "integer",
+    default: 0
+  }
+}
+
 export const configStore = new Store<IConfig>({
   cwd: app.getAppPath(),
-  schema: {
-    AppProtocolVersion: {
-      type: "string",
-      default:
-        "2001/019101FEec7ed4f918D396827E1277DEda1e20D4/MEQCIBlLqJk+INI.EHa2EvdUl.7LIZoOXRm3+9GF0fQPakw8AiBE2wbRGSnohWgDHm1gSU+iSpVv7sxKQFHcrfKFTD72dg==/ZHUxNjpXaW5kb3dzQmluYXJ5VXJsdTU0Omh0dHBzOi8vZG93bmxvYWQubmluZS1jaHJvbmljbGVzLmNvbS92MjAwMS9XaW5kb3dzLnppcHUxNDptYWNPU0JpbmFyeVVybHU1NTpodHRwczovL2Rvd25sb2FkLm5pbmUtY2hyb25pY2xlcy5jb20vdjIwMDEvbWFjT1MudGFyLmd6dTk6dGltZXN0YW1wdTIwOjIwMjAtMDYtMzBUMDU6NDg6MTFaZQ==",
-    },
-    SnapshotPaths: {
-      type: "array",
-      default: [],
-    },
-    GenesisBlockPath: {
-      type: "string",
-      default: "",
-    },
-    MinimumDifficulty: {
-      type: "integer",
-      default: 5000000,
-    },
-    StoreType: {
-      type: "string",
-      default: "rocksdb",
-    },
-    NoMiner: {
-      type: "boolean",
-      default: true,
-    },
-    TrustedAppProtocolVersionSigners: {
-      type: "array",
-      default: [
-        "02a5e2811a9bfa4eec274e806debd622c53702bce39a809918563a4cf34189ff85",
-      ],
-    },
-    IceServerStrings: {
-      type: "array",
-      default: [
-        "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us.planetarium.dev:3478",
-        "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us2.planetarium.dev:3478",
-        "turn://0ed3e48007413e7c2e638f13ddd75ad272c6c507e081bd76a75e4b7adc86c9af:0apejou+ycZFfwtREeXFKdfLj2gCclKzz5ZJ49Cmy6I=@turn-us3.planetarium.dev:3478",
-      ],
-    },
-    PeerStrings: {
-      type: "array",
-      default: [],
-    },
-    BlockchainStoreDirParent: {
-      type: "string",
-      default: "",
-    },
-    BlockchainStoreDirName: {
-      type: "string",
-      default: "9c",
-    },
-    Locale: {
-      type: "string",
-      default: app.getLocale(),
-    },
-    Workers: {
-      type: "integer",
-      default: 20,
-    },
-    Confirmations: {
-      type: "integer",
-      default: 0,
-    },
-    HeadlessArgs: {
-      type: "array",
-      default: [],
-    },
-    Mixpanel: {
-      type: "boolean",
-      default: true,
-    },
-    Sentry: {
-      type: "boolean",
-      default: true,
-    },
-    MuteTeaser: {
-      type: "boolean",
-      default: false,
-    },
-    AwsAccessKey: {
-      type: "string",
-      default: undefined,
-    },
-    AwsSecretKey: {
-      type: "string",
-      default: undefined,
-    },
-    AwsRegion: {
-      type: "string",
-      default: undefined,
-    },
-    DataProviderUrl: {
-      type: "string",
-      default: undefined
-    },
-    ConfigVersion: {
-      type: "number",
-      default: 0
-    }
-  },
+  schema
 });
+export const userConfigStore = new Store<IConfig>();
 
 const LocalServerUrl = (): string => {
   return `${LocalServerHost().host}:${LocalServerPort().port}`;
@@ -160,9 +163,24 @@ const getLocalApplicationDataPath = (): string => {
 };
 
 export const blockchainStoreDirParent =
-  configStore.get("BlockchainStoreDirParent") === ""
+  get("BlockchainStoreDirParent") === ""
     ? path.join(getLocalApplicationDataPath(), "planetarium")
-    : configStore.get("BlockchainStoreDirParent");
+    : get("BlockchainStoreDirParent");
+
+export function get<K extends keyof IConfig>(key: K, defaultValue?: IConfig[K]): IConfig[K] {
+  if (userConfigStore.has(key)) {
+    return userConfigStore.get(key);
+  }
+
+  return configStore.get(key, defaultValue);
+}
+
+export function getBlockChainStorePath(): string {
+  return path.join(
+    blockchainStoreDirParent,
+    get("BlockchainStoreDirName")
+  )
+}
 
 export const REQUIRED_DISK_SPACE = 2 * 1000 * 1000 * 1000;
 export const SNAPSHOT_SAVE_PATH = app.getPath("userData");
@@ -179,9 +197,5 @@ export const CUSTOM_SERVER: boolean =
   LocalServerPort().notDefault ||
   RpcServerHost().notDefault ||
   RpcServerPort().notDefault;
-export const BLOCKCHAIN_STORE_PATH = path.join(
-  blockchainStoreDirParent,
-  configStore.get("BlockchainStoreDirName")
-);
 export const MIXPANEL_TOKEN = "80a1e14b57d050536185c7459d45195a";
 export const TRANSIFEX_TOKEN = "1/9ac6d0a1efcda679e72e470221e71f4b0497f7ab";

--- a/src/main/headless/headless.ts
+++ b/src/main/headless/headless.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, execFileSync } from "child_process";
 import { ipcMain } from "electron";
 import { dirname, basename } from "path";
-import { configStore, CUSTOM_SERVER, LOCAL_SERVER_URL } from "../../config";
+import { userConfigStore, CUSTOM_SERVER, LOCAL_SERVER_URL } from "../../config";
 import { retry } from "@lifeomic/attempt";
 import { FetchError, HeadlessExitedError } from "../../errors";
 import { execute, sleep } from "../../utils";
@@ -120,7 +120,7 @@ class Headless {
 
   public async setMining(mine: boolean): Promise<boolean> {
     console.log(`Setting mining: ${mine}`);
-    configStore.set("NoMiner", !mine);
+    userConfigStore.set("NoMiner", !mine);
     const body = JSON.stringify({
       Mine: mine,
     });

--- a/src/preload/sentry.ts
+++ b/src/preload/sentry.ts
@@ -1,5 +1,5 @@
 import isDev from "electron-is-dev";
-import { configStore } from "../config";
+import { get } from "../config";
 import { version } from "../../package.json";
 
 const { init } =
@@ -15,7 +15,7 @@ export function initializeSentry() {
     console.debug("Sentry is disabled in development mode.");
     return;
   }
-  if (configStore.get("Sentry") === true) {
+  if (get("Sentry")) {
     console.debug("Sentry is enabled in production mode.");
     init({
       dsn: dsn,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,7 +15,7 @@ import { Provider } from "mobx-react";
 import AccountStore from "./stores/account";
 import { IStoreContainer } from "../interfaces/store";
 import { RouterStore, syncHistoryWithStore } from "mobx-react-router";
-import { LOCAL_SERVER_URL, configStore } from "../config";
+import { LOCAL_SERVER_URL } from "../config";
 import GameStore from "./stores/game";
 import Root from "./Root";
 import StandaloneStore from "./stores/standaloneStore";

--- a/src/renderer/i18n/index.tsx
+++ b/src/renderer/i18n/index.tsx
@@ -1,7 +1,6 @@
 import { tx } from "@transifex/native";
-import { useLanguages } from "@transifex/react";
 import React, { createContext, useEffect, useState } from "react";
-import { configStore, TRANSIFEX_TOKEN } from "../../config";
+import { userConfigStore, get, TRANSIFEX_TOKEN } from "../../config";
 
 interface LocaleContext {
   locale: string;
@@ -14,10 +13,10 @@ const context = createContext<LocaleContext>({
 const { Provider } = context;
 
 export function LocaleProvider({ children }: React.PropsWithChildren<{}>) {
-  const [locale, setLocale] = useState(() => configStore.get("Locale"));
+  const [locale, setLocale] = useState(() => get("Locale"));
 
   useEffect(() => {
-    const unsubscribe = configStore.onDidChange("Locale", (v) =>
+    const unsubscribe = userConfigStore.onDidChange("Locale", (v) =>
       setLocale(v ?? "en")
     );
     return unsubscribe;
@@ -32,7 +31,7 @@ export function LocaleProvider({ children }: React.PropsWithChildren<{}>) {
 
     validateLocale(locale).then((valid) => valid || setLocale("en"));
 
-    configStore.set("Locale", locale);
+    userConfigStore.set("Locale", locale);
   }, [locale]);
 
   return <Provider value={{ locale }}>{children}</Provider>;

--- a/src/renderer/stores/game.ts
+++ b/src/renderer/stores/game.ts
@@ -1,6 +1,6 @@
 import { observable, action, computed } from "mobx";
 import { ipcRenderer, IpcRendererEvent } from "electron";
-import { RPC_SERVER_HOST, RPC_SERVER_PORT, configStore } from "../../config";
+import { RPC_SERVER_HOST, RPC_SERVER_PORT, userConfigStore, get as getConfig } from "../../config";
 
 export default class GameStore {
   @observable
@@ -16,13 +16,13 @@ export default class GameStore {
     ipcRenderer.on("game closed", (event: IpcRendererEvent) => {
       this._isGameStarted = false;
     });
-    this._genesisBlockPath = configStore.get("GenesisBlockPath") as string;
-    this._language = configStore.get("Locale") as string;
-    this._appProtocolVersion = configStore.get(
+    this._genesisBlockPath = getConfig("GenesisBlockPath") as string;
+    this._language = getConfig("Locale") as string;
+    this._appProtocolVersion = getConfig(
       "AppProtocolVersion"
     ) as string;
 
-    configStore.onDidChange(
+    userConfigStore.onDidChange(
       "Locale",
       (value) => (this._language = value ?? "en")
     );
@@ -43,7 +43,7 @@ export default class GameStore {
     const awsSinkGuid: string = ipcRenderer.sendSync(
       "get-aws-sink-cloudwatch-guid"
     );
-    const dataProviderUrl = configStore.get("DataProviderUrl");
+    const dataProviderUrl = getConfig("DataProviderUrl");
 
     ipcRenderer.send("launch game", {
       args: [

--- a/src/renderer/stores/standaloneStore.ts
+++ b/src/renderer/stores/standaloneStore.ts
@@ -1,5 +1,5 @@
 import { observable, action } from "mobx";
-import { configStore } from "../../config";
+import { get } from "../../config";
 
 export default class StandaloneStore {
   @observable
@@ -12,7 +12,7 @@ export default class StandaloneStore {
   public IsSetPrivateKeyEnded: boolean;
 
   constructor() {
-    this.NoMiner = configStore.get("NoMiner") as boolean;
+    this.NoMiner = get("NoMiner") as boolean;
     this.Ready = false;
     this.IsSetPrivateKeyEnded = false;
   }

--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -17,7 +17,7 @@ import {
 } from "@material-ui/core";
 import { FolderOpen, Close } from "@material-ui/icons";
 import useStores from "../../../hooks/useStores";
-import { configStore, blockchainStoreDirParent } from "../../../config";
+import { userConfigStore, get as getConfig, blockchainStoreDirParent } from "../../../config";
 import { SettingsFormEvent } from "../../../interfaces/event";
 import configurationViewStyle from "./ConfigurationView.style";
 import { T, useLanguages, useLocale } from "@transifex/react";
@@ -46,19 +46,19 @@ const ConfigurationView = observer(() => {
   const handleSubmit = (event: SettingsFormEvent) => {
     event.preventDefault();
     const chainDir = event.target.chain.value;
-    configStore.set("BlockchainStoreDirParent", rootChainPath);
-    configStore.set("BlockchainStoreDirName", chainDir);
+    userConfigStore.set("BlockchainStoreDirParent", rootChainPath);
+    userConfigStore.set("BlockchainStoreDirName", chainDir);
 
     const localeName =
       languages.find((v) => v.localized_name === event.target.select.value)
         ?.code ?? "en";
-    configStore.set("Locale", localeName);
+    userConfigStore.set("Locale", localeName);
 
     const agreeAnalytic = event.target.analytic.checked;
-    configStore.set("Mixpanel", agreeAnalytic);
+    userConfigStore.set("Mixpanel", agreeAnalytic);
 
     const isEnableSentry = event.target.sentry.checked;
-    configStore.set("Sentry", isEnableSentry);
+    userConfigStore.set("Sentry", isEnableSentry);
 
     remote.app.relaunch();
     remote.app.exit();
@@ -121,7 +121,7 @@ const ConfigurationView = observer(() => {
             fullWidth
             name="chain"
             className={classes.textField}
-            defaultValue={configStore.get("BlockchainStoreDirName")}
+            defaultValue={getConfig("BlockchainStoreDirName")}
           />
           <FormLabel className={classes.newLine}>
             <T _str="Select Language" _tags={transifexTags} />
@@ -156,7 +156,7 @@ const ConfigurationView = observer(() => {
                 control={
                   <Checkbox
                     className={classes.checkbox}
-                    defaultChecked={configStore.get("Sentry")}
+                    defaultChecked={getConfig("Sentry")}
                     color="default"
                     name="sentry"
                   />
@@ -167,7 +167,7 @@ const ConfigurationView = observer(() => {
                 control={
                   <Checkbox
                     className={classes.checkbox}
-                    defaultChecked={configStore.get("Mixpanel")}
+                    defaultChecked={getConfig("Mixpanel")}
                     color="default"
                     name="analytic"
                   />

--- a/src/renderer/views/error/ErrorDiskSpaceView.tsx
+++ b/src/renderer/views/error/ErrorDiskSpaceView.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import errorViewStyle from "./ErrorView.style";
 import { Typography } from "@material-ui/core";
 import prettyBytes from "pretty-bytes";
-import { BLOCKCHAIN_STORE_PATH, REQUIRED_DISK_SPACE } from "../../../config";
+import { getBlockChainStorePath, REQUIRED_DISK_SPACE } from "../../../config";
 import * as Sentry from "@sentry/electron";
 import { T } from "@transifex/react";
 import { ipcRenderer } from "electron";
@@ -32,7 +32,7 @@ const ErrorDiskSpaceView = () => {
         <T
           _str="Root chain store path: {path}"
           _tags={transifexTags}
-          path={BLOCKCHAIN_STORE_PATH}
+          path={getBlockChainStorePath()}
         />
       </Typography>
     </div>

--- a/src/renderer/views/error/ErrorNoPermissionView.tsx
+++ b/src/renderer/views/error/ErrorNoPermissionView.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
-import { ipcRenderer, remote } from "electron";
+import { ipcRenderer } from "electron";
 import errorViewStyle from "./ErrorView.style";
-import { Button, Typography } from "@material-ui/core";
-import { BLOCKCHAIN_STORE_PATH } from "../../../config";
+import { Typography } from "@material-ui/core";
+import { getBlockChainStorePath } from "../../../config";
 import * as Sentry from "@sentry/electron";
 import { T } from "@transifex/react";
 
@@ -28,7 +28,7 @@ const ErrorNoPermissionView = () => {
           _tags={transifexTags}
         />
         <br />
-        <code className={classes.code}>{BLOCKCHAIN_STORE_PATH}</code>
+        <code className={classes.code}>{getBlockChainStorePath()}</code>
         <br />
         <T
           _str="Please change chain directory by following steps below."

--- a/src/renderer/views/layout/Layout.tsx
+++ b/src/renderer/views/layout/Layout.tsx
@@ -9,7 +9,7 @@ import useStores from "../../../hooks/useStores";
 import { observer } from "mobx-react";
 
 import { T } from "@transifex/react";
-import { configStore } from "../../../config";
+import { get as getConfig } from "../../../config";
 import AccountInfoContainer from "../../components/AccountInfo/AccountInfoContainer";
 import InfoIcon from "../../components/InfoIcon";
 
@@ -42,7 +42,7 @@ export const Layout: React.FC = observer(({ children }) => {
       "clipboard"
     ) as HTMLTextAreaElement)!;
     const stringValue = `
-      APV: ${configStore.get("AppProtocolVersion") as string} 
+      APV: ${getConfig("AppProtocolVersion") as string} 
       Address: ${accountStore.selectedAddress} 
       Debug: ${accountStore.isLogin} / ${topmostBlocksResult.loading}
       Mined blocks: ${minedBlocks?.length} (out of recent ${topmostBlocks?.length
@@ -118,7 +118,7 @@ export const Layout: React.FC = observer(({ children }) => {
             </Button>
           </li>
         </ul>
-        <div className="LauncherLayoutVersion">{`v${(configStore.get("AppProtocolVersion") as string).split("/")[0]
+        <div className="LauncherLayoutVersion">{`v${(getConfig("AppProtocolVersion") as string).split("/")[0]
           }`}</div>
         <div
           id={"LauncherClientIcon"}

--- a/src/renderer/views/lobby/PreloadView.tsx
+++ b/src/renderer/views/lobby/PreloadView.tsx
@@ -16,7 +16,7 @@ import MenuBookIcon from "@material-ui/icons/MenuBook";
 import GrainIcon from "@material-ui/icons/Grain";
 import preloadViewStyle from "./PreloadView.style";
 import LobbyView from "./LobbyView";
-import { configStore } from "../../../config";
+import { get as getConfig, userConfigStore } from "../../../config";
 import { YouTubeInternal } from "../../../interfaces/refs";
 
 import { T, useT } from "@transifex/react";
@@ -31,7 +31,7 @@ const PreloadView = observer((props: IStoreContainer) => {
     height: "220",
     playerVars: {
       autoplay: 1,
-      mute: configStore.get("MuteTeaser") ? 1 : 0,
+      mute: getConfig("MuteTeaser") ? 1 : 0,
     },
   };
 
@@ -49,7 +49,7 @@ const PreloadView = observer((props: IStoreContainer) => {
   const handleLaunch = useCallback(() => {
     const player = youtubeRef.current?.internalPlayer;
     if (player === undefined) throw Error("YouTube Player not found");
-    if (videoOpts.playerVars?.mute === 0) configStore.set("MuteTeaser", true);
+    if (videoOpts.playerVars?.mute === 0) userConfigStore.set("MuteTeaser", true);
     player.pauseVideo();
   }, [youtubeRef]);
 

--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -2,7 +2,7 @@ import { Container, Typography, CircularProgress } from "@material-ui/core";
 import { observer } from "mobx-react";
 import { ipcRenderer, IpcRendererEvent } from "electron";
 import React, { useState, useEffect } from "react";
-import { configStore } from "../../../config";
+import { get as getConfig } from "../../../config";
 import {
   useNodeExceptionSubscription,
   useNodeStatusSubscriptionSubscription,
@@ -59,7 +59,7 @@ const PreloadProgressView = observer(() => {
 
   const makeProgressMessage = () => {
     if (preloadEnded) {
-      return configStore.get("PeerStrings").length > 0
+      return getConfig("PeerStrings").length > 0
         ? completedMessage
         : noPeerMessage;
     } else {


### PR DESCRIPTION
This PR is the following work of #820 .

The problem with #820 is that you can't persist the local settings without a `ConfigVersion`. The 9c launcher has a UI to change settings and is an app that users frequently change settings for, and if you change the ConfigVersion each time, the goal of #820 is practically difficult to achieve.

Therefore, to fundamentally solve this problem,
- Instead of following the existing app installation path, `config.json`, create a separate `config.json` left in the user setting directory.
- Arrange the code so that all settings can only be accessed through `get()` defined in `config.ts`
- Modified entire code to lookup user settings first in `get()`, and follow app settings only if not present.