### PR TITLE
Change the description of migration item 

### DIFF
--- a/src/v2/views/MonsterCollectionOverlay/Migration.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/Migration.tsx
@@ -65,7 +65,7 @@ export default function Migration({
               {deposit}
             </strong>
           </MigrationAlertItem>
-          <MigrationAlertItem title="Duration of progress">
+          <MigrationAlertItem title="Last updated">
             <span>
               <strong>{elapsed.number}</strong> {elapsed.unit}
               {elapsed.unit !== "blocks" && (


### PR DESCRIPTION
During development, I've noticed that the `startedBlockIndex` doesn't really represent the block index the user has started using Monster Collection. Since there's no correct way to show them, the caption has been changed.