### PR TITLE
Add mixpanel function

### DIFF
--- a/src/v2/components/core/Layout/UserInfo/index.tsx
+++ b/src/v2/components/core/Layout/UserInfo/index.tsx
@@ -24,6 +24,7 @@ import { useBalance } from "src/v2/utils/useBalance";
 import MonsterCollectionOverlay from "src/v2/views/MonsterCollectionOverlay";
 import { useStaking } from "src/v2/utils/staking";
 import { useTx, placeholder } from "src/v2/utils/useTx";
+import { trackEvent } from "src/v2/utils/mixpanel";
 
 const UserInfoStyled = styled(motion.ul, {
   position: "fixed",
@@ -137,7 +138,7 @@ export default function UserInfo() {
               .then((txId) => {
                 if (!txId) return;
                 fetchResult({ variables: { txId } });
-                ipcRenderer.send("mixpanel-track-event", "Staking/Claim", {
+                trackEvent("Staking/Claim", {
                   txId,
                   avatar: avatar.address,
                 });

--- a/src/v2/utils/mixpanel.ts
+++ b/src/v2/utils/mixpanel.ts
@@ -1,0 +1,9 @@
+import { ipcRenderer } from "electron";
+
+export function trackEvent(eventName: string, props: any) {
+  try {
+    ipcRenderer.send("mixpanel-track-event", eventName, props);
+  } catch (e) {
+    console.error("Error tracking event", e);
+  }
+}

--- a/src/v2/utils/mixpanel.ts
+++ b/src/v2/utils/mixpanel.ts
@@ -1,6 +1,6 @@
 import { ipcRenderer } from "electron";
 
-export function trackEvent(eventName: string, props: any) {
+export function trackEvent(eventName: string, props?: any) {
   try {
     ipcRenderer.send("mixpanel-track-event", eventName, props);
   } catch (e) {

--- a/src/v2/utils/usePreload.ts
+++ b/src/v2/utils/usePreload.ts
@@ -10,6 +10,7 @@ import {
 import { useStore } from "src/v2/utils/useStore";
 import { ipcRenderer } from "electron";
 import { useEffect, useMemo } from "react";
+import { trackEvent } from "./mixpanel";
 
 const statusMessage = [
   t("Idling"),
@@ -75,7 +76,7 @@ export function usePreload() {
     if (isEnded) {
       standalone.setReady(true);
       send("DONE");
-      ipcRenderer.send("mixpanel-track-event", `Launcher/Preload Completed`);
+      trackEvent(`Launcher/Preload Completed`);
     }
   }, [nodeStatusSubscriptionResult?.nodeStatus?.preloadEnded]);
 

--- a/src/v2/views/LoginView/index.tsx
+++ b/src/v2/views/LoginView/index.tsx
@@ -17,6 +17,7 @@ import { preloadService } from "src/v2/machines/preloadMachine";
 import { get } from "src/config";
 import toast from "react-hot-toast";
 import _refiner from "refiner-js";
+import { trackEvent } from "src/v2/utils/mixpanel";
 
 const transifexTags = "v2/login-view";
 
@@ -34,7 +35,7 @@ function LoginView() {
     );
     if (error !== undefined) {
       setInvalid(true);
-      ipcRenderer.send("mixpanel-track-event", "Launcher/LoginFailed");
+      trackEvent("Launcher/LoginFailed");
     }
 
     if (unprotectedPrivateKey !== undefined) {
@@ -42,7 +43,7 @@ function LoginView() {
       account.setPrivateKey(key);
       account.setLoginStatus(true);
       ipcRenderer.send("mixpanel-alias", account.selectedAddress);
-      ipcRenderer.send("mixpanel-track-event", "Launcher/Login");
+      trackEvent("Launcher/Login");
       ipcRenderer.send("standalone/set-signer-private-key", key);
 
       _refiner("setProject", "43e75b10-c10d-11ec-a73a-958e7574f4fc");

--- a/src/v2/views/MonsterCollectionOverlay/index.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/index.tsx
@@ -17,6 +17,7 @@ import {
 import Migration from "./Migration";
 import { ipcRenderer } from "electron";
 import { useTip } from "src/v2/utils/useTip";
+import { trackEvent } from "src/v2/utils/mixpanel";
 
 function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
   const account = useStore("account");
@@ -66,14 +67,10 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
         currentNCG={balance}
         onChangeAmount={(amount) => {
           setLoading(true);
-          try {
-            ipcRenderer.send("mixpanel-track-event", "Staking/AmountChange", {
-              amount: amount.toString(),
-              previousAmount: current.stateQuery.stakeState?.deposit,
-            });
-          } catch (e) {
-            console.error(e);
-          }
+          trackEvent("Staking/AmountChange", {
+            amount: amount.toString(),
+            previousAmount: current.stateQuery.stakeState?.deposit,
+          });
           return tx(amount.toString())
             .then(
               (v) =>
@@ -95,7 +92,7 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
             collectionSheet={collection.stateQuery.monsterCollectionSheet}
             onActionTxId={(txId) => {
               setLoading(true);
-              ipcRenderer.send("mixpanel-track-event", "Staking/Migration", {
+              trackEvent("Staking/Migration", {
                 txId,
                 tip,
                 level: collection.stateQuery.monsterCollectionState?.level,

--- a/src/v2/views/RegisterView/index.tsx
+++ b/src/v2/views/RegisterView/index.tsx
@@ -10,6 +10,7 @@ import { ipcRenderer } from "electron";
 import type { RawPrivateKey } from "src/main/headless/key-store";
 import { useHistory } from "react-router";
 import { CSS } from "src/v2/stitches.config";
+import { trackEvent } from "src/v2/utils/mixpanel";
 
 const registerStyles: CSS = {
   padding: 52,
@@ -37,7 +38,7 @@ function RegisterView() {
   const onSubmit = ({ password, activationKey }: FormData) => {
     if (!key) return;
 
-    ipcRenderer.send("mixpanel-track-event", "Launcher/CreatePrivateKey");
+    trackEvent("Launcher/CreatePrivateKey");
     ipcRenderer.sendSync("import-private-key", key.privateKey, password);
     const [privateKey, error]:
       | [string, undefined]


### PR DESCRIPTION
Sometimes tracking an event fails for various reasons. It might be an IPC issue, network or something else. However, any failure of tracking an event should not break the launcher itself; the tracking is entirely optional.

This PR makes the launcher more resilient to Mixpanel failures by handling unexpected errors.