### PR TITLE
Fix Setting to be clickable when RPC host is long

### DIFF
--- a/src/renderer/views/layout/Layout.tsx
+++ b/src/renderer/views/layout/Layout.tsx
@@ -85,6 +85,15 @@ export const Layout: React.FC = observer(({ children }) => {
             );
           }}
         />
+        <div className="LauncherLayoutVersion">
+          block: {tip > 0 ? `#${tip}` : "loading.."}
+          <br />
+          {`version: v${
+            (getConfig("AppProtocolVersion") as string).split("/")[0]
+          }`}
+          <br />
+          node: {node}
+        </div>
         <ul className={"LauncherClientOption"}>
           <li>
             <Button
@@ -147,15 +156,6 @@ export const Layout: React.FC = observer(({ children }) => {
             </Button>
           </li>
         </ul>
-        <div className="LauncherLayoutVersion">
-          block: {tip > 0 ? `#${tip}` : "loading.."}
-          <br />
-          {`version: v${
-            (getConfig("AppProtocolVersion") as string).split("/")[0]
-          }`}
-          <br />
-          node: {node}
-        </div>
         <div
           id={"LauncherClientIcon"}
           className={`LauncherClientIcon ${infoButtonState ? "activate" : ""}`}


### PR DESCRIPTION
This fix ensures the menu items are still can be clicked when the RPC host gets too long. This bug hasn't been discovered when running on the mainnet because the host domain was rather short but it could cause some friction when connecting to other RPC servers.

This fix doesn't address some part of the host that gets hidden when the RPC host is too long; I've acknowledged this problem but it will be revisited on another PR.

## But this PR just changes the order of elements?
The stacking context depends on the order of the elements: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context