### PR TITLE
Bump NineChronicles.Headless & downgrade .NET SDK in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14"
-      # dotent 설치
-      - uses: actions/setup-dotnet@v1.7.2
-        name: Set up .NET Core SDK
-        with:
-          dotnet-version: '6.0.*'
       # 의존성 설치
       - run: yarn add @planetarium/cli
       # APV 생성
@@ -110,11 +105,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14"
-      # dotent 설치
-      - uses: actions/setup-dotnet@v1.7.2
-        name: Set up .NET Core SDK
-        with:
-          dotnet-version: '6.0.*'
       - name: Pull node_modules cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -12,11 +12,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "14"
-      # dotent 설치
-      - uses: actions/setup-dotnet@v1.7.2
-        name: Set up .NET Core SDK
-        with:
-          dotnet-version: '6.0.*'
       - name: Install Dependencies
         run: yarn add @planetarium/cli # Will run yarn install implictly
       - name: Generate key


### PR DESCRIPTION
This PR reflects https://github.com/planetarium/NineChronicles.Headless/pull/904 to the launcher.