### PR TITLE
Stop loading screen at error

### DIFF
--- a/src/collection/pages/main/main.tsx
+++ b/src/collection/pages/main/main.tsx
@@ -380,7 +380,9 @@ const Main: React.FC<Props> = (props: Props) => {
     setEdit(false);
     setOpenLoading(true);
 
-    collectionMutation();
+    collectionMutation().catch((e) => {
+      setOpenLoading(false);
+    });
   };
 
   const handleConfirmCancel = () => {


### PR DESCRIPTION
When the exception was thrown at the `collectionMutation` the collection screen just hung on the loading screen. Although the failure was rarely happening I thought it would be a nice thing to consider.