### PR TITLE
Use native controls on macos

### DIFF
--- a/src/main/v2/application.ts
+++ b/src/main/v2/application.ts
@@ -21,6 +21,7 @@ export async function createWindow(): Promise<BrowserWindow> {
     frame: false,
     resizable: false,
     autoHideMenuBar: true,
+    titleBarStyle: process.platform !== "win32" ? "hidden" : undefined,
     icon: join(app.getAppPath(), logoImage),
   });
 

--- a/src/main/v2/application.ts
+++ b/src/main/v2/application.ts
@@ -21,7 +21,7 @@ export async function createWindow(): Promise<BrowserWindow> {
     frame: false,
     resizable: false,
     autoHideMenuBar: true,
-    titleBarStyle: process.platform !== "win32" ? "hidden" : undefined,
+    titleBarStyle: process.platform === "darwin" ? "hidden" : undefined,
     icon: join(app.getAppPath(), logoImage),
   });
 

--- a/src/v2/components/core/Layout/index.tsx
+++ b/src/v2/components/core/Layout/index.tsx
@@ -77,7 +77,7 @@ function Layout({
         <Menu />
       </BottomControls>
       <InfoText />
-      <WindowControls />
+      {process.platform === "win32" && <WindowControls />}
     </Background>
   );
 }


### PR DESCRIPTION
<img width="1412" alt="스크린샷 2022-05-03 17 24 45" src="https://user-images.githubusercontent.com/42037851/166423773-093dd56d-b8ff-494a-a6ea-3fdd42cad26b.png">

I activated macOS native control use `process.platform`

@BasixKOR 