### PR TITLE
[Feature] Add init player [temp]

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -198,6 +198,21 @@ export const MIXPANEL_TOKEN = "80a1e14b57d050536185c7459d45195a";
 export const TRANSIFEX_TOKEN = "1/9ac6d0a1efcda679e72e470221e71f4b0497f7ab";
 export const DEFAULT_DOWNLOAD_BASE_URL = "https://download.nine-chronicles.com";
 
+export const EXECUTE_PATH: {
+  [k in NodeJS.Platform]: string | null;
+} = {
+  aix: null,
+  android: null,
+  darwin: MAC_GAME_PATH,
+  freebsd: null,
+  linux: LINUX_GAME_PATH,
+  openbsd: null,
+  sunos: null,
+  win32: WIN_GAME_PATH,
+  cygwin: WIN_GAME_PATH,
+  netbsd: null,
+};
+
 export async function initializeNode(): Promise<NodeInfo> {
   console.log("config initialize called");
   const nodeList = await NodeList();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -7,9 +7,8 @@ import {
   configStore,
   get as getConfig,
   getBlockChainStorePath,
-  LINUX_GAME_PATH,
-  MAC_GAME_PATH,
   WIN_GAME_PATH,
+  EXECUTE_PATH,
   RPC_SERVER_HOST,
   RPC_SERVER_PORT,
   MIXPANEL_TOKEN,
@@ -136,21 +135,6 @@ const updateOptions: IUpdateOptions = {
   downloadStarted: quitAllProcesses,
   relaunchRequired: relaunch,
   getWindow: () => win,
-};
-
-const EXECUTE_PATH: {
-  [k in NodeJS.Platform]: string | null;
-} = {
-  aix: null,
-  android: null,
-  darwin: MAC_GAME_PATH,
-  freebsd: null,
-  linux: LINUX_GAME_PATH,
-  openbsd: null,
-  sunos: null,
-  win32: WIN_GAME_PATH,
-  cygwin: WIN_GAME_PATH,
-  netbsd: null,
 };
 
 client

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -6,13 +6,18 @@ import * as utils from "../../utils";
 import { IDownloadProgress } from "src/interfaces/ipc";
 import { tmpName } from "tmp-promise";
 import { DownloadBinaryFailedError } from "../exceptions/download-binary-failed";
-import { get as getConfig } from "../../config";
+import {
+  get as getConfig,
+  EXECUTE_PATH,
+  WIN_GAME_PATH,
+} from "../../config";
 import path from "path";
 import fs from "fs";
 import Headless from "../headless/headless";
 import lockfile from "lockfile";
 import { spawn as spawnPromise } from "child-process-promise";
 import { playerUpdate } from "./player-update";
+import { playerUpdateTemp } from "./player-update-temp";
 import {
   getDownloadUrl,
   getVersionNumberFromAPV,
@@ -74,6 +79,12 @@ export async function update(update: Update, listeners: IUpdateOptions) {
   const win = listeners.getWindow();
 
   if (peerVersionNumber <= localVersionNumber) {
+    const executePath = EXECUTE_PATH[process.platform] || WIN_GAME_PATH;
+
+    if (!fs.existsSync(executePath)) {
+        await playerUpdateTemp(win, listeners);
+    }
+
     return;
   }
 

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -6,11 +6,7 @@ import * as utils from "../../utils";
 import { IDownloadProgress } from "src/interfaces/ipc";
 import { tmpName } from "tmp-promise";
 import { DownloadBinaryFailedError } from "../exceptions/download-binary-failed";
-import {
-  get as getConfig,
-  EXECUTE_PATH,
-  WIN_GAME_PATH,
-} from "../../config";
+import { get as getConfig, EXECUTE_PATH, WIN_GAME_PATH } from "../../config";
 import path from "path";
 import fs from "fs";
 import Headless from "../headless/headless";
@@ -82,7 +78,7 @@ export async function update(update: Update, listeners: IUpdateOptions) {
     const executePath = EXECUTE_PATH[process.platform] || WIN_GAME_PATH;
 
     if (!fs.existsSync(executePath)) {
-        await playerUpdateTemp(win, listeners);
+      await playerUpdateTemp(win, listeners);
     }
 
     return;

--- a/src/main/update/player-update-temp.ts
+++ b/src/main/update/player-update-temp.ts
@@ -7,12 +7,8 @@ import fs from "fs";
 import extractZip from "extract-zip";
 import { spawn as spawnPromise } from "child-process-promise";
 import { get as getConfig } from "../../config";
-import {
-  getDownloadUrl,
-  getVersionNumberFromAPV,
-} from "./util";
+import { getDownloadUrl, getVersionNumberFromAPV } from "./util";
 import lockfile from "lockfile";
-
 
 const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
 
@@ -21,7 +17,6 @@ export interface IUpdateOptions {
   relaunchRequired(): void;
   getWindow(): Electron.BrowserWindow | null;
 }
-
 
 const playerTempPath = path.join(app.getPath("temp"), "player");
 const extractPath = path.join(app.getPath("userData"), "player");
@@ -48,8 +43,9 @@ export async function playerUpdateTemp(
     throw e;
   }
 
-
-  const localVersionNumber: number = getVersionNumberFromAPV(getConfig("AppProtocolVersion"));
+  const localVersionNumber: number = getVersionNumberFromAPV(
+    getConfig("AppProtocolVersion")
+  );
 
   if (win === null) {
     console.log("Stop update process because win is null.");

--- a/src/main/update/player-update-temp.ts
+++ b/src/main/update/player-update-temp.ts
@@ -1,0 +1,170 @@
+import { DownloadItem, app } from "electron";
+import { download, Options as ElectronDLOptions } from "electron-dl";
+import { IDownloadProgress } from "src/interfaces/ipc";
+import { DownloadBinaryFailedError } from "../exceptions/download-binary-failed";
+import path from "path";
+import fs from "fs";
+import extractZip from "extract-zip";
+import { spawn as spawnPromise } from "child-process-promise";
+import { get as getConfig } from "../../config";
+import {
+  getDownloadUrl,
+  getVersionNumberFromAPV,
+} from "./util";
+import lockfile from "lockfile";
+
+
+const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
+
+export interface IUpdateOptions {
+  downloadStarted(): Promise<void>;
+  relaunchRequired(): void;
+  getWindow(): Electron.BrowserWindow | null;
+}
+
+
+const playerTempPath = path.join(app.getPath("temp"), "player");
+const extractPath = path.join(app.getPath("userData"), "player");
+
+export async function playerUpdateTemp(
+  win: Electron.BrowserWindow | null,
+  listeners: IUpdateOptions
+) {
+  if (lockfile.checkSync(lockfilePath)) {
+    console.log(
+      "'encounter different version' event seems running already. Stop this flow."
+    );
+    return;
+  }
+
+  try {
+    lockfile.lockSync(lockfilePath);
+    console.log(
+      "Created 'encounter different version' lockfile at ",
+      lockfilePath
+    );
+  } catch (e) {
+    console.error("Error occurred during trying lock.");
+    throw e;
+  }
+
+
+  const localVersionNumber: number = getVersionNumberFromAPV(getConfig("AppProtocolVersion"));
+
+  if (win === null) {
+    console.log("Stop update process because win is null.");
+    return;
+  }
+
+  await listeners.downloadStarted();
+
+  const network = getConfig("Network", "9c-main");
+  const netenv = network === "9c-main" ? "main" : network;
+
+  // FIXME: project version number hard coding: 1.
+  const downloadUrl = getDownloadUrl(
+    netenv,
+    localVersionNumber,
+    "player",
+    1,
+    process.platform
+  );
+
+  win.webContents.send("update download started");
+
+  // TODO: It would be nice to have a continuous download feature.
+  const options: ElectronDLOptions = {
+    onStarted: (downloadItem: DownloadItem) => {
+      console.log("[player] Starts to download:", downloadItem);
+    },
+    onProgress: (status: IDownloadProgress) => {
+      const percent = (status.percent * 100) | 0;
+      console.log(
+        `[player] Downloading ${downloadUrl}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
+      );
+      win?.webContents.send("update download progress", status);
+    },
+    directory: playerTempPath,
+  };
+  console.log("[player] Starts to download:", downloadUrl);
+  let dl: DownloadItem | null | undefined;
+  try {
+    dl = await download(win, downloadUrl, options);
+  } catch (error) {
+    win.webContents.send("go to error page", "download-binary-failed");
+    throw new DownloadBinaryFailedError(downloadUrl);
+  }
+
+  win.webContents.send("update download complete");
+  const dlFname = dl?.getFilename();
+  const dlPath = dl?.getSavePath();
+  console.log("[player] Finished to download:", dlPath);
+
+  if (fs.existsSync(extractPath)) {
+    fs.rmdirSync(extractPath, { recursive: true });
+  } else {
+    fs.mkdirSync(extractPath);
+  }
+
+  console.log("[player] Clean up exists player");
+
+  console.log("[player] The 9C player installation path:", extractPath);
+  if (process.platform == "win32") {
+    // Unzip ZIP
+    console.log(
+      "[player] Start to extract the zip archive",
+      dlPath,
+      "to",
+      extractPath
+    );
+
+    await extractZip(dlPath, {
+      dir: extractPath,
+      onEntry: (_, zipfile) => {
+        const progress = zipfile.entriesRead / zipfile.entryCount;
+        win?.webContents.send("update extract progress", progress);
+      },
+    });
+    win.webContents.send("update extract complete");
+  } else if (process.platform == "darwin") {
+    // untar .tar.{gz,bz2}
+    const lowerFname = dlFname.toLowerCase();
+    const bz2 = lowerFname.endsWith(".tar.bz2") || lowerFname.endsWith(".tbz");
+    console.log(
+      "[player] Start to extract the tarball archive",
+      dlPath,
+      "to",
+      extractPath
+    );
+    try {
+      await spawnPromise(
+        "tar",
+        [`xvf${bz2 ? "j" : "z"}`, dlPath, "-C", extractPath],
+        { capture: ["stdout", "stderr"] }
+      );
+    } catch (e) {
+      console.error(`${e}:\n`, e.stderr);
+      throw e;
+    }
+    console.log(
+      "The tarball archive",
+      dlPath,
+      "has extracted to ",
+      extractPath
+    );
+  } else {
+    console.warn("[player] Not supported platform.");
+    return;
+  }
+
+  win.webContents.send("update copying progress");
+  win.webContents.send("update copying complete");
+
+  lockfile.unlockSync(lockfilePath);
+  console.log(
+    "Removed 'encounter different version' lockfile at ",
+    lockfilePath
+  );
+
+  listeners.relaunchRequired();
+}


### PR DESCRIPTION
If the player does not exist, run `player-update-temp` instead of `player-update`
The `player-update-temp` copied the player-update, but some differences are event request and lockfile