### PR TITLE
Pin @planetarium/cli to ~0.26.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@graphql-codegen/typescript-operations": "^1.15.4",
     "@graphql-codegen/typescript-react-apollo": "^1.15.4",
     "@graphql-codegen/typescript-resolvers": "^1.16.3",
-    "@planetarium/cli": "^0.9.5",
+    "@planetarium/cli": "~0.26.3",
     "@sentry/cli": "^1.54.0",
     "@sentry/webpack-plugin": "^1.11.1",
     "@storybook/addon-actions": "^6.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,10 +3697,10 @@
     "@planetarium/check-free-space-win32-arm64-msvc" "0.0.1"
     "@planetarium/check-free-space-win32-x64-msvc" "0.0.1"
 
-"@planetarium/cli@^0.9.5":
-  version "0.9.5"
-  resolved "https://registry.npmjs.org/@planetarium/cli/-/cli-0.9.5.tgz"
-  integrity sha512-N5FdWowcULHW8ayJFd6/AqaltSY9/0fL5SjoaYAw5EwEHo4wz4g3IQHLrGyprDXgZRuVyu+au2yggRbC/HtEyw==
+"@planetarium/cli@~0.26.3":
+  version "0.26.3"
+  resolved "https://registry.yarnpkg.com/@planetarium/cli/-/cli-0.26.3.tgz#b3590b5587490b1194dbebb1cca8306062d89a1e"
+  integrity sha512-NMdGUlVd5pySLtZDqYegHjo3LM4R72NuFnitP+BjuUBI5t0jwt4RGzDvRJRiq8nJ9xtME4uPuZ29W7y8WJC+Fg==
   dependencies:
     node-fetch "^2.6.0"
     unzipper "^0.10.11"


### PR DESCRIPTION
This is a temporary workaround to <https://github.com/planetarium/libplanet/issues/1790>.  It should use the latest version after <https://github.com/planetarium/libplanet/issues/1790> is fixed.