### PR TITLE
Add configuration ui for log size

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "axios": "^0.21.2",
     "bencodex": "^0.1.1",
     "buffer": "^5.6.0",
+    "byte-parser": "^1.0.0",
     "cancellationtoken": "^2.2.0",
     "child-process-promise": "^2.2.1",
     "core-js": "^3.15.1",

--- a/src/interfaces/event.ts
+++ b/src/interfaces/event.ts
@@ -10,6 +10,7 @@ interface SettingsFormElement extends HTMLFormElement {
   select: HTMLInputElement;
   analytic: HTMLInputElement;
   sentry: HTMLInputElement;
+  logSize: HTMLInputElement;
 }
 
 export interface LoginFormEvent extends FormEvent<LoginFormElement> {

--- a/src/interfaces/event.ts
+++ b/src/interfaces/event.ts
@@ -10,7 +10,7 @@ interface SettingsFormElement extends HTMLFormElement {
   select: HTMLInputElement;
   analytic: HTMLInputElement;
   sentry: HTMLInputElement;
-  logSize: HTMLInputElement;
+  logsize: HTMLInputElement;
 }
 
 export interface LoginFormEvent extends FormEvent<LoginFormElement> {

--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -66,6 +66,9 @@ const ConfigurationView = observer(() => {
     const useRemoteHeadlessChecked = event.target.useRemoteHeadless.checked;
     userConfigStore.set("UseRemoteHeadless", useRemoteHeadlessChecked);
 
+    const logSize = event.target.logsize.value;
+    userConfigStore.set("LogSizeBytes", logSize);
+
     remote.app.relaunch();
     remote.app.exit();
   };
@@ -165,6 +168,16 @@ const ConfigurationView = observer(() => {
           >
             <T _str="Open Path" _tags={transifexTags} />
           </Button>
+
+          <FormLabel className={classes.newLine}>
+            <T _str="Log Size" _tags={transifexTags} />
+          </FormLabel>
+          <TextField
+            fullWidth
+            name="logsize"
+            className={classes.textField}
+            defaultValue={getConfig("LogSizeBytes")}
+          />
 
           <FormControl className={classes.checkboxGroup}>
             <FormLabel className={classes.newLine}>

--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -28,7 +28,7 @@ import { T, useLanguages, useLocale } from "@transifex/react";
 import { Select } from "../../components/Select";
 import ClearCacheButton from "../../components/ClearCacheButton";
 import log from "electron-log";
-import byteParse from "byte-parser"
+import byteParse from "byte-parser";
 
 const transifexTags = "configuration";
 
@@ -67,11 +67,14 @@ const ConfigurationView = observer(() => {
     const useRemoteHeadlessChecked = event.target.useRemoteHeadless.checked;
     userConfigStore.set("UseRemoteHeadless", useRemoteHeadlessChecked);
 
-    const logSize = event.target.logsize.value
+    const logSize = event.target.logsize.value;
     try {
       userConfigStore.set("LogSizeBytes", byteParse(logSize));
     } catch (e) {
-      userConfigStore.set("LogSizeBytes", parseInt(logSize.replace(/\D/g, ''), 10));
+      userConfigStore.set(
+        "LogSizeBytes",
+        parseInt(logSize.replace(/\D/g, ""), 10)
+      );
     }
 
     remote.app.relaunch();

--- a/src/renderer/views/config/ConfigurationView.tsx
+++ b/src/renderer/views/config/ConfigurationView.tsx
@@ -28,6 +28,7 @@ import { T, useLanguages, useLocale } from "@transifex/react";
 import { Select } from "../../components/Select";
 import ClearCacheButton from "../../components/ClearCacheButton";
 import log from "electron-log";
+import byteParse from "byte-parser"
 
 const transifexTags = "configuration";
 
@@ -66,8 +67,12 @@ const ConfigurationView = observer(() => {
     const useRemoteHeadlessChecked = event.target.useRemoteHeadless.checked;
     userConfigStore.set("UseRemoteHeadless", useRemoteHeadlessChecked);
 
-    const logSize = event.target.logsize.value;
-    userConfigStore.set("LogSizeBytes", logSize);
+    const logSize = event.target.logsize.value
+    try {
+      userConfigStore.set("LogSizeBytes", byteParse(logSize));
+    } catch (e) {
+      userConfigStore.set("LogSizeBytes", parseInt(logSize.replace(/\D/g, ''), 10));
+    }
 
     remote.app.relaunch();
     remote.app.exit();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5982,6 +5982,11 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+byte-parser@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/byte-parser/-/byte-parser-1.0.0.tgz#93ba24737860410827f55eeb81e5b80660aacfd8"
+  integrity sha512-zvGPc9QyjgzpRN7iOU/FzHcTnIMPAZykM9HyWlIOu8hPu1q+TxjsKCi1xi8tbZQGyvIUUB/mRIlZDst3gyyznQ==
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"


### PR DESCRIPTION
Add configuration ui for log size in setting.
Input value is string and parses it into bytes.

Issue [#1151](https://github.com/planetarium/9c-launcher/issues/1151#issue-1101183960)