### PR TITLE
Remove TopBanner from Layout

### DIFF
--- a/src/renderer/views/layout/Layout.tsx
+++ b/src/renderer/views/layout/Layout.tsx
@@ -11,7 +11,6 @@ import { T } from "@transifex/react";
 import { get as getConfig, NodeInfo } from "../../../config";
 import AccountInfoContainer from "../../components/AccountInfo/AccountInfoContainer";
 import InfoIcon from "../../components/InfoIcon";
-import TopBanner from "../../components/TopBanner";
 
 import explorerLogo from "../../resources/block-explorer-logo.png";
 import patchNoteLogo from "../../resources/wrench.png";
@@ -75,7 +74,6 @@ export const Layout: React.FC = observer(({ children }) => {
 
   return (
     <>
-      <TopBanner />
       <main>{children}</main>
       <nav className="hero">
         <AccountInfoContainer


### PR DESCRIPTION
We won't get rid of TopBanner entirely since it's likely that we will use it somewhere in the future.