### PR TITLE
[Fix] Rollback filename

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -204,7 +204,7 @@ export const CUSTOM_SERVER: boolean =
   RpcServerPort().notDefault;
 export const MIXPANEL_TOKEN = "80a1e14b57d050536185c7459d45195a";
 export const TRANSIFEX_TOKEN = "1/9ac6d0a1efcda679e72e470221e71f4b0497f7ab";
-export const DEFAULT_DOWNLOAD_BASE_URL = "https://download.nine-chronicles.com";
+export const DEFAULT_DOWNLOAD_BASE_URL = "https://release.nine-chronicles.com";
 
 export const EXECUTE_PATH: {
   [k in NodeJS.Platform]: string | null;

--- a/src/main/update/util.ts
+++ b/src/main/update/util.ts
@@ -35,13 +35,13 @@ export function getDownloadUrl(
 const FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {
   aix: null,
   android: null,
-  darwin: "mac.tar.gz",
+  darwin: "macOS.tar.gz",
   freebsd: null,
-  linux: "linux.tar.gz",
+  linux: "Linux.tar.gz",
   openbsd: null,
   sunos: null,
-  win32: "win.zip",
-  cygwin: "win.zip",
+  win32: "Windows.zip",
+  cygwin: "Windows.zip",
   netbsd: null,
 };
 


### PR DESCRIPTION
I have decided on the file name `win.zip`, `mac.tar.gz` but exists s3 file name is `Windows.zip`, `macOS.tar.gz`
We don't have a reason to change the file name, So I rollback file name
~~And fix default download base url~~