### PR TITLE
Correct `schema.graphql`

### DIFF
--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -462,7 +462,7 @@ type StakeRegularRewardRowType {
 }
 
 type StakeRegularRewardSheetType {
-  orderedList: [StakeRegularRewardRowType]
+  orderedList: [StakeRegularRewardRowType!]!
 }
 
 type StakeStateType {


### PR DESCRIPTION
Since f48a993e9936dce510a794e14b6714a2b820196e, the headless GraphQL type patch was applied. This commit synchronize `schema.graphql` with the schema of the headless.

----

I hope this pull request will resolve the `styles` check failure.