### PR TITLE
Make StatusBar shorter

### DIFF
--- a/src/v2/components/core/Layout/StatusBar.tsx
+++ b/src/v2/components/core/Layout/StatusBar.tsx
@@ -12,7 +12,7 @@ import { useHistory } from "react-router";
 const StatusBarStyled = styled("div", {
   display: "flex",
   flexDirection: "column",
-  width: 500,
+  width: 450,
 });
 
 const StatusMessage = styled("span", {


### PR DESCRIPTION
This prevents overlap with the sidebar on the left.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/7413880/183617804-598f7fc7-bd0d-471b-b701-03cb21fe345b.png) | ![image](https://user-images.githubusercontent.com/7413880/183617856-7539706c-0b4f-4809-9001-7db65731698f.png) |

