### PR TITLE
Prevent form enabling side button

### DIFF
--- a/src/v2/components/ui/TextField.tsx
+++ b/src/v2/components/ui/TextField.tsx
@@ -159,7 +159,7 @@ export const PasswordField = React.forwardRef<HTMLInputElement, TextFieldProps>(
         <Label htmlFor={id}>{label}</Label>
         {message && <Message invalid={invalid}>{message}</Message>}
         <Side>
-          <SideButton onClick={toggleVisible}>
+          <SideButton type="button" onClick={toggleVisible}>
             <Icon />
           </SideButton>
         </Side>


### PR DESCRIPTION
When pressing <kbd>Enter</kbd> key on password field the visibility button is triggered because by default, `<button>` element gets `submit` type. This PR aims to fix this by specifying the `button` type.

##### Reference
* [`<button>`: The button element, `type` Attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type)