### PR TITLE
Fix monster collection UI bug 

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "react": "^16.13.1",
     "react-apollo": "^3.1.5",
     "react-dom": "^16.13.1",
-    "react-mount-animation": "^0.0.9",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-youtube": "^7.11.3",

--- a/src/collection/components/Cart/Cart.tsx
+++ b/src/collection/components/Cart/Cart.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useState } from "react"
 import { CollectionItemModel } from "../../models/collection";
-import { getMonsterImageFromTier } from "../../common/utils";
 import { CollectionItemTier, CollectionPhase } from "../../types"
 
 import './Cart.scss';
 import CartItem from "./CartItem/CartItem";
 import CollectionButton from "../Button/Button";
 import stepIcon from "../../common/resources/bg-staking-slot-step.png";
-import Animated from "react-mount-animation";
 
 export type Props = {
   cartList: CollectionItemModel[],
@@ -29,8 +27,6 @@ const Cart: React.FC<Props> = (props: Props) => {
     onSubmit,
     warningMessage
   } = props;
-  const [warning, setWarning] = useState<boolean>(false);
-  const [warningTimer, setWarningTimer] = useState<NodeJS.Timeout>();
 
   const getNeedGoldAmount = (item: CollectionItemModel) => {
     let value = 0;
@@ -46,28 +42,14 @@ const Cart: React.FC<Props> = (props: Props) => {
     const latestItem = cartList.find(x => x.collectionPhase === CollectionPhase.LATEST);
 
     if (latestItem?.tier !== CollectionItemTier.TIER1) return;
-
-    if (warningTimer != null) {
-      clearTimeout(warningTimer);
-    }
-
-    setWarning(true);
-    const timer = setTimeout(() => setWarning(false), 5 * 1000);
-    setWarningTimer(timer);
   }
-
-  useEffect(() => {
-    return () => {
-      if (warningTimer) clearTimeout(warningTimer);
-    }
-  }, [])
 
 
   return <div className={'CartContainer'}>
     <div className={'CartItemListBackground'}>
-      <Animated.div show={warningMessage != ""} className='CartWarningMessage' unmountAnimId='fadeout'>
+      <div className='CartWarningMessage' hidden={warningMessage === ""}>
         {warningMessage}
-      </Animated.div>
+      </div>
 
       <div className={'CartItemListContainer'}>
         {
@@ -91,14 +73,14 @@ const Cart: React.FC<Props> = (props: Props) => {
           onClick={onSubmit}
         >
           Apply
-      </CollectionButton>
+        </CollectionButton>
         <CollectionButton
           width={164}
           height={30}
           onClick={onCancel}
         >
           Cancel
-      </CollectionButton>
+        </CollectionButton>
 
       </div>
     </div>

--- a/src/collection/components/Cart/CartItem/CartItem.tsx
+++ b/src/collection/components/Cart/CartItem/CartItem.tsx
@@ -9,94 +9,94 @@ import GoldImage from "../../../common/resources/gold.png";
 import './CartItem.scss';
 
 export type Props = {
-    item: CollectionItemModel
-    canCollect: boolean
-    onPush: (item: CollectionItemModel) => void,
-    onClick: (item: CollectionItemModel) => void,
-    onRemove: (tier: CollectionItemModel) => void,
+  item: CollectionItemModel
+  canCollect: boolean
+  onPush: (item: CollectionItemModel) => void,
+  onClick: (item: CollectionItemModel) => void,
+  onRemove: (tier: CollectionItemModel) => void,
 }
 
 type MonsterItemProps = {
-    icon: string
-    item: CollectionItemModel
-    onRemove: (tier: CollectionItemModel) => void,
-    onClick: (item: CollectionItemModel) => void,
+  icon: string
+  item: CollectionItemModel
+  onRemove: (tier: CollectionItemModel) => void,
+  onClick: (item: CollectionItemModel) => void,
 }
 
 type AddItemProps = {
-    item: CollectionItemModel
-    canCollect: boolean
-    onPush: (item: CollectionItemModel) => void,
-    onClick: (item: CollectionItemModel) => void,
+  item: CollectionItemModel
+  canCollect: boolean
+  onPush: (item: CollectionItemModel) => void,
+  onClick: (item: CollectionItemModel) => void,
 }
 
 
 const LockItem: React.FC = () => {
-    return (
+  return (
     <div>
-        <img src={LockImage} className={'LockIcon'} />
+      <img src={LockImage} className={'LockIcon'} />
     </div>
-    )
+  )
 }
 
 const AddItem: React.FC<AddItemProps> = (props: AddItemProps) => {
-    const { item, canCollect, onClick, onPush } = props;
+  const { item, canCollect, onClick, onPush } = props;
 
-    const handleClick = () => {
-        canCollect ? onPush(item) : onClick(item)
-    }
-    return (
-        <div>
-            <div className={'AddItem'} onClick={handleClick} />
-        </div>
+  const handleClick = () => {
+    canCollect ? onPush(item) : onClick(item)
+  }
+  return (
+    <div>
+      <div className={'AddItem'} onClick={handleClick} />
+    </div>
 
-    )
+  )
 }
 
 const MonsterItem: React.FC<MonsterItemProps> = (props: MonsterItemProps) => {
-    const { icon, item, onClick, onRemove } = props;
-    return (
+  const { icon, item, onClick, onRemove } = props;
+  return (
     <div>
-        <div className={'CartIcon'} onClick={() => {onClick(item)}} />
-        <img src={require(`../../../common/resources/${icon}.png`).default} />
-        {
-            item.collectionPhase === CollectionPhase.LATEST 
-                ? <img className='RemoveButton' src={CancelImage} onClick={() => {onRemove(item)}} /> 
-                : <></>
-        }
+      <div className={'CartIcon'} onClick={() => { onClick(item) }} />
+      <img src={require(`../../../common/resources/${icon}.png`)} />
+      {
+        item.collectionPhase === CollectionPhase.LATEST
+          ? <img className='RemoveButton' src={CancelImage} onClick={() => { onRemove(item) }} />
+          : <></>
+      }
     </div>)
 }
 
 const CartItem: React.FC<Props> = (props: Props) => {
-    const {item, canCollect, onPush, onRemove, onClick} = props;
+  const { item, canCollect, onPush, onRemove, onClick } = props;
 
-    const getResource = (tier: CollectionItemTier) => {
-        return getCartMonsterImageFromTier(tier);
-    }
+  const getResource = (tier: CollectionItemTier) => {
+    return getCartMonsterImageFromTier(tier);
+  }
 
-    const getComponent = (item: CollectionItemModel) => {
-        if(item.collectionPhase === CollectionPhase.LOCKED) return <LockItem />
-        else if(item.collectionPhase === CollectionPhase.CANDIDATE) return <AddItem item={item} onPush={onPush} onClick={onClick} canCollect={canCollect} />
-        else return <MonsterItem icon={getResource(item.tier)} onClick={onClick} item={item} onRemove={onRemove} />
-    }
+  const getComponent = (item: CollectionItemModel) => {
+    if (item.collectionPhase === CollectionPhase.LOCKED) return <LockItem />
+    else if (item.collectionPhase === CollectionPhase.CANDIDATE) return <AddItem item={item} onPush={onPush} onClick={onClick} canCollect={canCollect} />
+    else return <MonsterItem icon={getResource(item.tier)} onClick={onClick} item={item} onRemove={onRemove} />
+  }
 
-    return (
-        <div className={'CartItemContainer'}>
-            <div className={`CartIconContainer CollectionImageBackground`}>
-                {
-                    getComponent(item)
-                }
-            </div>
-            
-            <div className={'CartValueContainer'}>
-            <img className={'GoldIcon'} src={GoldImage} />
-              <div className={`CartValue ${canCollect ? '' : 'RedFontColor'}`} >
-                  {item.value}
-              </div>
-            </div>
+  return (
+    <div className={'CartItemContainer'}>
+      <div className={`CartIconContainer CollectionImageBackground`}>
+        {
+          getComponent(item)
+        }
+      </div>
+
+      <div className={'CartValueContainer'}>
+        <img className={'GoldIcon'} src={GoldImage} />
+        <div className={`CartValue ${canCollect ? '' : 'RedFontColor'}`} >
+          {item.value}
+        </div>
+      </div>
 
     </div>
-    )
+  )
 }
 
 export default CartItem;

--- a/src/collection/components/CollectionItem/CollectionItem.tsx
+++ b/src/collection/components/CollectionItem/CollectionItem.tsx
@@ -1,30 +1,28 @@
-import React, { useState } from "react";
+import React from "react";
 import { CollectionItemModel } from "../../models/collection";
 import { CollectionPhase } from "../../types";
-import {getMonsterImageFromTier} from '../../common/utils';
-import CircleAddIcon from "../common/icon/CircleAddIcon";
+import { getMonsterImageFromTier } from '../../common/utils';
 import ArrowIcon from "../../common/resources/ui-staking-arrow.png";
 
 import './CollectionItem.scss';
-import { useInterval } from "../../../hooks/useInterval";
 
 export type Props = {
-    item: CollectionItemModel;
-    isEdit: boolean;
+  item: CollectionItemModel;
+  isEdit: boolean;
 }
 
 const CollectionItem: React.FC<Props> = (props: Props) => {
-    
-    const { item, isEdit } = props;
-    const monsterResources = getMonsterImageFromTier(item.tier);
-    return <div className={`CollectionItemContainer TIER${Number(item.tier)}`} >
-        <div>
-          <img src={ArrowIcon} className={`arrow ${item.collectionPhase === CollectionPhase.CANDIDATE && isEdit ? 'visible' : 'hide'}`} />
-        <img className={`${item.collectionPhase > CollectionPhase.CANDIDATE && 'Outline'} 
+
+  const { item, isEdit } = props;
+  const monsterResources = getMonsterImageFromTier(item.tier);
+  return <div className={`CollectionItemContainer TIER${Number(item.tier)}`} >
+    <div>
+      <img src={ArrowIcon} className={`arrow ${item.collectionPhase === CollectionPhase.CANDIDATE && isEdit ? 'visible' : 'hide'}`} />
+      <img className={`${item.collectionPhase > CollectionPhase.CANDIDATE && 'Outline'} 
             ${item.collectionPhase === CollectionPhase.CANDIDATE && !isEdit && 'Outline'}`}
-            src={require(`../../common/resources/${monsterResources}.png`).default} />
-        </div>
+        src={require(`../../common/resources/${monsterResources}.png`)} />
     </div>
+  </div>
 }
 
 export default CollectionItem;

--- a/src/collection/components/ExpectedStatusBoard/ExpectedStatusBoard.tsx
+++ b/src/collection/components/ExpectedStatusBoard/ExpectedStatusBoard.tsx
@@ -43,23 +43,24 @@ const ExpectedStatusBoard: React.FC<Props> = (props: Props) => {
   return (
     <div className={"ExpectedStatusBoardBackground"}>
       <div className={"ExpectedStatusBoardContainer"}>
-      <div className={"CurrentStakedGoldContainer"}>
-        <div className={"ExpectedStatusBoardTitle"}>MY BALANCE</div>
-        <RewardItem left={depositedGold} right={depositedGold} item={"GOLD"} />
-      </div>
-
-      <div className={"CurrentExpectedRewardContainer"}>
-        <div className={"ExpectedStatusBoardTitle"}>REWARDS</div>
-        <div className={"ExpectedReward"}>
-          {getRewardCategoryList().map((x) => (
-            <RewardItem
-              left={currentReward.get(x) || 0}
-              right={targetReward.get(x) || 0}
-              item={x}
-            />
-          ))}
+        <div className={"CurrentStakedGoldContainer"}>
+          <div className={"ExpectedStatusBoardTitle"}>MY BALANCE</div>
+          <RewardItem left={depositedGold} right={depositedGold} item={"GOLD"} />
         </div>
-      </div>
+
+        <div className={"CurrentExpectedRewardContainer"}>
+          <div className={"ExpectedStatusBoardTitle"}>REWARDS</div>
+          <div className={"ExpectedReward"}>
+            {getRewardCategoryList().map((x, i) => (
+              <RewardItem
+                key={i}
+                left={currentReward.get(x) || 0}
+                right={targetReward.get(x) || 0}
+                item={x}
+              />
+            ))}
+          </div>
+        </div>
       </div>
 
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15632,13 +15632,6 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-mount-animation@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/react-mount-animation/-/react-mount-animation-0.0.9.tgz#f78cf3147fe21ac233d517c9a4fa84a93742846c"
-  integrity sha512-4CR+vtLDzhAyDGcns+9C7V1l7IMQIAn5sjznV0WCR1LJs9pMwm6FGAmLC73VOXVHU9kc1KJPxezcclIbpWw9RQ==
-  dependencies:
-    react "^17.0.1"
-
 react-popper-tooltip@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/react-popper-tooltip/-/react-popper-tooltip-3.1.1.tgz"
@@ -15757,14 +15750,6 @@ react@^16.13.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-config-file@6.0.0:
   version "6.0.0"
@@ -16381,6 +16366,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry-axios@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-2.4.0.tgz#b5da2afed8dd0134c73c86206e1d1881d7c66a67"
+  integrity sha512-rK7UBYgbrNoVothbSmM0tEm9DIiXapmVUrnUYn+d9AuQvF0AY5RkJU2FQvlufe9hlFwrCdDhrJTwiyRtR7wUaA==
 
 retry@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This PR fixes the white screen bug on Monster Collection UI. To accomplish this, it fixes mainly two points

1. Dropped `react-mount-animation` since it occurs hook error.
2. Stripped `.default` accesses of asset loaders for png. (I'm guessing it's probably no longer needed due to a specification change in webpack, but I'm not sure)

And more, it also fixes that `ExpectedStatusBoard` hadn't assigned key prop to its children.