### PR TITLE
Get rid of all eslint errors and add lint in CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,9 @@ jobs:
       - run:
           command: yarn tsc --noEmit
           name: Type Check
+      - run:
+          command: yarn eslint ./src --quiet
+          name: ESLint Check
   chromatic:
     docker:
       - image: cimg/node:lts

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,9 @@
     "plugin:@typescript-eslint/recommended",
     "prettier"
   ],
+  "ignorePatterns": [
+    "**/generated/**"
+  ],
   "rules": {
     "jsx-a11y/alt-text": 0,
     "react/prop-types": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,11 +11,13 @@
     "jsx-a11y/alt-text": 0,
     "react/prop-types": 0,
     "no-underscore-dangle": 0,
+    "no-constant-condition": 0,
     "import/first": "error",
     "import/newline-after-import": "error",
     "import/prefer-default-export": 0,
     "@typescript-eslint/no-inferrable-types": 0,
     "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/no-empty-function": 0,
     "@typescript-eslint/no-unused-vars": 0,
     "@typescript-eslint/ban-types": [
       "error",

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { GraphQLClient } from "graphql-request";
 import { getSdk } from "./generated/graphql-request";
 
 const { app } =
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
   process.type === "browser" ? require("electron") : require("electron").remote;
 
 const schema: any = {

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -3,8 +3,7 @@ import { Context, useContext } from "react";
 import { MobXProviderContext } from "mobx-react";
 import { IStoreContainer } from "../interfaces/store";
 
-// @ts-ignore
-const storeContext: Context<IStoreContainer> = MobXProviderContext;
+const storeContext: Context<IStoreContainer> = MobXProviderContext as any;
 
 export default function useStores() {
   return useContext(storeContext);

--- a/src/main/headless/headless.ts
+++ b/src/main/headless/headless.ts
@@ -326,7 +326,7 @@ class Headless {
       // FIXME: define a new interface or research the type exists.
       if (
         error instanceof Object &&
-        (error as Object).hasOwnProperty("status") &&
+        Object.prototype.hasOwnProperty.call(error, "status") &&
         error.status !== 0
       ) {
         return null;

--- a/src/main/headless/remoteHeadless.ts
+++ b/src/main/headless/remoteHeadless.ts
@@ -89,7 +89,7 @@ class RemoteHeadless {
       // FIXME: define a new interface or research the type exists.
       if (
         error instanceof Object &&
-        (error as Object).hasOwnProperty("status") &&
+        Object.prototype.hasOwnProperty.call(error, "status") &&
         error.status !== 0
       ) {
         return null;

--- a/src/main/v2/application.ts
+++ b/src/main/v2/application.ts
@@ -36,7 +36,10 @@ export async function createWindow(): Promise<BrowserWindow> {
       options.frame = true;
       options.resizable = true;
       options.webPreferences!.nodeIntegration = false;
-    } else event.preventDefault(), shell.openExternal(url);
+    } else {
+      event.preventDefault();
+      shell.openExternal(url);
+    }
   });
 
   win.on("close", function (event: any) {

--- a/src/renderer/DifferentAppProtocolVersionSubscriptionProvider.tsx
+++ b/src/renderer/DifferentAppProtocolVersionSubscriptionProvider.tsx
@@ -56,8 +56,7 @@ export const DifferentAppProtocolVersionSubscriptionProvider: React.FC = ({
       setCopyingState(false);
     });
 
-    //@ts-ignore
-    // Force-update function for developers (debug purpose)
+    // @ts-expect-error -- Force-update function for developers (debug purpose)
     window.updateLauncher = (url) => {
       const extra: string = encode({
         WindowsBinaryUrl: url,

--- a/src/renderer/IntroView.tsx
+++ b/src/renderer/IntroView.tsx
@@ -21,7 +21,8 @@ const IntroView = observer(({ accountStore, routerStore }: IStoreContainer) => {
     } else {
       const addresses = protectedPrivateKeys.map((value) => value?.address);
       addresses.map((value) => {
-        !accountStore.addresses.includes(value) && accountStore.addAddress(value);
+        !accountStore.addresses.includes(value) &&
+          accountStore.addAddress(value);
       });
 
       routerStore.push("/login");

--- a/src/renderer/IntroView.tsx
+++ b/src/renderer/IntroView.tsx
@@ -21,9 +21,7 @@ const IntroView = observer(({ accountStore, routerStore }: IStoreContainer) => {
     } else {
       const addresses = protectedPrivateKeys.map((value) => value?.address);
       addresses.map((value) => {
-        accountStore.addresses.includes(value)
-          ? null
-          : accountStore.addAddress(value);
+        !accountStore.addresses.includes(value) && accountStore.addAddress(value);
       });
 
       routerStore.push("/login");

--- a/src/renderer/components/Select.tsx
+++ b/src/renderer/components/Select.tsx
@@ -25,7 +25,6 @@ export const Select: React.FC<ISelectProps> = observer(
         id="select"
         variant="outlined"
         value={value}
-        // @ts-ignore
         onChange={handleChange}
         fullWidth
         {...props}

--- a/src/renderer/views/lobby/LobbyView.tsx
+++ b/src/renderer/views/lobby/LobbyView.tsx
@@ -62,7 +62,7 @@ const LobbyView = observer((props: ILobbyViewProps) => {
     (event: ChangeEvent<HTMLInputElement>) => {
       setActivationKey(event.target.value.trim());
     },
-    [event]
+    []
   );
 
   const { refetch: nonceRefetch } = useActivationKeyNonceQuery({

--- a/src/renderer/views/preload/PreloadProgressView.tsx
+++ b/src/renderer/views/preload/PreloadProgressView.tsx
@@ -130,7 +130,7 @@ const PreloadProgressView = observer(() => {
       }
     );
 
-    //@ts-ignore
+    // @ts-expect-error -- debug purpose
     window.relaunchStandalone = () => ipcRenderer.send("relaunch standalone");
   }, []);
 

--- a/src/transfer/stores/mockHeadless.ts
+++ b/src/transfer/stores/mockHeadless.ts
@@ -68,6 +68,7 @@ export default class MockedHeadlessStore implements IHeadlessStore {
         break;
       case "timeout":
         onTimeout(3, "blockHash");
+      // falls through
       default:
         onFailure(4, "blockHash");
     }

--- a/src/v2/Routes.tsx
+++ b/src/v2/Routes.tsx
@@ -32,9 +32,7 @@ const Redirector = observer(() => {
       history.replace("/welcome");
     } else {
       protectedPrivateKeys.filter(Boolean).map(({ address }) => {
-        account.addresses.includes(address)
-          ? null
-          : account.addAddress(address);
+        !account.addresses.includes(address) && account.addAddress(address);
       });
 
       history.replace("/login");

--- a/src/v2/utils/useTx.ts
+++ b/src/v2/utils/useTx.ts
@@ -109,8 +109,6 @@ export function useTx<K extends keyof ActionArguemnts>(
           if (res.data) console.log(event, parameters, res.data.stageTxV2);
           return res;
         });
-      } catch (e) {
-        throw e;
       } finally {
         inProgress.current = false;
       }

--- a/src/v2/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/v2/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -136,11 +136,9 @@ export function MonsterCollectionContent({
     setIsEditing(false);
   });
 
-  if (!levels) return null;
-
   const index = isEditing ? selectedIndex : currentIndex;
-  const rewards = levels[index!]?.rewards;
-  const bonusRewards = levels[index!]?.bonusRewards;
+  const rewards = levels?.[index!]?.rewards;
+  const bonusRewards = levels?.[index!]?.bonusRewards;
   const bonusRewardMap = useMemo(
     () =>
       bonusRewards &&
@@ -148,6 +146,8 @@ export function MonsterCollectionContent({
     [levels, index]
   );
   const currentAmount = isEditing || !deposit ? amountDecimal : deposit;
+
+  if (!levels) return null;
 
   return (
     <>


### PR DESCRIPTION
This partiallty resolves second TODO of #1565.

### rule justification
- "@typescript-eslint/no-empty-function"
All of use cases of empty functions were for preventing default action of certain callbacks or events.
eslint suggests leave explicit` //this is empty function` commentation, but I think we can just ignore it.
- no-constant-condition
It's needless to say that `while(true)` is more coherent than `while (typeof x === "undefined")` which [eslint suggests](https://eslint.org/docs/latest/rules/no-constant-condition) as alternative.