### PR TITLE
Track when launcher launches

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -233,6 +233,12 @@ async function initializeApp() {
         await update(u, updateOptions);
       });
 
+    mixpanel?.track("Launcher/Start", {
+      isV2,
+      useRemoteHeadless,
+      updateAvailable: !!u,
+    });
+
     try {
       remoteNode = await initializeNode();
     } catch (e) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -66,7 +66,7 @@ function App() {
     []
   );
 
-  function listenOnlineStatus() {
+  useEffect(() => {
     const updateOnlineStatus = () => {
       if (!navigator.onLine) {
         window.alert(
@@ -85,11 +85,11 @@ function App() {
 
     window.addEventListener("online", updateOnlineStatus);
     window.addEventListener("offline", updateOnlineStatus);
-  }
 
-  useEffect(() => {
-    ipcRenderer.send("mixpanel-track-event", "Launcher/Start");
-    listenOnlineStatus();
+    return () => {
+      window.removeEventListener("online", updateOnlineStatus);
+      window.removeEventListener("offline", updateOnlineStatus);
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Allows tracking whether the user is using the remote headless, and v2 interface.