### PR TITLE
Use build-headless command for cache in E2E

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ commands:
       - run:
           command: |
             [ -d dist/publish ] || yarn build-headless:<< parameters.os >>
+          shell: bash
       - save_cache:
           key: headless-pub-<< parameters.os >>-{{ checksum "tree-hash" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
       - yarn-install
       - run: scripts/create-key.ps1
       - install-dotnet
-      - run: yarn build-headless
+      - build-headless
       - run: yarn build-prod
       - run: scripts/copy-config.ps1
       - run: yarn test


### PR DESCRIPTION
I'm expecting to see performance improvements on the E2E test times.