### PR TITLE
Add SnapshotThreshold property

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,10 @@ const schema: any = {
     type: "boolean",
     default: true,
   },
+  SnapshotThreshold: {
+    type: "number",
+    default: 0,
+  },
   TrustedAppProtocolVersionSigners: {
     type: "array",
     default: [

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -5,6 +5,7 @@ export interface IConfig {
   GenesisBlockPath: string;
   StoreType: string;
   NoMiner: boolean;
+  SnapshotThreshold: number;
   TrustedAppProtocolVersionSigners: string[];
   IceServerStrings: string[];
   PeerStrings: string[];

--- a/src/main/monosnapshot.ts
+++ b/src/main/monosnapshot.ts
@@ -12,7 +12,7 @@ import { DownloadSnapshotMetadataFailedError } from "./exceptions/download-snaps
 import { ExtractSnapshotFailedError } from "./exceptions/extract-snapshot-failed";
 import { ClearCacheException } from "./exceptions/clear-cache-exception";
 import { INineChroniclesMixpanel } from "./mixpanel";
-import { REQUIRED_DISK_SPACE } from "../config";
+import { get, REQUIRED_DISK_SPACE } from "../config";
 
 export async function downloadMetadata(
   basePath: string,
@@ -37,11 +37,17 @@ export async function downloadMetadata(
   }
 }
 
+/**
+ * Determines if we should download the snapshots.
+ * If this function retruns false, the headless will be launched immidiately.
+ */
 export function validateMetadata(
   localMetadata: BlockMetadata,
   snapshotMetadata: BlockMetadata
 ): boolean {
-  return snapshotMetadata.Index > localMetadata.Index;
+  return (
+    snapshotMetadata.Index > localMetadata.Index + get("SnapshotThreshold")
+  );
 }
 
 export async function downloadSnapshot(


### PR DESCRIPTION
This PR introduces `SnapshotThreshold` property which configures the block count to download snapshot or launch the headless.

### Unanswered concerns
* Should this property be configurable via UI?