### PR TITLE
Fix selectedIndex deps

### DIFF
--- a/src/v2/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -98,7 +98,7 @@ export function MonsterCollectionContent({
       amountDecimal.gte(v.requiredGold)
     );
     return index != null && index !== -1 ? index : null;
-  }, [sheet, levels]);
+  }, [amountDecimal, levels]);
 
   const isLockedUp =
     tip != null && !!stakeState && tip <= stakeState.cancellableBlockIndex;


### PR DESCRIPTION
This could have been prevented with [`react-hooks/exhaustive-deps`](https://reactjs.org/docs/hooks-rules.html#eslint-plugin)...