### PR TITLE
introduce retry axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-youtube": "^7.11.3",
+    "retry-axios": "^2.4.0",
     "style-loader": "^3.0.0",
     "subscriptions-transport-ws": "^0.9.16",
     "textfit": "^2.4.0",


### PR DESCRIPTION
This PR adds the `retry-axios` module so that axios will retry downloading snapshots when there's an issue with the network connection while downloading.