### PR TITLE
Fix Quit Launcher to work without Mixpanel

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -145,7 +145,7 @@ if (!app.requestSingleInstanceLock()) {
 
   let quitTracked = false;
   app.on("before-quit", (event) => {
-    if (mixpanel !== null && !quitTracked) {
+    if (mixpanel != null && !quitTracked) {
       event.preventDefault();
       mixpanel?.track("Launcher/Quit", undefined, () => {
         quitTracked = true;


### PR DESCRIPTION
!=== checks for null only, while != checks for undefined too.