### PR TITLE
Import V1 GraphQL generated code instead of V2

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -29,10 +29,7 @@ import type { NodeInfo } from "../config";
 import RPCSpinner from "./components/RPCSpinner/RPCSpinner";
 import { PreloadEndedDocument, PreloadEndedQuery } from "src/generated/graphql";
 import { Update } from "src/main/update";
-import {
-  GenesisHashDocument,
-  GenesisHashQuery,
-} from "src/v2/generated/graphql";
+import { GenesisHashDocument, GenesisHashQuery } from "src/generated/graphql";
 
 const Store: IStoreContainer = {
   accountStore: new AccountStore(),


### PR DESCRIPTION
This fixes white-screen errors happening on V1 users.