### PR TITLE
Replace new-window event with setWindowOpenHandler

### DIFF
--- a/src/main/v2/application.ts
+++ b/src/main/v2/application.ts
@@ -24,20 +24,21 @@ export async function createWindow(): Promise<BrowserWindow> {
     icon: join(app.getAppPath(), logoImage),
   });
   remoteEnable(win.webContents);
-  win.webContents.on("new-window", function (
-    event,
-    url: string,
-    _a,
-    _,
-    options
-  ) {
+  win.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith("https://stately.ai/viz?inspect")) {
-      options.frame = true;
-      options.resizable = true;
-      options.webPreferences!.nodeIntegration = false;
+      return {
+        action: "allow",
+        overrideBrowserWindowOptions: {
+          frame: true,
+          resizable: true,
+          webPreferences: {
+            nodeIntegration: false,
+          },
+        },
+      };
     } else {
-      event.preventDefault();
       shell.openExternal(url);
+      return { action: "deny" };
     }
   });
 


### PR DESCRIPTION
Replacing deprecated API before it gets deleted: https://www.electronjs.org/docs/latest/api/web-contents#event-new-window-deprecated