### PR TITLE
Improve InfoText

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -12,3 +12,5 @@ declare module "*.module.scss" {
   const content: { [className: string]: string };
   export default content;
 }
+
+declare const GIT_HASH: string;

--- a/src/v2/components/core/Layout/InfoText.tsx
+++ b/src/v2/components/core/Layout/InfoText.tsx
@@ -30,6 +30,7 @@ function InfoText() {
         account.isLogin && `Account: ${account.selectedAddress}`,
         `Node: ${node}`,
         awsSinkGuid && `Client ID: ${awsSinkGuid}`,
+        `Commit: ${GIT_HASH}`,
       ]
         .filter(Boolean)
         .join("\n"),

--- a/src/v2/components/core/Layout/InfoText.tsx
+++ b/src/v2/components/core/Layout/InfoText.tsx
@@ -9,6 +9,7 @@ import {
   useTopmostBlocksQuery,
 } from "../../../generated/graphql";
 import { styled } from "src/v2/stitches.config";
+import toast from "react-hot-toast";
 
 const awsSinkGuid: string | undefined = ipcRenderer.sendSync(
   "get-aws-sink-cloudwatch-guid"
@@ -49,15 +50,10 @@ function InfoText() {
     [account.isLogin, loading, topmostBlocks, minedBlocks]
   );
 
-  const [copied, setCopied] = useState(false);
   const onClick = () => {
     clipboard.writeText(debugValue);
-    setCopied(true);
+    toast("Copied diagnostic inforomation.");
   };
-  useEffect(() => {
-    if (!copied) return;
-    setTimeout(() => setCopied(false), 1000);
-  }, [copied]);
 
   const { data: blockTip } = useTipSubscription();
   const [node, setNode] = useState<string>("loading");
@@ -79,7 +75,6 @@ function InfoText() {
       tip: {blockTip?.tipChanged?.index || 0}
       <br />
       {`version: v${getConfig("AppProtocolVersion").split("/")[0]}`}
-      {copied && " copied!"}
     </InfoTextStyled>
   );
 }

--- a/src/v2/components/core/Layout/InfoText.tsx
+++ b/src/v2/components/core/Layout/InfoText.tsx
@@ -7,6 +7,7 @@ import { get as getConfig, NodeInfo } from "../../../../config";
 import { useTipSubscription } from "../../../generated/graphql";
 import { styled } from "src/v2/stitches.config";
 import toast from "react-hot-toast";
+import { T } from "@transifex/react";
 
 const awsSinkGuid: string | undefined = ipcRenderer.sendSync(
   "get-aws-sink-cloudwatch-guid"
@@ -39,7 +40,7 @@ function InfoText() {
 
   const onClick = () => {
     clipboard.writeText(debugValue);
-    toast("Copied diagnostic inforomation.", {
+    toast(<T _str="Copied diagnostic inforomation." _tags="v2/diagnostics" />, {
       position: "bottom-left",
       id: "diagnostics-copied",
     });

--- a/src/v2/components/core/Layout/InfoText.tsx
+++ b/src/v2/components/core/Layout/InfoText.tsx
@@ -4,10 +4,7 @@ import { observer } from "mobx-react";
 import { useStore } from "../../../utils/useStore";
 import { clipboard, ipcRenderer } from "electron";
 import { get as getConfig, NodeInfo } from "../../../../config";
-import {
-  useTipSubscription,
-  useTopmostBlocksQuery,
-} from "../../../generated/graphql";
+import { useTipSubscription } from "../../../generated/graphql";
 import { styled } from "src/v2/stitches.config";
 import toast from "react-hot-toast";
 
@@ -24,39 +21,30 @@ const InfoTextStyled = styled("div", {
 
 function InfoText() {
   const account = useStore("account");
-  const { loading, data } = useTopmostBlocksQuery({ pollInterval: 1000 * 10 });
-  const topmostBlocks = data?.nodeStatus.topmostBlocks;
-
-  const minedBlocks = useMemo(
-    () =>
-      account.isLogin && topmostBlocks != null
-        ? topmostBlocks.filter((b) => b?.miner == account.selectedAddress)
-        : null,
-    [account.isLogin, topmostBlocks]
-  );
+  const [node, setNode] = useState<string>("loading");
 
   const debugValue = useMemo(
     () =>
       [
         `APV: ${getConfig("AppProtocolVersion")}`,
         account.isLogin && `Account: ${account.selectedAddress}`,
-        `Debug: ${account.isLogin} / ${loading}`,
-        minedBlocks &&
-          `Mined blocks: ${minedBlocks?.length} (out of recent ${topmostBlocks?.length} blocks)`,
+        `Node: ${node}`,
         awsSinkGuid && `Client ID: ${awsSinkGuid}`,
       ]
         .filter(Boolean)
         .join("\n"),
-    [account.isLogin, loading, topmostBlocks, minedBlocks]
+    [account.isLogin, account.selectedAddress, node, awsSinkGuid]
   );
 
   const onClick = () => {
     clipboard.writeText(debugValue);
-    toast("Copied diagnostic inforomation.");
+    toast("Copied diagnostic inforomation.", {
+      position: "bottom-left",
+      id: "diagnostics-copied",
+    });
   };
 
   const { data: blockTip } = useTipSubscription();
-  const [node, setNode] = useState<string>("loading");
 
   useEffect(
     () =>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,9 +8,15 @@ const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 const { version } = require("./package.json");
 const TerserPlugin = require("terser-webpack-plugin");
 
+const child_process = require("child_process");
+
 // const to avoid typos
 const DEVELOPMENT = "development";
 const PRODUCTION = "production";
+
+const gitHash = child_process.execSync("git rev-parse HEAD", {
+  encoding: "utf8",
+});
 
 /** @returns {import('webpack').Configuration} */
 function createRenderConfig(isDev) {
@@ -28,7 +34,7 @@ function createRenderConfig(isDev) {
       fallback: {
         os: false,
         fs: false,
-      }
+      },
     },
 
     mode: isDev ? DEVELOPMENT : PRODUCTION,
@@ -72,10 +78,7 @@ function createRenderConfig(isDev) {
         },
         {
           test: /\.css$/,
-          use: [
-            { loader: "style-loader" },
-            { loader: "css-loader" },
-          ],
+          use: [{ loader: "style-loader" }, { loader: "css-loader" }],
         },
         {
           test: /\.m?js/,
@@ -105,7 +108,10 @@ function createRenderConfig(isDev) {
                 ["@babel/plugin-proposal-decorators", { legacy: true }],
                 ["@babel/plugin-proposal-class-properties", { loose: true }],
                 ["@babel/plugin-proposal-private-methods", { loose: true }],
-                ["@babel/plugin-proposal-private-property-in-object", { loose: true }],
+                [
+                  "@babel/plugin-proposal-private-property-in-object",
+                  { loose: true },
+                ],
                 "react-hot-loader/babel",
               ],
               sourceMaps: isDev,
@@ -124,6 +130,10 @@ function createRenderConfig(isDev) {
     plugins: [
       new MiniCssExtractPlugin({
         filename: "main.css",
+      }),
+
+      new DefinePlugin({
+        GIT_HASH: JSON.stringify(gitHash),
       }),
 
       new HtmlPlugin({
@@ -153,11 +163,11 @@ function createRenderConfig(isDev) {
 
     devServer: isDev
       ? {
-        contentBase: path.join(__dirname, "dist"),
-        compress: true,
-        port: 9000,
-        historyApiFallback: true,
-      }
+          contentBase: path.join(__dirname, "dist"),
+          compress: true,
+          port: 9000,
+          historyApiFallback: true,
+        }
       : undefined,
 
     optimization: {
@@ -250,7 +260,10 @@ function createMainConfig(isDev) {
               plugins: [
                 ["@babel/plugin-proposal-class-properties", { loose: true }],
                 ["@babel/plugin-proposal-private-methods", { loose: true }],
-                ["@babel/plugin-proposal-private-property-in-object", { loose: true }]
+                [
+                  "@babel/plugin-proposal-private-property-in-object",
+                  { loose: true },
+                ],
               ],
             },
           },
@@ -326,8 +339,10 @@ module.exports = (env) => {
   }
 
   console.log(
-    `\n##\n## BUILDING BUNDLE FOR: ${target === "main" ? "main process" : "render process"
-    }\n## CONFIGURATION: ${isDev ? DEVELOPMENT : PRODUCTION
+    `\n##\n## BUILDING BUNDLE FOR: ${
+      target === "main" ? "main process" : "render process"
+    }\n## CONFIGURATION: ${
+      isDev ? DEVELOPMENT : PRODUCTION
     }\n## VERSION: ${version}\n##\n`
   );
 


### PR DESCRIPTION
## Added a toast message that shows up when you copy the diagnostics via click.

![Animation](https://user-images.githubusercontent.com/7413880/163524993-260731a2-fab7-4c29-af97-c2076c484965.gif)

## Update diagnostics to include only necessary information for 9C developers.
 - 'Debug', and 'Mined blocks' sections have been removed.
   - Most developers on the team didn't find these particularly useful, and it costs a lot to calculate which blocks have been mined by the current user.
 - RPC node host, and commit hash of the build are now included in diagnostics.
   - These data don't cost us any extra resources.