### PR TITLE
Replace useTipSubscription with useGetTipQuery

### DIFF
--- a/src/v2/components/core/Layout/InfoText.tsx
+++ b/src/v2/components/core/Layout/InfoText.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react";
 import { useStore } from "../../../utils/useStore";
 import { clipboard, ipcRenderer } from "electron";
 import { get as getConfig, NodeInfo } from "../../../../config";
-import { useTipSubscription } from "../../../generated/graphql";
+import { useGetTipQuery } from "../../../generated/graphql";
 import { styled } from "src/v2/stitches.config";
 import toast from "react-hot-toast";
 import { T } from "@transifex/react";
@@ -46,7 +46,9 @@ function InfoText() {
     });
   };
 
-  const { data: blockTip } = useTipSubscription();
+  const { data: blockTip } = useGetTipQuery({
+    pollInterval: 1000,
+  });
 
   useEffect(
     () =>
@@ -62,7 +64,7 @@ function InfoText() {
     <InfoTextStyled onClick={onClick}>
       node: {node}
       <br />
-      tip: {blockTip?.tipChanged?.index || 0}
+      tip: {blockTip?.nodeStatus.tip.index || 0}
       <br />
       {`version: v${getConfig("AppProtocolVersion").split("/")[0]}`}
     </InfoTextStyled>

--- a/src/v2/components/core/Layout/UserInfo/index.tsx
+++ b/src/v2/components/core/Layout/UserInfo/index.tsx
@@ -3,7 +3,6 @@ import { motion } from "framer-motion";
 import { styled } from "src/v2/stitches.config";
 import {
   TxStatus,
-  useTipSubscription,
   useTransactionResultLazyQuery,
 } from "src/v2/generated/graphql";
 import { useStore } from "src/v2/utils/useStore";

--- a/src/v2/utils/staking.ts
+++ b/src/v2/utils/staking.ts
@@ -1,7 +1,4 @@
-import {
-  useCurrentStakingQuery,
-  useTipSubscription,
-} from "../generated/graphql";
+import { useCurrentStakingQuery, useGetTipQuery } from "../generated/graphql";
 import { useStore } from "./useStore";
 
 export function useStaking() {
@@ -14,15 +11,18 @@ export function useStaking() {
   };
 
   const { data: current, refetch } = useCurrentStakingQuery(commonQuery);
-  const { data: tip } = useTipSubscription();
+  const { data: tip } = useGetTipQuery({
+    pollInterval: 1000,
+  });
 
   return {
     ...current?.stateQuery.stakeState,
-    tip: tip?.tipChanged?.index ?? 0,
+    tip: tip?.nodeStatus.tip ?? 0,
     canClaim:
-      !!tip?.tipChanged &&
+      !!tip &&
       !!current?.stateQuery.stakeState?.claimableBlockIndex &&
-      current.stateQuery.stakeState.claimableBlockIndex <= tip.tipChanged.index,
+      current.stateQuery.stakeState.claimableBlockIndex <=
+        tip.nodeStatus.tip.index,
     refetch,
   };
 }

--- a/src/v2/views/MonsterCollectionOverlay/index.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/index.tsx
@@ -10,6 +10,7 @@ import { placeholder, useTx } from "src/v2/utils/useTx";
 import {
   TxStatus,
   useCurrentStakingQuery,
+  useGetTipQuery,
   useStakingSheetQuery,
   useTipSubscription,
   useTransactionResultLazyQuery,
@@ -22,7 +23,9 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
     variables: { address: account.selectedAddress },
   });
   const balance = useBalance();
-  const { data: tip } = useTipSubscription();
+  const { data: tip } = useGetTipQuery({
+    pollInterval: 1000,
+  });
 
   const tx = useTx("stake", placeholder);
   const [
@@ -55,7 +58,7 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
             )
             .catch(console.error)
         }
-        tip={tip?.tipChanged?.index}
+        tip={tip?.nodeStatus.tip.index}
       />
     </MonsterCollectionOverlayBase>
   );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7413880/170937549-f0cd15b1-8415-4423-a919-c5b546951dba.png)

Changing UI every time a tip has changed had a serious negative impact on the performance of the launcher's UI. This PR reverted back to using `nodeStatus.tip.index` and polling them.