### PR TITLE
[Refactor] Doesn't import downloadUrl from apv extra data

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -196,6 +196,7 @@ export const CUSTOM_SERVER: boolean =
   RpcServerPort().notDefault;
 export const MIXPANEL_TOKEN = "80a1e14b57d050536185c7459d45195a";
 export const TRANSIFEX_TOKEN = "1/9ac6d0a1efcda679e72e470221e71f4b0497f7ab";
+export const DOWNLOAD_URI = "download.nine-chronicles.com";
 
 export async function initializeNode(): Promise<NodeInfo> {
   console.log("config initialize called");

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,0 +1,1 @@
+export const DOWNLOAD_URL = "https://download.nine-chronicles.com"

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,1 +1,0 @@
-export const DOWNLOAD_URL = "https://download.nine-chronicles.com";

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,1 +1,1 @@
-export const DOWNLOAD_URL = "https://download.nine-chronicles.com"
+export const DOWNLOAD_URL = "https://download.nine-chronicles.com";

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -108,16 +108,10 @@ export async function update(update: Update, listeners: IUpdateOptions) {
   const extra = decode(buffer) as BencodexDict;
   console.log("peerVersionExtra (decoded):", JSON.stringify(extra)); // Stringifies the JSON for extra clarity in the log
 
-  // FIXME: project version number hard coding: 1.
   const network = getConfig("Network", "9c-main");
+  const netenv = network === "9c-main" ? "main" : network;
 
-  let netenv;
-  if (network === "9c-main") {
-    netenv = "main";
-  } else {
-    netenv = network;
-  }
-
+  // FIXME: project version number hard coding: 1.
   const launcherDownloadUrl = getDownloadUrl(
     netenv,
     peerVersionNumber,
@@ -125,6 +119,7 @@ export async function update(update: Update, listeners: IUpdateOptions) {
     1,
     process.platform
   );
+  // FIXME: project version number hard coding: 1.
   const playerDownloadUrl = getDownloadUrl(
     netenv,
     peerVersionNumber,

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -13,7 +13,11 @@ import Headless from "../headless/headless";
 import lockfile from "lockfile";
 import { spawn as spawnPromise } from "child-process-promise";
 import { playerUpdate } from "./player-update";
-import { getDownloadUrl, getVersionNumberFromAPV, decodeLocalAPV } from "./util";
+import {
+  getDownloadUrl,
+  getVersionNumberFromAPV,
+  decodeLocalAPV,
+} from "./util";
 
 const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
 
@@ -61,7 +65,6 @@ export interface IUpdateOptions {
   getWindow(): Electron.BrowserWindow | null;
 }
 
-
 export async function update(update: Update, listeners: IUpdateOptions) {
   const localVersionNumber: number =
     update.current ?? getVersionNumberFromAPV(getConfig("AppProtocolVersion"));
@@ -106,8 +109,29 @@ export async function update(update: Update, listeners: IUpdateOptions) {
   console.log("peerVersionExtra (decoded):", JSON.stringify(extra)); // Stringifies the JSON for extra clarity in the log
 
   // FIXME: project version number hard coding: 1.
-  const launcherDownloadUrl = getDownloadUrl(peerVersionNumber, "launcher", 1, process.platform);
-  const playerDownloadUrl = getDownloadUrl(peerVersionNumber, "player", 1, process.platform);
+  const network = getConfig("Network", "9c-main");
+
+  let netenv;
+  if (network === "9c-main") {
+    netenv = "main";
+  } else {
+    netenv = network;
+  }
+
+  const launcherDownloadUrl = getDownloadUrl(
+    netenv,
+    peerVersionNumber,
+    "launcher",
+    1,
+    process.platform
+  );
+  const playerDownloadUrl = getDownloadUrl(
+    netenv,
+    peerVersionNumber,
+    "player",
+    1,
+    process.platform
+  );
 
   console.log("launcherDownloadUrl: ", launcherDownloadUrl);
   console.log("playerDownloadUrl: ", playerDownloadUrl);

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -13,6 +13,7 @@ import Headless from "../headless/headless";
 import lockfile from "lockfile";
 import { spawn as spawnPromise } from "child-process-promise";
 import { playerUpdate } from "./player-update";
+import { getDownloadUrl, getVersionNumberFromAPV, decodeLocalAPV } from "./util";
 
 const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
 
@@ -60,19 +61,6 @@ export interface IUpdateOptions {
   getWindow(): Electron.BrowserWindow | null;
 }
 
-function getVersionNumberFromAPV(apv: string): number {
-  const [version] = apv.split("/");
-  return parseInt(version, 10);
-}
-
-function decodeLocalAPV(): BencodexDict | undefined {
-  const localApvToken = getConfig("AppProtocolVersion");
-  const extra = Buffer.from(localApvToken.split("/")[1], "hex");
-
-  if (!extra.length) return;
-
-  return decode(extra) as BencodexDict | undefined;
-}
 
 export async function update(update: Update, listeners: IUpdateOptions) {
   const localVersionNumber: number =
@@ -116,33 +104,18 @@ export async function update(update: Update, listeners: IUpdateOptions) {
   console.log("peerVersionExtra (bytes):", buffer);
   const extra = decode(buffer) as BencodexDict;
   console.log("peerVersionExtra (decoded):", JSON.stringify(extra)); // Stringifies the JSON for extra clarity in the log
-  const macOSBinaryUrl = extra.get("macOSBinaryUrl") as string;
-  const macOSPlayerBinaryUrl = extra.get("macOSPlayerBinaryUrl") as string;
-  const windowsPlayerBinaryUrl = extra.get("WindowsPlayerBinaryUrl") as string;
-  const windowsBinaryUrl = extra.get("WindowsBinaryUrl") as string;
 
-  console.log("macOSBinaryUrl: ", macOSBinaryUrl);
-  console.log("WindowsBinaryUrl: ", windowsBinaryUrl);
-  console.log("macOSPlayerBinaryUrl: ", macOSPlayerBinaryUrl);
-  console.log("WindowsPlayerBinaryUrl: ", windowsPlayerBinaryUrl);
+  // FIXME: project version number hard coding: 1.
+  const launcherDownloadUrl = getDownloadUrl(peerVersionNumber, "launcher", 1, process.platform);
+  const playerDownloadUrl = getDownloadUrl(peerVersionNumber, "player", 1, process.platform);
 
-  const downloadUrl =
-    process.platform === "win32"
-      ? windowsBinaryUrl
-      : process.platform === "darwin"
-      ? macOSBinaryUrl
-      : null;
-  const playerDownloadUrl =
-    process.platform === "win32"
-      ? windowsPlayerBinaryUrl
-      : process.platform === "darwin"
-      ? macOSPlayerBinaryUrl
-      : null;
+  console.log("launcherDownloadUrl: ", launcherDownloadUrl);
+  console.log("playerDownloadUrl: ", playerDownloadUrl);
 
-  if (downloadUrl == null) {
-    console.log(`Stop update process. Not support ${process.platform}.`);
-    return;
-  }
+  // if (launcherDownloadUrl == null) {
+  //   console.log(`Stop update process. Not support ${process.platform}.`);
+  //   return;
+  // }
 
   const compatVersion = BigInt(
     (extra.get("CompatiblityVersion") as string | number) ?? 0
@@ -181,19 +154,19 @@ export async function update(update: Update, listeners: IUpdateOptions) {
     onProgress: (status: IDownloadProgress) => {
       const percent = (status.percent * 100) | 0;
       console.log(
-        `Downloading ${downloadUrl}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
+        `Downloading ${launcherDownloadUrl}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
       );
       win?.webContents.send("update download progress", status);
     },
     directory: app.getPath("temp"),
   };
-  console.log("Starts to download:", downloadUrl);
+  console.log("Starts to download:", launcherDownloadUrl);
   let dl: DownloadItem | null | undefined;
   try {
-    dl = await download(win, downloadUrl, options);
+    dl = await download(win, launcherDownloadUrl, options);
   } catch (error) {
     win.webContents.send("go to error page", "download-binary-failed");
-    throw new DownloadBinaryFailedError(downloadUrl);
+    throw new DownloadBinaryFailedError(launcherDownloadUrl);
   }
 
   win.webContents.send("update download complete");

--- a/src/main/update/util.ts
+++ b/src/main/update/util.ts
@@ -1,7 +1,6 @@
-import { DOWNLOAD_URL } from "../constants";
 import { NotSupportedPlatformError } from "../exceptions/not-supported-platform";
 import { decode, BencodexDict } from "bencodex";
-import { get as getConfig } from "../../config";
+import { DOWNLOAD_URI, get as getConfig } from "../../config";
 
 export function getVersionNumberFromAPV(apv: string): number {
   const [version] = apv.split("/");
@@ -30,7 +29,7 @@ export function getDownloadUrl(
     throw new NotSupportedPlatformError(platform);
   }
 
-  return `${DOWNLOAD_URL}/${env}/v${rc}/${project}/v${projectVersion}/${fn}`;
+  return `https://${DOWNLOAD_URI}/${env}/v${rc}/${project}/v${projectVersion}/${fn}`;
 }
 
 const FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {
@@ -42,6 +41,6 @@ const FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {
   openbsd: null,
   sunos: null,
   win32: "win.zip",
-  cygwin: null,
+  cygwin: "win.zip",
   netbsd: null,
 };

--- a/src/main/update/util.ts
+++ b/src/main/update/util.ts
@@ -1,9 +1,7 @@
-
 import { DOWNLOAD_URL } from "../constants";
 import { NotSupportedPlatformError } from "../exceptions/not-supported-platform";
 import { decode, BencodexDict } from "bencodex";
 import { get as getConfig } from "../../config";
-
 
 export function getVersionNumberFromAPV(apv: string): number {
   const [version] = apv.split("/");
@@ -19,25 +17,31 @@ export function decodeLocalAPV(): BencodexDict | undefined {
   return decode(extra) as BencodexDict | undefined;
 }
 
-export function getDownloadUrl(rc: number, project: "player" | "launcher", projectVersion: number, platform: NodeJS.Platform): string {
-  const fn = FILENAME_MAP[platform]; // nullable
+export function getDownloadUrl(
+  env: string,
+  rc: number,
+  project: "player" | "launcher",
+  projectVersion: number,
+  platform: NodeJS.Platform
+): string {
+  const fn = FILENAME_MAP[platform];
 
   if (fn === null) {
     throw new NotSupportedPlatformError(platform);
   }
 
-  return `${DOWNLOAD_URL}/v${rc}/${project}/v${projectVersion}/${fn}`;
+  return `${DOWNLOAD_URL}/${env}/v${rc}/${project}/v${projectVersion}/${fn}`;
 }
 
-const FILENAME_MAP: {[k in NodeJS.Platform]: string | null} = {
-  "aix": null,
-  "android": null,
-  "darwin": "mac.tar.gz",
-  "freebsd": null,
-  "linux": null,
-  "openbsd": null,
-  "sunos": null,
-  "win32": "win.zip",
-  "cygwin": null,
-  "netbsd": null
-}
+const FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {
+  aix: null,
+  android: null,
+  darwin: "mac.tar.gz",
+  freebsd: null,
+  linux: null,
+  openbsd: null,
+  sunos: null,
+  win32: "win.zip",
+  cygwin: null,
+  netbsd: null,
+};

--- a/src/main/update/util.ts
+++ b/src/main/update/util.ts
@@ -1,0 +1,43 @@
+
+import { DOWNLOAD_URL } from "../constants";
+import { NotSupportedPlatformError } from "../exceptions/not-supported-platform";
+import { decode, BencodexDict } from "bencodex";
+import { get as getConfig } from "../../config";
+
+
+export function getVersionNumberFromAPV(apv: string): number {
+  const [version] = apv.split("/");
+  return parseInt(version, 10);
+}
+
+export function decodeLocalAPV(): BencodexDict | undefined {
+  const localApvToken = getConfig("AppProtocolVersion");
+  const extra = Buffer.from(localApvToken.split("/")[1], "hex");
+
+  if (!extra.length) return;
+
+  return decode(extra) as BencodexDict | undefined;
+}
+
+export function getDownloadUrl(rc: number, project: "player" | "launcher", projectVersion: number, platform: NodeJS.Platform): string {
+  const fn = FILENAME_MAP[platform]; // nullable
+
+  if (fn === null) {
+    throw new NotSupportedPlatformError(platform);
+  }
+
+  return `${DOWNLOAD_URL}/v${rc}/${project}/v${projectVersion}/${fn}`;
+}
+
+const FILENAME_MAP: {[k in NodeJS.Platform]: string | null} = {
+  "aix": null,
+  "android": null,
+  "darwin": "mac.tar.gz",
+  "freebsd": null,
+  "linux": null,
+  "openbsd": null,
+  "sunos": null,
+  "win32": "win.zip",
+  "cygwin": null,
+  "netbsd": null
+}


### PR DESCRIPTION
Related to https://github.com/planetarium/9c-launcher/issues/1706, https://github.com/planetarium/9c-launcher/pull/1731

Now, We don't import downloadUrl from apv extra data.
The downloadURL is created according to the version scheme, and the downloadURL attempts to update it assuming it exists.