### PR TITLE
Strip 0x prefix when revoking a key

### DIFF
--- a/src/v2/views/RevokeView.tsx
+++ b/src/v2/views/RevokeView.tsx
@@ -44,7 +44,7 @@ function RevokeView() {
         onClick={() => {
           ipcRenderer.sendSync(
             "revoke-protected-private-key",
-            account.selectedAddress
+            account.selectedAddress.replace("0x", "")
           );
           account.removeAddress(account.selectedAddress);
           history.push("/");


### PR DESCRIPTION
The address should be given without the prefix, see this line: https://github.com/planetarium/9c-launcher/blob/1b9ea3c9aabf6f0e9e19b3371daced97dcd3fcc0/src/main/main.ts#L496