### PR TITLE
Replace onActionTxId with onConfirm

### DIFF
--- a/src/v2/components/core/Layout/UserInfo/index.tsx
+++ b/src/v2/components/core/Layout/UserInfo/index.tsx
@@ -23,6 +23,7 @@ import { useT } from "@transifex/react";
 import { useBalance } from "src/v2/utils/useBalance";
 import MonsterCollectionOverlay from "src/v2/views/MonsterCollectionOverlay";
 import { useStaking } from "src/v2/utils/staking";
+import { useTx, placeholder } from "src/v2/utils/useTx";
 
 const UserInfoStyled = styled(motion.ul, {
   position: "fixed",
@@ -83,6 +84,8 @@ export default function UserInfo() {
     return getRemain(minutes);
   }, [claimableBlockIndex, tip]);
 
+  const tx = useTx("claim-stake-reward", placeholder);
+
   const [claimLoading, setClaimLoading] = useState<boolean>(false);
   useEffect(() => setClaimLoading(false), [receivedBlockIndex]);
 
@@ -128,25 +131,23 @@ export default function UserInfo() {
           onClose={() => setOpenDialog(false)}
           tip={tip}
           rewards={[]} // FIXME: Unused. Should be removed.
-          onActionTxId={(txId, avatar) => {
-            if (avatar)
-              toast.success(
-                t("Successfully sent rewards to {name} #{address}", {
-                  _tags: "v2/monster-collection",
-                  name: avatar.name,
-                  address: avatar.address.slice(2, 6),
-                })
-              );
-
+          onConfirm={(avatar) => {
+            tx(avatar.address.replace(/^0x/, ""))
+              .then((v) => v.data?.stageTxV2)
+              .then((txId) => {
+                if (!txId) return;
+                fetchResult({ variables: { txId } });
+                toast.success(
+                  t("Successfully sent rewards to {name} #{address}", {
+                    _tags: "v2/monster-collection",
+                    name: avatar.name,
+                    address: avatar.address.slice(2, 6),
+                  })
+                );
+                setClaimLoading(true);
+              })
+              .catch((e) => console.error(e));
             setOpenDialog(false);
-            if (txId) {
-              setClaimLoading(true);
-              fetchResult({
-                variables: {
-                  txId,
-                },
-              });
-            }
           }}
         />
       </UserInfoItem>

--- a/src/v2/views/ClaimCollectionRewardsOverlay/ClaimContent.tsx
+++ b/src/v2/views/ClaimCollectionRewardsOverlay/ClaimContent.tsx
@@ -47,7 +47,7 @@ export interface Avatar {
 
 function ClaimContent({
   data,
-  onActionTxId,
+  onConfirm,
   rewards,
   tip,
   onClose,
@@ -73,16 +73,9 @@ function ClaimContent({
   ]);
   const hasMultipleAvatars = !avatars || avatars.length !== 1;
 
-  const tx = useTx(
-    "claim-stake-reward",
-    currentAvatar?.address.replace("0x", "")
-  );
-
   useEffect(() => {
-    if (hasMultipleAvatars || !isOpen) return;
-    tx().then(
-      (v) => v.data != null && onActionTxId(v.data.stageTxV2, currentAvatar)
-    );
+    if (hasMultipleAvatars || !isOpen || !currentAvatar) return;
+    onConfirm(currentAvatar);
   }, [avatars, isOpen]);
 
   if (!hasMultipleAvatars) return null;
@@ -117,17 +110,13 @@ function ClaimContent({
         ))}
       </RadioGroup>
       <ButtonBar placement="bottom">
-        <Button onClick={() => onActionTxId(null)}>
+        <Button onClick={() => onClose()}>
           <T _str="Cancel" _tags={transifexTags} />
         </Button>
         <Button
           variant="primary"
-          onClick={() =>
-            tx().then(
-              (v) =>
-                v.data != null && onActionTxId(v.data.stageTxV2, currentAvatar)
-            )
-          }
+          disabled={!currentAvatar}
+          onClick={() => currentAvatar && onConfirm(currentAvatar)}
         >
           <T _str="Send" _tags={transifexTags} />
         </Button>

--- a/src/v2/views/ClaimCollectionRewardsOverlay/index.tsx
+++ b/src/v2/views/ClaimCollectionRewardsOverlay/index.tsx
@@ -13,7 +13,7 @@ import ClaimContent, { Avatar } from "./ClaimContent";
 export interface ClaimCollectionRewardsOverlayProps extends OverlayProps {
   rewards: Reward[];
   tip: number;
-  onActionTxId: (txId: string | null, avatar?: Avatar) => void;
+  onConfirm(avatar: Avatar): void;
 }
 
 const transifexTags = "v2/views/ClaimCollectionRewardsOverlay";


### PR DESCRIPTION
## Motivation
ClaimContent stages `claim-stake-reward` action tx directly, effectively making it impossible to reuse it for other actions.

## Changes
ClaimContent no longer stages a tx.