### PR TITLE
Center reward item frame on collection

### DIFF
--- a/src/v2/views/MonsterCollectionOverlay/reward.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/reward.tsx
@@ -138,6 +138,8 @@ const ItemFrame = styled("div", {
   alignItems: "center",
   width: 94,
   height: 94,
+  marginLeft: "auto",
+  marginRight: "auto",
   backgroundImage: theme.images.itemBg,
   "> img": {
     display: "block",


### PR DESCRIPTION
Somehow I forgot to make a pull request.