### PR TITLE
Fix tsc pre-commit hook command

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -10,8 +10,9 @@ pre-commit:
       glob: "*.{js,ts,jsx,tsx}"
       run: yarn prettier {staged_files} --write && git add {staged_files}
     typescript:
+      files: git diff --cached --name-only
       glob: "*.{js,ts,jsx,tsx}"
-      run: yarn tsc --noEmit {staged_files}
+      run: yarn tsc --noEmit
 post-checkout:
   # Reconfigure the environment after a git checkout.
   parallel: true


### PR DESCRIPTION
This fixes the tsc command to not give each files as an argument, thus letting TypeScript check files based on the tsconfig.json.