### PR TITLE
Make left pane itself draggable

### DIFF
--- a/src/v2/components/core/Layout/index.tsx
+++ b/src/v2/components/core/Layout/index.tsx
@@ -32,10 +32,10 @@ const Sidebar = styled("main", {
   height: "100%",
   backgroundColor: "$gray",
   opacity: 0.95,
-  dragable: false,
   boxSizing: "border-box",
   padding: 52,
   "& > * + *": { marginTop: 16 },
+  "& > *": { dragable: false },
   paddingBottom: 104,
   variants: {
     flex: {


### PR DESCRIPTION
Because draggable elements aren't interactive, we make the children of the pane to be non-draggable.