### PR TITLE
Handle case where locale is unset

### DIFF
--- a/src/renderer/i18n/index.tsx
+++ b/src/renderer/i18n/index.tsx
@@ -20,7 +20,7 @@ const context = createContext<LocaleContext>({
 const { Provider } = context;
 
 export function LocaleProvider({ children }: React.PropsWithChildren<{}>) {
-  const [locale, setLocale] = useState(() => get("Locale"));
+  const [locale, setLocale] = useState(() => get("Locale") ?? "en");
 
   useEffect(() => {
     const unsubscribe = userConfigStore.onDidChange("Locale", (v) =>
@@ -37,8 +37,6 @@ export function LocaleProvider({ children }: React.PropsWithChildren<{}>) {
     tx.setCurrentLocale(locale);
 
     validateLocale(locale).then((valid) => valid || setLocale("en"));
-
-    userConfigStore.set("Locale", locale);
   }, [locale]);
 
   return <Provider value={{ locale }}>{children}</Provider>;


### PR DESCRIPTION
This bug left unnoticed because we always have included the Locale, but it wasn't the case for some and for extra safety this PR solves this issue.