### PR TITLE
Fix restarting headless failure

### DIFF
--- a/src/main/headless/headless.ts
+++ b/src/main/headless/headless.ts
@@ -213,7 +213,7 @@ class Headless {
       }
 
       const node = execute(this._path, args);
-      node.addListener("exit", this.exitedHandler);
+      node.addListener("exit", this.exitedHandler.bind(this));
       NODESTATUS.Node = node;
     }
 


### PR DESCRIPTION
`this` was pointing the NodeJS child process instance, causing failures.

Regression from: https://github.com/planetarium/9c-launcher/commit/3715d76cbe861dec4b7a608b33dc0be7e9c11713
Fixes #1847 