### PR TITLE
Drop Corepack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,7 @@ commands:
           keys:
             - yarn3-packages-{{ arch }}-{{ checksum "yarn.lock" }}
       - run:
-          command: |
-            corepack enable
-            yarn install --immutable
+          command: yarn install --immutable
           environment:
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       - save_cache:


### PR DESCRIPTION
Yarn has a built-in ability to run newer Yarn Berry if it finds `yarnPath` in `yarnrc.yml`, and it seems like Corepack is causing some build failures. This PR should reduce moving parts on our CI and thus make the process more reliable.