### PR TITLE
Prevent calling trySetAgentAddress on first render

### DIFF
--- a/src/transfer/App.tsx
+++ b/src/transfer/App.tsx
@@ -65,13 +65,16 @@ const App: React.FC = () => {
   );
 
   const [agentAddress, setAgentAddress] = useState<string>("");
-  ipcRenderer.on("set ninechronicles address", (_, address) => {
-    console.log("set ninechronicles address at Transfer App.tsx");
-    setAgentAddress(address);
-  });
 
   useEffect(() => {
     async function main() {
+      if (!agentAddress) {
+        ipcRenderer.once("set ninechronicles address", (_, address) => {
+          console.log("set ninechronicles address at Transfer App.tsx");
+          setAgentAddress(address);
+        });
+        return;
+      }
       const success = await storeContainer.headlessStore.trySetAgentAddress(
         agentAddress
       );

--- a/src/transfer/App.tsx
+++ b/src/transfer/App.tsx
@@ -86,6 +86,9 @@ const App: React.FC = () => {
     }
     main();
   }, [agentAddress]);
+
+  if (!agentAddress) return null;
+
   return (
     <StoreContext.Provider value={storeContainer}>
       <ThemeProvider theme={theme}>


### PR DESCRIPTION
Avoids "Agent address is empty" error.