### PR TITLE
Track staking events on Mixpanel

### DIFF
--- a/src/v2/components/core/Layout/UserInfo/index.tsx
+++ b/src/v2/components/core/Layout/UserInfo/index.tsx
@@ -17,7 +17,7 @@ import monsterIconUrl from "src/v2/resources/monster.png";
 import { getRemain } from "src/collection/common/utils";
 import ClaimCollectionRewardsOverlay from "src/v2/views/ClaimCollectionRewardsOverlay";
 import { ClaimButton } from "./ClaimButton";
-import { clipboard } from "electron";
+import { clipboard, ipcRenderer } from "electron";
 import { toast } from "react-hot-toast";
 import { useT } from "@transifex/react";
 import { useBalance } from "src/v2/utils/useBalance";
@@ -137,6 +137,10 @@ export default function UserInfo() {
               .then((txId) => {
                 if (!txId) return;
                 fetchResult({ variables: { txId } });
+                ipcRenderer.send("mixpanel-track-event", "Staking/Claim", {
+                  txId,
+                  avatar: avatar.address,
+                });
                 toast.success(
                   t("Successfully sent rewards to {name} #{address}", {
                     _tags: "v2/monster-collection",

--- a/src/v2/views/MonsterCollectionOverlay/index.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/index.tsx
@@ -95,7 +95,7 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
               ipcRenderer.send("mixpanel-track-event", "Staking/Migration", {
                 txId,
                 tip: tip.nodeStatus.tip.index,
-                amount: collection.stateQuery.monsterCollectionState?.level,
+                level: collection.stateQuery.monsterCollectionState?.level,
               });
               fetchStatus({ variables: { txId } });
             }}

--- a/src/v2/views/MonsterCollectionOverlay/index.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/index.tsx
@@ -17,6 +17,7 @@ import {
   useTransactionResultLazyQuery,
 } from "src/v2/generated/graphql";
 import Migration from "./Migration";
+import { ipcRenderer } from "electron";
 
 function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
   const account = useStore("account");
@@ -66,6 +67,10 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
         currentNCG={balance}
         onChangeAmount={(amount) => {
           setLoading(true);
+          ipcRenderer.send("mixpanel-track-event", "Staking/AmountChange", {
+            amount,
+            previousAmount: current.stateQuery.stakeState?.deposit,
+          });
           return tx(amount.toString())
             .then(
               (v) =>

--- a/src/v2/views/MonsterCollectionOverlay/index.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/index.tsx
@@ -92,6 +92,11 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
             collectionSheet={collection.stateQuery.monsterCollectionSheet}
             onActionTxId={(txId) => {
               setLoading(true);
+              ipcRenderer.send("mixpanel-track-event", "Staking/Migration", {
+                txId,
+                tip: tip.nodeStatus.tip.index,
+                amount: collection.stateQuery.monsterCollectionState?.level,
+              });
               fetchStatus({ variables: { txId } });
             }}
             onClose={onClose}


### PR DESCRIPTION
Currently emits:
 - **Staking/Claim**: An avatar address, and TxId.
 - **Staking/AmountChange**: A new amount and a previous amount.
 - **Staking/Migration**: A block index when the Tx initiated (inaccurate), TxId, and a level of migrated state.