### PR TITLE
feat(transfer): update swap maximum per daily

### DIFF
--- a/src/transfer/pages/swap/swap.tsx
+++ b/src/transfer/pages/swap/swap.tsx
@@ -148,7 +148,7 @@ const SwapPage: React.FC<Props> = observer((props: Props) => {
           </li>
           <li>
             <SwapNoticeLabel>
-              <T _str="* Maximum 5,000 NCG per day" _tags={transifexTags} />
+              <T _str="* Maximum {max, number, integer} NCG per day" _tags={transifexTags} max={5000} />
             </SwapNoticeLabel>
           </li>
           <li>

--- a/src/transfer/pages/swap/swap.tsx
+++ b/src/transfer/pages/swap/swap.tsx
@@ -148,7 +148,7 @@ const SwapPage: React.FC<Props> = observer((props: Props) => {
           </li>
           <li>
             <SwapNoticeLabel>
-              <T _str="* Maximum 100,000 NCG per day" _tags={transifexTags} />
+              <T _str="* Maximum 5,000 NCG per day" _tags={transifexTags} />
             </SwapNoticeLabel>
           </li>
           <li>


### PR DESCRIPTION
Since yesterday, NineChronicles Ethereum Bridge's swap maximum limit was down to 5,000 NCG per day.
This pull request applies the change to 9c-launcher.