### PR TITLE
ci(circleci): correct s3 upload path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ jobs:
             aws configure set aws_secret_access_key $env:AWS_SECRET_KEY
 
             aws s3 cp pack-dist/Windows.zip s3://9c-artifacts/$env:CIRCLE_SHA1
+            aws s3 cp pack-dist/Windows.zip s3://9c-artifacts/9c-launcher/$env:CIRCLE_SHA1/Windows.zip
           name: Upload to S3
   styles:
     docker:


### PR DESCRIPTION
Originally, it uploads to `s3://9c-artifacts/<SHA1>`.
It separates their folder and corrects its path to `<SHA1>/Windows.zip`, not `<SHA1>`.

Currently, it uploads to both `<SHA1>` and `9c-launcher/<SHA1>/Windows.zip` because the internal script refers to the previous path, `<SHA1> yet. After updating the scripts, I'll stop the workflow to upload to `<SHA1>`.

You can see the binary at https://d3rgdei88xmq6p.cloudfront.net/9c-launcher/c8cb980844efaf758ec0e67f654185135c5125bf/Windows.zip