### PR TITLE
ci(circleci): stop uploading staled s3 artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ jobs:
             aws configure set aws_access_key_id $env:AWS_ACCESS_KEY
             aws configure set aws_secret_access_key $env:AWS_SECRET_KEY
 
-            aws s3 cp pack-dist/Windows.zip s3://9c-artifacts/$env:CIRCLE_SHA1
             aws s3 cp pack-dist/Windows.zip s3://9c-artifacts/9c-launcher/$env:CIRCLE_SHA1/Windows.zip
           name: Upload to S3
   styles:


### PR DESCRIPTION
# Description

This pull request's journey was started at #1120. And it was applied to deploy script at https://github.com/planetarium/k8s-config/commit/49ad9926c085709d73bd1fcf56040262ce72dd15. This is the time to stop uploading the incorrect path S3 artifact.