### PR TITLE
Remove encounter version log

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -243,9 +243,6 @@ async function update(
   peerVersionExtra: string
 ) {
   if (peerVersionNumber <= localVersionNumber) {
-    console.log(
-      "Encountered version is not higher than the local version. Abort update."
-    );
     return;
   }
 


### PR DESCRIPTION
This log provides no useful information for debugging and it's often logged too much after every update and fills up the log. Fixes #1116.