### PR TITLE
fix validate activation key logic

### DIFF
--- a/src/renderer/components/RetypePasswordForm.tsx
+++ b/src/renderer/components/RetypePasswordForm.tsx
@@ -135,7 +135,7 @@ const RetypePasswordForm = ({
     const splits = code.split("/");
     const privateKey = splits[0];
     const address = splits[1];
-    if (privateKey.length !== 64 || address.length !== 40) {
+    if (address.length !== 40) {
       return false;
     }
 


### PR DESCRIPTION
This PR removes the `privateKey.length !== 64` logic that's causing a UI bug in https://github.com/planetarium/9c-launcher/blob/development/src/renderer/views/lobby/LobbyView.tsx#L139-L165.