### PR TITLE
Add checkbox to disable V2 interface

### DIFF
--- a/src/v2/views/SettingsOverlay/index.tsx
+++ b/src/v2/views/SettingsOverlay/index.tsx
@@ -192,6 +192,13 @@ function SettingsOverlay({ onClose, isOpen }: OverlayProps) {
           <Checkbox {...register("Sentry")}>
             <T _str="Report errors and bugs" _tags={transifexTags} />
           </Checkbox>
+
+          <GroupTitle>
+            <T _str="Experimental Features" _tags={transifexTags} />
+          </GroupTitle>
+          <Checkbox {...register("UseV2Interface")}>
+            <T _str="Use V2 Interface" _tags={transifexTags} />
+          </Checkbox>
         </FormSection>
       </Form>
       <Button


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7413880/160339660-fb365015-9db5-47cb-9069-a20c86f9f4b1.png)
The UI looks a bit dumb now. It should be reviewed on future versions.