### PR TITLE
[Fix] File related bugs

### DIFF
--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -44,7 +44,7 @@ export async function playerUpdate(
   if (fs.existsSync(playerPath)) {
     fs.rmdirSync(playerPath, { recursive: true });
   } else {
-    fs.mkdirSync(playerPath);
+    fs.mkdirSync(playerPath, { recursive: true });
   }
 
   console.log("[player] Clean up exists player");

--- a/src/main/update/util.ts
+++ b/src/main/update/util.ts
@@ -59,5 +59,9 @@ export function cleanupOldPlayer() {
       : OLD_WIN_GAME_PATH
   );
 
-  fs.unlinkSync(oldPlayerPath);
+  try {
+    fs.unlinkSync(oldPlayerPath)
+  } catch(e) {
+    console.error("Player not found", e);
+  }
 }


### PR DESCRIPTION
1. [I added network info in playerPath](https://github.com/planetarium/9c-launcher/pull/1777), but an error occurs because the recursive option doesn't have.
2. The modified launcher doesn't have `9c.exe`, but the delete player script didn't handle the error