### PR TITLE
Fix getCurrentStepStatusMessage to always return array

### DIFF
--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -44,7 +44,7 @@ const PreloadProgressView = observer(() => {
 
   const getCurrentStepStatusMessage = () => {
     if (!(0 < currentStep && currentStep <= statusMessage.length)) {
-      return "Failed to get message for current step";
+      return Array(2).fill("Failed to get message for current step");
     }
 
     return statusMessage[currentStep - 1];


### PR DESCRIPTION
Fixes regression from #964.