### PR TITLE
Update REQUIRED_DISK_SPACE

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -222,7 +222,7 @@ export function getBlockChainStorePath(): string {
   )
 }
 
-export const REQUIRED_DISK_SPACE = 2 * 1000 * 1000 * 1000;
+export const REQUIRED_DISK_SPACE = 20 * 1000 * 1000 * 1000;
 export const SNAPSHOT_SAVE_PATH = app.getPath("userData");
 export const MAC_GAME_PATH = "9c.app/Contents/MacOS/9c";
 export const WIN_GAME_PATH = "9c.exe";


### PR DESCRIPTION
A workaround of #969. We should be calculating the size of the required snapshots (considering we won't download the complete snapshot after the first launch), but while we are figuring that out, let's stick to the total size of the snapshots.