### PR TITLE
Don't show block count when zero

### DIFF
--- a/src/v2/components/core/Layout/StatusBar.tsx
+++ b/src/v2/components/core/Layout/StatusBar.tsx
@@ -33,7 +33,7 @@ function StatusBar() {
     <StatusBarStyled>
       <StatusMessage>
         <span>{message}</span>
-        {blockCount && !isDone && <small>[{blockCount}]</small>}
+        {!!blockCount && !isDone && <small>[{blockCount}]</small>}
         {isDone && account.isLogin && !game.isGameStarted && (
           <Button
             variant="primary"


### PR DESCRIPTION
I almost forgot that zero is a falsy value. This aims to fix showing literal 0 on the screen.