### PR TITLE
Add query to fetch genesis hash

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -395,3 +395,11 @@ query StakingSheet {
     }
   }
 }
+
+query GenesisHash {
+  nodeStatus {
+    genesis {
+      hash
+    }
+  }
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -29,6 +29,10 @@ import type { NodeInfo } from "../config";
 import RPCSpinner from "./components/RPCSpinner/RPCSpinner";
 import { PreloadEndedDocument, PreloadEndedQuery } from "src/generated/graphql";
 import { Update } from "src/main/update";
+import {
+  GenesisHashDocument,
+  GenesisHashQuery,
+} from "src/v2/generated/graphql";
 
 const Store: IStoreContainer = {
   accountStore: new AccountStore(),
@@ -140,6 +144,18 @@ function App() {
           link: link,
           cache: new InMemoryCache(),
         });
+
+        client
+          .query<GenesisHashQuery>({
+            query: GenesisHashDocument,
+          })
+          .then((result) => {
+            if (!result.data) return;
+            ipcRenderer.send(
+              "set-genesis-hash",
+              result.data.nodeStatus.genesis.hash
+            );
+          });
 
         setClient(client);
       }

--- a/src/v2/utils/apolloClient.ts
+++ b/src/v2/utils/apolloClient.ts
@@ -13,7 +13,12 @@ import { RetryLink } from "@apollo/client/link/retry";
 import { useEffect, useState } from "react";
 import { NodeInfo } from "src/config";
 import isDev from "electron-is-dev";
-import { PreloadEndedDocument, PreloadEndedQuery } from "../generated/graphql";
+import {
+  GenesisHashDocument,
+  GenesisHashQuery,
+  PreloadEndedDocument,
+  PreloadEndedQuery,
+} from "../generated/graphql";
 import type { Update } from "src/main/update";
 
 type Client = ApolloClient<NormalizedCacheObject>;
@@ -68,6 +73,19 @@ export default function useApolloClient(): Client | null {
         cache: new InMemoryCache(),
         connectToDevTools: !isDev,
       });
+
+      client
+        .query<GenesisHashQuery>({
+          query: GenesisHashDocument,
+        })
+        .then((result) => {
+          if (!result.data) return;
+          ipcRenderer.send(
+            "set-genesis-hash",
+            result.data.nodeStatus.genesis.hash
+          );
+        });
+
       setApolloClient(client);
     })().catch(console.error);
   }, []);


### PR DESCRIPTION
This PR fetches the genesis hash of the node via GraphQL, which allows using the launcher on every compatible 9C chain.