### PR TITLE
Add a checkbox to disable RPC when connection fails

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import {
   MIXPANEL_TOKEN,
   initializeNode,
   NodeInfo,
+  userConfigStore,
 } from "../config";
 import isDev from "electron-is-dev";
 import {
@@ -209,10 +210,12 @@ async function initializeApp() {
       remoteNode = await initializeNode();
     } catch (e) {
       console.error(e);
-      await dialog.showMessageBox(win!, {
+      const { checkboxChecked } = await dialog.showMessageBox(win!, {
         message: "Failed to connect remote node. please restart launcher.",
         type: "error",
-      });
+        checkboxLabel: "Disable RPC mode",
+      }); // TODO Replace with "go to error page" event
+      if (checkboxChecked) userConfigStore.set("UseRemoteHeadless", false);
 
       app.exit();
     }


### PR DESCRIPTION
This is a temporary measure to allow users to disable RPC mode if they are unable to connect to any of the remote nodes. The dialog looks like this:

![image](https://user-images.githubusercontent.com/7413880/148485333-6aee723b-27be-4409-9efd-b5e19b4ef032.png)
