### PR TITLE
fix: correct typo

### DIFF
--- a/src/renderer/stores/game.ts
+++ b/src/renderer/stores/game.ts
@@ -24,7 +24,7 @@ export default class GameStore {
     this._language = getConfig("Locale") as string;
     this._appProtocolVersion = getConfig("AppProtocolVersion") as string;
     ipcRenderer.invoke("get-node-info").then((node) => {
-      this._port = node.host;
+      this._host = node.host;
       this._port = node.rpcPort;
     });
     userConfigStore.onDidChange(


### PR DESCRIPTION
There was a typo and it causes to pass `undefined` as RPC server host and then the client throws the below exception:

```
Uploading Crash Report
RpcException: Status(StatusCode=Unavailable, Detail="DNS resolution failed")
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at MagicOnion.Client.ResponseContext`1+<Deserialize>d__11[T].MoveNext () [0x0008b] in <75f6d544341b4631a367a9d03a086fed>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[TResult].GetResult () [0x00000] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at MagicOnion.UnaryResult`1+<UnwrapResponse>d__11[TResponse].MoveNext () [0x000d7] in <75f6d544341b4631a367a9d03a086fed>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Runtime.CompilerServices.TaskAwaiter`1[TResult].GetResult () [0x00000] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at Nekoyume.BlockChain.RPCAgent+<>c__DisplayClass49_0+<<Initialize>b__0>d.MoveNext () [0x00070] in <e52c0750a9e54867a8d7a2dbc5a8b97c>:0 
Rethrow as AggregateException: One or more errors occurred.
  at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) [0x00011] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Threading.Tasks.Task`1[TResult].GetResultCore (System.Boolean waitCompletionNotification) [0x0002b] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at System.Threading.Tasks.Task`1[TResult].get_Result () [0x0000f] in <695d1cc93cca45069c528c15c9fdd749>:0 
  at Nekoyume.BlockChain.RPCAgent+<Initialize>d__49.MoveNext () [0x00135] in <e52c0750a9e54867a8d7a2dbc5a8b97c>:0 
  at UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) [0x00026] in <92f89c20fef94524a39f70be94da1178>:0 
```