### PR TITLE
Correct monster collection deposit

### DIFF
--- a/src/v2/views/MonsterCollectionOverlay/Migration.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/Migration.tsx
@@ -43,9 +43,10 @@ export default function Migration({
 
   const deposit = useMemo(
     () =>
-      collectionSheet?.orderedList?.find(
-        (v) => v?.level === collectionState.level
-      )?.requiredGold,
+      collectionSheet?.orderedList
+        ?.filter((v) => v?.level <= collectionState.level)
+        .map((v) => v.requiredGold)
+        .reduce((a, b) => a + b, 0),
     [collectionState, collectionSheet]
   );
   const elapsedBlocks = tip - collectionState.startedBlockIndex;

--- a/src/v2/views/MonsterCollectionOverlay/Migration.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/Migration.tsx
@@ -44,8 +44,9 @@ export default function Migration({
   const deposit = useMemo(
     () =>
       collectionSheet?.orderedList
-        ?.filter((v) => v?.level <= collectionState.level)
-        .map((v) => v.requiredGold)
+        ?.flatMap((item) =>
+          item && item.level <= collectionState.level ? item.requiredGold : []
+        )
         .reduce((a, b) => a + b, 0),
     [collectionState, collectionSheet]
   );


### PR DESCRIPTION
I opened this pull request to fix the monster collection deposit on the migration window. Monster Collection stored the total amount of monsters until the level. In other words, if you want to start a monster collection at the level 4, you have to store level 1's required gold, level 2's required gold, level 3's required gold, and level 4's required gold. So, it currently shows `54000` but should show `63500` (`500` + `1800` + `7200` + `54000`).

This pull request fixes it and you can see the logic at [planetarium/lib9c:Lib9c/Action/MonsterCollect.cs#L100-L103](https://github.com/planetarium/lib9c/blob/ccf8cb029939c0ea966f032045ae0a81b18bf78d/Lib9c/Action/MonsterCollect.cs#L100-L103).

```csharp
            for (int i = 0; i < level; i++)
            {
                requiredGold += currency * monsterCollectionSheet[i + 1].RequiredGold;
            }
```