### PR TITLE
Keep mixpanel event names untranslated

### DIFF
--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -63,7 +63,7 @@ const PreloadProgressView = observer(() => {
         ? completedMessage
         : noPeerMessage;
     } else {
-      return getCurrentStepStatusMessage().concat(
+      return getCurrentStepStatusMessage()[1].concat(
         ` ... (${currentStep}/${totalStep}) ${Math.floor(progress)}%`
       );
     }
@@ -138,7 +138,7 @@ const PreloadProgressView = observer(() => {
   useEffect(() => {
     ipcRenderer.send(
       "mixpanel-track-event",
-      `Launcher/${getCurrentStepStatusMessage()}`
+      `Launcher/${getCurrentStepStatusMessage()[0]}`
     );
   }, [currentStep]);
 
@@ -236,16 +236,16 @@ const PreloadProgressView = observer(() => {
 });
 
 const statusMessage = [
-  t("Validating Snapshot"),
-  t("Downloading Snapshot"),
-  t("Downloading State Snapshot"),
-  t("Extracting Snapshot"),
-  t("Starting Headless"),
-  t("Downloading Block Hashes"),
-  t("Downloading Blocks"),
-  t("Verifying Block Headers"),
-  t("Downloading States"),
-  t("Executing Actions"),
+  ["Validating Snapshot", t("Validating Snapshot")],
+  ["Downloading Snapshot", t("Downloading Snapshot")],
+  ["Downloading State Snapshot", t("Downloading State Snapshot")],
+  ["Extracting Snapshot", t("Extracting Snapshot")],
+  ["Starting Headless", t("Starting Headless")],
+  ["Downloading Block Hashes", t("Downloading Block Hashes")],
+  ["Downloading Blocks", t("Downloading Blocks")],
+  ["Verifying Block Headers", t("Verifying Block Headers")],
+  ["Downloading States", t("Downloading States")],
+  ["Executing Actions", t("Executing Actions")],
 ] as const;
 
 const getProgress = (


### PR DESCRIPTION
Fixes regression from the Transifex patch.