### PR TITLE
refactor: use async invoke for getting private keys

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -431,9 +431,9 @@ function initializeIpc() {
     mixpanel?.alias(alias);
   });
 
-  ipcMain.on("get-protected-private-keys", async (event) => {
-    event.returnValue = standalone.keyStore.list();
-  });
+  ipcMain.handle("get-protected-private-keys", async () =>
+    standalone.keyStore.list()
+  );
 
   ipcMain.on(
     "unprotect-private-key",

--- a/src/renderer/IntroView.tsx
+++ b/src/renderer/IntroView.tsx
@@ -1,19 +1,22 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { observer, inject } from "mobx-react";
 import { IStoreContainer } from "../interfaces/store";
-import { useProtectedPrivateKeysQuery } from "../generated/graphql";
 
 import { T } from "@transifex/react";
 import { ipcRenderer } from "electron";
 import { ProtectedPrivateKey } from "src/main/headless/key-store";
 
 const IntroView = observer(({ accountStore, routerStore }: IStoreContainer) => {
-  const protectedPrivateKeys: ProtectedPrivateKey[] = ipcRenderer.sendSync(
-    "get-protected-private-keys"
-  );
+  const [protectedPrivateKeys, setProtectedPrivateKeys] = useState<
+    ProtectedPrivateKey[] | null
+  >(null);
 
   useEffect(() => {
-    if (protectedPrivateKeys.length < 1) {
+    if (!protectedPrivateKeys) {
+      ipcRenderer
+        .invoke("get-protected-private-keys")
+        .then(setProtectedPrivateKeys);
+    } else if (protectedPrivateKeys.length < 1) {
       routerStore.push("/main");
     } else {
       const addresses = protectedPrivateKeys.map((value) => value?.address);

--- a/src/v2/Routes.tsx
+++ b/src/v2/Routes.tsx
@@ -1,6 +1,6 @@
 import { ipcRenderer } from "electron";
 import { observer } from "mobx-react";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { Redirect, Route, Switch, useHistory } from "react-router";
 import type { ProtectedPrivateKey } from "src/main/headless/key-store";
 import { useStore } from "./utils/useStore";
@@ -18,12 +18,16 @@ import ErrorView from "./views/ErrorView";
 const Redirector = observer(() => {
   const account = useStore("account");
   const history = useHistory();
+  const [protectedPrivateKeys, setProtectedPrivateKeys] = useState<
+    ProtectedPrivateKey[] | null
+  >(null);
 
   useEffect(() => {
-    const protectedPrivateKeys: ProtectedPrivateKey[] = ipcRenderer.sendSync(
-      "get-protected-private-keys"
-    );
-    if (protectedPrivateKeys.length < 1) {
+    if (!protectedPrivateKeys) {
+      ipcRenderer
+        .invoke("get-protected-private-keys")
+        .then(setProtectedPrivateKeys);
+    } else if (protectedPrivateKeys.length < 1) {
       history.replace("/welcome");
     } else {
       protectedPrivateKeys.filter(Boolean).map(({ address }) => {


### PR DESCRIPTION
Guessing this could improve blocked at the loading screen. I'm planning to test it after getting the packaged launcher from CI.