### PR TITLE
Introduce `migrate-monster-collection` command

### DIFF
--- a/src/main/headless/action.ts
+++ b/src/main/headless/action.ts
@@ -86,4 +86,22 @@ export class Action extends StandaloneSubcommand {
       return false;
     }
   }
+
+  public MigrateMonsterCollection(
+    avatarAddress: string,
+    path: string
+  ): boolean {
+    try {
+      this.execSync(
+        "action",
+        "migrate-monster-collection",
+        avatarAddress,
+        path
+      );
+      return true;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  }
 }

--- a/src/main/headless/headless.ts
+++ b/src/main/headless/headless.ts
@@ -114,6 +114,17 @@ class Headless {
     );
 
     ipcMain.on(
+      "migrate-monster-collection",
+      async (event, avatarAddress: string, filePath: string) => {
+        console.log("migrate-monster-collection");
+        event.returnValue = this.action.MigrateMonsterCollection(
+          avatarAddress,
+          filePath
+        );
+      }
+    );
+
+    ipcMain.on(
       "transfer-asset",
       async (
         event,


### PR DESCRIPTION
This pull request should be merged after merging #1445 PR

----

This pull request introduces the `migrate-monster-collection` headless nation command for the `MigrateMonsterCollection` lib9c action to migrate monster collection state to stake state. I'm sorry because I missed this part. I'll look for the part to apply this API.