### PR TITLE
Await for page load

### DIFF
--- a/src/main/v2/application.ts
+++ b/src/main/v2/application.ts
@@ -49,7 +49,7 @@ export async function createWindow(): Promise<BrowserWindow> {
     await win.loadURL("http://localhost:9000/v2.html");
     await win.webContents.openDevTools({ mode: "detach" });
   } else {
-    win.loadFile("v2.html");
+    await win.loadFile("v2.html");
   }
 
   return win;


### PR DESCRIPTION
This ensures the IPC event listeners are registered correctly when the createWindow has been resolved.