### PR TITLE
Move download folder into BlockchainStoreDirParent

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "electron-log": "^4.2.1",
     "electron-store": "^5.2.0",
     "extract-zip": "^2.0.1",
+    "fast-glob": "^3.2.11",
     "file-loader": "^6.0.0",
     "framer-motion": "^4.1.17",
     "graphql": "^15.4.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -591,7 +591,7 @@ async function initializeHeadless(): Promise<void> {
           isProcessSuccess = await snapshot.processSnapshot(
             snapshotDownloadUrl,
             chainPath,
-            app.getPath("userData"),
+            path.join(getConfig("BlockchainStoreDirParent"), "temp"),
             standalone,
             win,
             initializeHeadlessCts.token,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -69,6 +69,7 @@ import {
   setQuitting as setV2Quitting,
 } from "./v2/application";
 import { getFreeSpace } from "@planetarium/check-free-space";
+import fg from "fast-glob";
 import {
   checkForUpdates,
   cleanUpLockfile,
@@ -243,6 +244,13 @@ async function initializeApp() {
 
       app.exit();
     }
+
+    // Detects and move old snapshot caches as they're unused.
+    // Ignores any failure as they're not critical.
+    fg("snapshot-*", { cwd: app.getPath("userData") }).then((files) =>
+      Promise.allSettled(files.map((file) => fs.promises.unlink(file)))
+    );
+
     if (useRemoteHeadless) {
       console.log("main initializeApp call initializeRemoteHeadless");
       initializeRemoteHeadless();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10510,6 +10510,17 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.6.tgz#434dd9529845176ea049acc9343e8282765c6e1a"


### PR DESCRIPTION
This ensures users with insufficient space left on the main drive can play the game with another suitable data storage location.

- [ ] Make sure the former location is cleaned up.
	- `userData`, where the cache lies before this patch.
	- `{BlockchainStoreDirParent}/temp`, the newer location after this patch, but the path needs to be cleaned upon change.