### PR TITLE
[Refactor] Separate update check

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -220,6 +220,7 @@ export const EXECUTE_PATH: {
   cygwin: WIN_GAME_PATH,
   netbsd: null,
 };
+export const baseUrl = get("DownloadBaseURL", DEFAULT_DOWNLOAD_BASE_URL);
 
 export async function initializeNode(): Promise<NodeInfo> {
   console.log("config initialize called");

--- a/src/interfaces/apv.ts
+++ b/src/interfaces/apv.ts
@@ -1,8 +1,8 @@
-export interface IApv {
+export interface ISimpleApv {
   version: number;
-  signature: string;
-  signer: string;
   extra: { [key: string]: string };
 }
-
-export type ISimpleApv = Pick<IApv, "version" | "extra">;
+export interface IApv extends ISimpleApv {
+  signature: string;
+  signer: string;
+}

--- a/src/interfaces/apv.ts
+++ b/src/interfaces/apv.ts
@@ -4,3 +4,5 @@ export interface IApv {
   signer: string;
   extra: { [key: string]: string };
 }
+
+export type ISimpleApv = Pick<IApv, "version" | "extra">;

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -29,6 +29,6 @@ export interface IConfig {
   LaunchPlayer: boolean;
   RemoteNodeList: string[];
   PreferLegacyInterface: boolean;
-  DownloadBaseURL: string | undefined;
+  DownloadBaseURL: string;
   UseUpdate: boolean;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -268,11 +268,13 @@ async function initializeApp() {
       getConfig("TrustedAppProtocolVersionSigners")
     );
 
-    if (context && !isV2) update(context, updateOptions);
-    else if (context && isV2)
-      ipcMain.handle("start update", async () => {
-        await update(context, updateOptions);
-      });
+    if (useUpdate) {
+      if (context && !isV2) update(context, updateOptions);
+      else if (context && isV2)
+        ipcMain.handle("start update", async () => {
+          await update(context, updateOptions);
+        });
+    }
 
     if (app.commandLine.hasSwitch("protocol"))
       send(win!, IPC_OPEN_URL, process.argv[process.argv.length - 1]);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,6 +16,7 @@ import {
   NodeInfo,
   userConfigStore,
   netenv,
+  baseUrl,
 } from "../config";
 import {
   app,
@@ -101,8 +102,7 @@ const standaloneExecutablePath = path.join(
   "NineChronicles.Headless.Executable"
 );
 
-const baseURL = getConfig("DownloadBaseURL", DEFAULT_DOWNLOAD_BASE_URL);
-const REMOTE_CONFIG_URL = `${baseURL}/9c-launcher-config.json`;
+const REMOTE_CONFIG_URL = `${baseUrl}/9c-launcher-config.json`;
 
 let win: BrowserWindow | null = null;
 let collectionWin: BrowserWindow | null = null;
@@ -255,15 +255,7 @@ async function initializeApp() {
     webEnable(win.webContents);
     createTray(path.join(app.getAppPath(), logoImage));
 
-    const context = await checkForUpdate(
-      standalone,
-      process.platform,
-      netenv,
-      getConfig("PeerStrings"),
-      baseURL,
-      getConfig("AppProtocolVersion"),
-      getConfig("TrustedAppProtocolVersionSigners")
-    );
+    const context = await checkForUpdate(standalone, process.platform);
 
     if (useUpdate && context) {
       if (!isV2) update(context, updateOptions);
@@ -334,12 +326,9 @@ function initializeIpc() {
       };
 
       const context = await checkForUpdateUsedPeersApv(
-        simpleApv,
         standalone,
-        process.platform,
-        netenv,
-        baseURL,
-        getConfig("AppProtocolVersion")
+        simpleApv,
+        process.platform
       );
       await update(context, updateOptions);
     }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,7 +15,6 @@ import {
   initializeNode,
   NodeInfo,
   userConfigStore,
-  netenv,
   baseUrl,
 } from "../config";
 import {
@@ -80,7 +79,7 @@ import {
   IUpdateOptions,
 } from "./update/launcher-update";
 import { performUpdate } from "./update/update";
-import { checkForUpdate, checkForUpdateUsedPeersApv } from "./update/check";
+import { checkForUpdate, checkForUpdateFromApv } from "./update/check";
 import { send } from "./v2/ipc";
 import {
   IPC_OPEN_URL,
@@ -325,7 +324,7 @@ function initializeIpc() {
         extra: extra ? Object.fromEntries(extra) : {},
       };
 
-      const update = await checkForUpdateUsedPeersApv(
+      const update = await checkForUpdateFromApv(
         standalone,
         simpleApv,
         process.platform

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -189,7 +189,7 @@ if (!app.requestSingleInstanceLock()) {
 
   cleanUp();
 
-  // intializeConfig();
+  intializeConfig();
   useRemoteHeadless = getConfig("UseRemoteHeadless");
   initializeApp();
   initializeIpc();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -73,11 +73,7 @@ import {
 } from "./v2/application";
 import { getFreeSpace } from "@planetarium/check-free-space";
 import fg from "fast-glob";
-import {
-  cleanUpLockfile,
-  isUpdating,
-  IUpdateOptions,
-} from "./update/launcher-update";
+import { cleanUpLockfile, isUpdating, IUpdateOptions } from "./update/update";
 import { performUpdate } from "./update/update";
 import { checkForUpdate, checkForUpdateFromApv } from "./update/check";
 import { send } from "./v2/ipc";

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -80,8 +80,7 @@ import {
 } from "./update/launcher-update";
 import {
   checkUpdateRequired,
-  IUpdateContext,
-  checkUpdateRequiredPeersApv,
+  checkUpdateRequiredUsedPeersApv,
 } from "./update/check";
 import { send } from "./v2/ipc";
 import {
@@ -322,7 +321,7 @@ async function initializeApp() {
 
 function initializeIpc() {
   ipcMain.on("encounter different version", async (_event, apv: IApv) => {
-    const context = await checkUpdateRequiredPeersApv(
+    const context = await checkUpdateRequiredUsedPeersApv(
       apv,
       standalone,
       process.platform,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -79,7 +79,7 @@ import {
   isUpdating,
   IUpdateOptions,
 } from "./update/launcher-update";
-import { update } from "./update/update";
+import { performUpdate } from "./update/update";
 import { checkForUpdate, checkForUpdateUsedPeersApv } from "./update/check";
 import { send } from "./v2/ipc";
 import {
@@ -255,13 +255,13 @@ async function initializeApp() {
     webEnable(win.webContents);
     createTray(path.join(app.getAppPath(), logoImage));
 
-    const context = await checkForUpdate(standalone, process.platform);
+    const update = await checkForUpdate(standalone, process.platform);
 
-    if (useUpdate && context) {
-      if (!isV2) update(context, updateOptions);
+    if (useUpdate && update) {
+      if (!isV2) performUpdate(update, updateOptions);
       else
         ipcMain.handle("start update", async () => {
-          await update(context, updateOptions);
+          await performUpdate(update, updateOptions);
         });
     }
 
@@ -271,7 +271,7 @@ async function initializeApp() {
     mixpanel?.track("Launcher/Start", {
       isV2,
       useRemoteHeadless,
-      updateAvailable: !!context,
+      updateAvailable: !!update,
     });
 
     try {
@@ -325,12 +325,12 @@ function initializeIpc() {
         extra: extra ? Object.fromEntries(extra) : {},
       };
 
-      const context = await checkForUpdateUsedPeersApv(
+      const update = await checkForUpdateUsedPeersApv(
         standalone,
         simpleApv,
         process.platform
       );
-      await update(context, updateOptions);
+      await performUpdate(update, updateOptions);
     }
   );
 

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -22,13 +22,13 @@ export async function checkForUpdate(
 ): Promise<IUpdateContext | null> {
   let peersApv;
   try {
-    peersApv = await getPeersApv(standalone, peerInfos, trustedApvSigners);
+    peersApv = getPeersApv(standalone, peerInfos, trustedApvSigners);
   } catch (e) {
     console.error(`getPeersApv Error ocurred ${e}:\n`, e.stderr);
     return null;
   }
 
-  const localApv = await getLocalApv(standalone, localApvToken);
+  const localApv = standalone.apv.analyze(localApvToken);
 
   if (peersApv.version > localApv.version)
     return {
@@ -49,7 +49,7 @@ export async function checkForUpdateUsedPeersApv(
   baseUrl: string,
   localApvToken: string
 ): Promise<IUpdateContext | null> {
-  const localApv = await getLocalApv(standalone, localApvToken);
+  const localApv = standalone.apv.analyze(localApvToken);
 
   if (peersApv.version > localApv.version)
     return {
@@ -77,11 +77,11 @@ export function checkCompatible(
   return true;
 }
 
-async function getPeersApv(
+function getPeersApv(
   standalone: Headless,
   peerInfos: string[],
   trustedApvSigners: string[]
-): Promise<IApv> {
+): IApv {
   if (peerInfos.length > 0) {
     const peerApvToken = standalone.apv.query(peerInfos[0]);
 
@@ -100,8 +100,4 @@ async function getPeersApv(
   }
 
   throw new GetPeersApvFailedError(`Empty peerInfos`);
-}
-
-async function getLocalApv(standalone: Headless, token: string): Promise<IApv> {
-  return standalone.apv.analyze(token);
 }

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -1,13 +1,12 @@
-import { IApv } from "src/interfaces/apv";
-import { parseExtraData } from "../../utils/apv";
+import { IApv, ISimpleApv } from "src/interfaces/apv";
 import { IDownloadUrls, getDownloadUrls } from "../../utils/url";
 import Headless from "../headless/headless";
 
 export class GetPeersApvFailedError extends Error {}
 
 export interface IUpdateContext {
-  newApv: IApv;
-  oldApv: IApv;
+  newApv: ISimpleApv;
+  oldApv: ISimpleApv;
   urls: IDownloadUrls;
 }
 
@@ -37,7 +36,7 @@ export async function checkUpdateRequired(
 
 // Could use overload function...
 export async function checkUpdateRequiredUsedPeersApv(
-  peersApv: IApv,
+  peersApv: ISimpleApv,
   standalone: Headless,
   platform: NodeJS.Platform,
   netenv: string,
@@ -57,15 +56,15 @@ export async function checkUpdateRequiredUsedPeersApv(
   return null;
 }
 
-export function checkCompatible(peersApv: IApv, localApv: IApv): boolean {
-  const peersApvExtra = parseExtraData(peersApv.extra);
-  const localApvExtra = parseExtraData(localApv.extra);
-
+export function checkCompatible(
+  peersApv: ISimpleApv,
+  localApv: ISimpleApv
+): boolean {
   const peersCompatVersion = BigInt(
-    (peersApvExtra.get("CompatiblityVersion") as string | number) ?? 0
+    (peersApv.extra["CompatiblityVersion"] as string | number) ?? 0
   );
   const localCompatVersion = BigInt(
-    (localApvExtra.get("CompatiblityVersion") as string | number) ?? 0
+    (localApv.extra["CompatiblityVersion"] as string | number) ?? 0
   );
 
   if (peersCompatVersion > localCompatVersion) {

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -61,7 +61,10 @@ export async function checkForUpdateUsedPeersApv(
   return null;
 }
 
-export function checkCompatible(
+/**
+ * Checks `CompatiblityVersion` to check if we can proceed with our updater.
+ */
+export function checkCompatiblity(
   peersApv: ISimpleApv,
   localApv: ISimpleApv
 ): boolean {

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -68,9 +68,9 @@ export function checkCompatible(
   );
 
   if (peersCompatVersion > localCompatVersion) {
-    return true;
+    return false;
   }
-  return false;
+  return true;
 }
 
 async function getPeersApv(

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -1,0 +1,115 @@
+import { IApv } from "src/interfaces/apv";
+import Headless from "../headless/headless";
+import { NotSupportedPlatformError } from "../exceptions/not-supported-platform";
+
+export class GetPeersApvFailedError extends Error {}
+
+export interface DownloadInfo {
+  launcher: string;
+  player: string;
+}
+
+export default async function checkForUpdates(
+  standalone: Headless,
+  // FIXME: should make config object
+  platform: NodeJS.Platform,
+  netenv: string,
+  peerInfos: string[],
+  baseUrl: string,
+  localApvToken: string,
+  trustedApvSigners: string[]
+): Promise<DownloadInfo | null> {
+  const peersApv = getPeersApv(standalone, peerInfos, trustedApvSigners);
+  const localApv = getLocalApv(standalone, localApvToken);
+
+  if (updateRequired(peersApv.version, localApv.version)) {
+    // FIXME: project version number hard coding: 1.
+    const launcherUrl = buildDownloadUrl(
+      baseUrl,
+      netenv,
+      peersApv.version,
+      "launcher",
+      1,
+      platform
+    );
+    const playerUrl = buildDownloadUrl(
+      baseUrl,
+      netenv,
+      peersApv.version,
+      "player",
+      1,
+      platform
+    );
+
+    return {
+      launcher: launcherUrl,
+      player: playerUrl,
+    };
+  }
+
+  return null;
+}
+
+function getPeersApv(
+  standalone: Headless,
+  peerInfos: string[],
+  trustedApvSigners: string[]
+): IApv {
+  if (peerInfos.length > 0) {
+    const peerApvToken = standalone.apv.query(peerInfos[0]);
+
+    if (peerApvToken !== null) {
+      if (standalone.apv.verify(trustedApvSigners, peerApvToken)) {
+        return standalone.apv.analyze(peerApvToken);
+      } else {
+        throw new GetPeersApvFailedError(
+          `Ignore APV[${peerApvToken}] due to failure to validating.`
+        );
+      }
+    }
+
+    throw new GetPeersApvFailedError(
+      `Empty peerApvToken, peerInfos: ${peerInfos}`
+    );
+  }
+
+  throw new GetPeersApvFailedError(`Empty peerInfos`);
+}
+
+function getLocalApv(standalone: Headless, token: string): IApv {
+  return standalone.apv.analyze(token);
+}
+
+function updateRequired(peersApvVersion: number, localApvVersion: number) {
+  return peersApvVersion > localApvVersion;
+}
+
+function buildDownloadUrl(
+  baseUrl: string,
+  env: string,
+  rc: number,
+  project: "player" | "launcher",
+  projectVersion: number,
+  platform: NodeJS.Platform
+): string {
+  const fn = FILENAME_MAP[platform];
+
+  if (fn === null) {
+    throw new NotSupportedPlatformError(platform);
+  }
+
+  return `${baseUrl}/${env}/v${rc}/${project}/v${projectVersion}/${fn}`;
+}
+
+const FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {
+  aix: null,
+  android: null,
+  darwin: "macOS.tar.gz",
+  freebsd: null,
+  linux: "Linux.tar.gz",
+  openbsd: null,
+  sunos: null,
+  win32: "Windows.zip",
+  cygwin: "Windows.zip",
+  netbsd: null,
+};

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -1,6 +1,7 @@
 import { IApv, ISimpleApv } from "src/interfaces/apv";
 import { IDownloadUrls, getDownloadUrls } from "../../utils/url";
 import Headless from "../headless/headless";
+import { get as getConfig, baseUrl, netenv } from "../../config";
 
 export class GetPeersApvFailedError extends Error {}
 
@@ -10,15 +11,13 @@ export interface IUpdateContext {
   urls: IDownloadUrls;
 }
 
+const peerInfos = getConfig("PeerStrings");
+const localApvToken = getConfig("AppProtocolVersion");
+const trustedApvSigners = getConfig("TrustedAppProtocolVersionSigners");
+
 export async function checkForUpdate(
   standalone: Headless,
-  platform: NodeJS.Platform,
-  // TODO: should make config object
-  netenv: string,
-  peerInfos: string[],
-  baseUrl: string,
-  localApvToken: string,
-  trustedApvSigners: string[]
+  platform: NodeJS.Platform
 ): Promise<IUpdateContext | null> {
   let peersApv;
   try {
@@ -42,12 +41,9 @@ export async function checkForUpdate(
 
 // FIXME: Could use overload function...
 export async function checkForUpdateUsedPeersApv(
-  peersApv: ISimpleApv,
   standalone: Headless,
-  platform: NodeJS.Platform,
-  netenv: string,
-  baseUrl: string,
-  localApvToken: string
+  peersApv: ISimpleApv,
+  platform: NodeJS.Platform
 ): Promise<IUpdateContext | null> {
   const localApv = standalone.apv.analyze(localApvToken);
 

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -5,7 +5,7 @@ import { get as getConfig, baseUrl, netenv } from "../../config";
 
 export class GetPeersApvFailedError extends Error {}
 
-export interface IUpdateContext {
+export interface IUpdate {
   newApv: ISimpleApv;
   oldApv: ISimpleApv;
   urls: IDownloadUrls;
@@ -18,7 +18,7 @@ const trustedApvSigners = getConfig("TrustedAppProtocolVersionSigners");
 export async function checkForUpdate(
   standalone: Headless,
   platform: NodeJS.Platform
-): Promise<IUpdateContext | null> {
+): Promise<IUpdate | null> {
   let peersApv;
   try {
     peersApv = getPeersApv(standalone, peerInfos, trustedApvSigners);
@@ -44,7 +44,7 @@ export async function checkForUpdateUsedPeersApv(
   standalone: Headless,
   peersApv: ISimpleApv,
   platform: NodeJS.Platform
-): Promise<IUpdateContext | null> {
+): Promise<IUpdate | null> {
   const localApv = standalone.apv.analyze(localApvToken);
 
   if (peersApv.version > localApv.version)

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -20,7 +20,14 @@ export async function checkUpdateRequired(
   localApvToken: string,
   trustedApvSigners: string[]
 ): Promise<IUpdateContext | null> {
-  const peersApv = await getPeersApv(standalone, peerInfos, trustedApvSigners);
+  let peersApv;
+  try {
+    peersApv = await getPeersApv(standalone, peerInfos, trustedApvSigners);
+  } catch (e) {
+    console.error(`getPeersApv Error ocurred ${e}:\n`, e.stderr);
+    return null;
+  }
+
   const localApv = await getLocalApv(standalone, localApvToken);
 
   if (updateRequired(peersApv.version, localApv.version))

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -1,7 +1,6 @@
 import { IApv } from "src/interfaces/apv";
-import { parseExtraData } from "src/utils/apv";
-import { IDownloadUrls, getDownloadUrls } from "src/utils/url";
-
+import { parseExtraData } from "../../utils/apv";
+import { IDownloadUrls, getDownloadUrls } from "../../utils/url";
 import Headless from "../headless/headless";
 
 export class GetPeersApvFailedError extends Error {}
@@ -36,7 +35,8 @@ export async function checkUpdateRequired(
   return null;
 }
 
-export async function checkUpdateRequiredPeersApv(
+// Could use overload function...
+export async function checkUpdateRequiredUsedPeersApv(
   peersApv: IApv,
   standalone: Headless,
   platform: NodeJS.Platform,

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -23,18 +23,17 @@ export async function checkUpdateRequired(
   const peersApv = await getPeersApv(standalone, peerInfos, trustedApvSigners);
   const localApv = await getLocalApv(standalone, localApvToken);
 
-  if (updateRequired(peersApv.version, localApv.version)) {
+  if (updateRequired(peersApv.version, localApv.version))
     return {
       newApv: peersApv,
       oldApv: localApv,
       urls: getDownloadUrls(baseUrl, netenv, peersApv.version, platform),
     };
-  }
 
   return null;
 }
 
-// Could use overload function...
+// FIXME: Could use overload function...
 export async function checkUpdateRequiredUsedPeersApv(
   peersApv: ISimpleApv,
   standalone: Headless,
@@ -45,13 +44,12 @@ export async function checkUpdateRequiredUsedPeersApv(
 ): Promise<IUpdateContext | null> {
   const localApv = await getLocalApv(standalone, localApvToken);
 
-  if (updateRequired(peersApv.version, localApv.version)) {
+  if (updateRequired(peersApv.version, localApv.version))
     return {
       newApv: peersApv,
       oldApv: localApv,
       urls: getDownloadUrls(baseUrl, netenv, peersApv.version, platform),
     };
-  }
 
   return null;
 }
@@ -67,9 +65,8 @@ export function checkCompatible(
     (localApv.extra["CompatiblityVersion"] as string | number) ?? 0
   );
 
-  if (peersCompatVersion > localCompatVersion) {
-    return false;
-  }
+  if (peersCompatVersion > localCompatVersion) return false;
+
   return true;
 }
 

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -192,17 +192,11 @@ export async function launcherUpdate(
     config
   );
 
-  await playerUpdate(context.urls.player, win);
-
   lockfile.unlockSync(lockfilePath);
   console.log(
     "Removed 'encounter different version' lockfile at ",
     lockfilePath
   );
-
-  // Restart
-  listeners.relaunchRequired();
-
   /*
       autoUpdater provided from Electron must code signed to work at macOS
       So we can't use it for now.

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -11,7 +11,7 @@ import fs from "fs";
 import lockfile from "lockfile";
 import { spawn as spawnPromise } from "child-process-promise";
 import { playerUpdate } from "./player-update";
-import { IUpdateContext, checkCompatible } from "./check";
+import { IUpdateContext } from "./check";
 
 const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
 
@@ -21,7 +21,7 @@ export interface IUpdateOptions {
   getWindow(): Electron.BrowserWindow | null;
 }
 
-export async function update(
+export async function launcherUpdate(
   context: IUpdateContext,
   listeners: IUpdateOptions
 ) {
@@ -56,27 +56,6 @@ export async function update(
   }
 
   await listeners.downloadStarted();
-
-  if (!checkCompatible(context.newApv, context.oldApv)) {
-    console.log(
-      `Stop update process. CompatiblityVersion is higher than current.`
-    );
-    win?.webContents.send("compatiblity-version-higher-than-current");
-    if (win) {
-      const { checkboxChecked } = await dialog.showMessageBox(win, {
-        type: "error",
-        message:
-          "Nine Chronicles has been updated but the update needs reinstallation due to techincal issues. Sorry for inconvenience.",
-        title: "Reinstallation required",
-        checkboxChecked: true,
-        checkboxLabel: "Open the installer page in browser",
-      });
-      if (checkboxChecked)
-        shell.openExternal("https://bit.ly/9c-manual-update");
-      app.exit(0);
-    }
-    return;
-  }
 
   win?.webContents.send("update download started");
   // TODO: It would be nice to have a continuous download feature.

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { DownloadItem, app } from "electron";
 import { download, Options as ElectronDLOptions } from "electron-dl";
 import extractZip from "extract-zip";
@@ -6,20 +7,10 @@ import { IDownloadProgress } from "src/interfaces/ipc";
 import { tmpName } from "tmp-promise";
 import { DownloadBinaryFailedError } from "../exceptions/download-binary-failed";
 import { get as getConfig } from "../../config";
-import path from "path";
 import fs from "fs";
-import lockfile from "lockfile";
 import { spawn as spawnPromise } from "child-process-promise";
-import { playerUpdate } from "./player-update";
 import { IUpdate } from "./check";
-
-const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
-
-export interface IUpdateOptions {
-  downloadStarted(): Promise<void>;
-  relaunchRequired(): void;
-  getWindow(): Electron.BrowserWindow | null;
-}
+import { IUpdateOptions } from "./update";
 
 export async function launcherUpdate(
   update: IUpdate,
@@ -35,24 +26,6 @@ export async function launcherUpdate(
   if (win === null) {
     console.log("Stop update process because win is null.");
     return;
-  }
-
-  if (lockfile.checkSync(lockfilePath)) {
-    console.log(
-      "'encounter different version' event seems running already. Stop this flow."
-    );
-    return;
-  }
-
-  try {
-    lockfile.lockSync(lockfilePath);
-    console.log(
-      "Created 'encounter different version' lockfile at ",
-      lockfilePath
-    );
-  } catch (e) {
-    console.error("Error occurred during trying lock.");
-    throw e;
   }
 
   await listeners.downloadStarted();
@@ -191,72 +164,4 @@ export async function launcherUpdate(
     "The existing and new configuration files has been merged:",
     config
   );
-
-  lockfile.unlockSync(lockfilePath);
-  console.log(
-    "Removed 'encounter different version' lockfile at ",
-    lockfilePath
-  );
-  /*
-      autoUpdater provided from Electron must code signed to work at macOS
-      So we can't use it for now.
-
-      FIXME: By attatching Squirell, make it update, later.
-
-      const { path: tmpPath } = await tmp.file({
-        postfix: ".json",
-        discardDescriptor: true,
-      });
-      const tmpFile = await fs.promises.open(tmpPath, "w");
-      const feedData = {
-        url: downloadUrl,
-      };
-
-      await tmpFile.writeFile(JSON.stringify(feedData), "utf8");
-      console.log(`Wrote a temp feed JSON file:`, tmpPath);
-      autoUpdater.setFeedURL({ url: `file://${tmpPath}` });
-
-      autoUpdater.on("error", (message) =>
-        console.error("AUTOUPDATER:ERROR", message)
-      );
-      autoUpdater.on("checking-for-update", () =>
-        console.error("AUTOUPDATER:CHECKING-FOR-UPDATE")
-      );
-      autoUpdater.on("update-available", () =>
-        console.error("AUTOUPDATER:UPDATE-AVAILABLE")
-      );
-      autoUpdater.on("update-not-available", () =>
-        console.error("AUTOUPDATER:UPDATE-NOT-AVAILABLE")
-      );
-      autoUpdater.on(
-        "update-downloaded",
-        (event, releaseNotes, releaseName, releaseDate, updateURL) =>
-          console.error(
-            "AUTOUPDATER:UPDATE-DOWNLOADED",
-            event,
-            releaseNotes,
-            releaseName,
-            releaseDate,
-            updateURL
-          )
-      );
-      autoUpdater.on("before-quit-for-update", () =>
-        console.error("AUTOUPDATER:BEFORE-QUIT-FOR-UPDATE")
-      );
-
-      autoUpdater.checkForUpdates();
-      */
-}
-
-export function isUpdating() {
-  return lockfile.checkSync(lockfilePath);
-}
-
-/**
- * unlock if lockfile locked.
- */
-export function cleanUpLockfile() {
-  if (lockfile.checkSync(lockfilePath)) {
-    lockfile.unlockSync(lockfilePath);
-  }
 }

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -1,4 +1,3 @@
-import { encode, decode, BencodexDict } from "bencodex";
 import { DownloadItem, app, dialog, shell } from "electron";
 import { download, Options as ElectronDLOptions } from "electron-dl";
 import extractZip from "extract-zip";
@@ -6,60 +5,15 @@ import * as utils from "../../utils";
 import { IDownloadProgress } from "src/interfaces/ipc";
 import { tmpName } from "tmp-promise";
 import { DownloadBinaryFailedError } from "../exceptions/download-binary-failed";
-import {
-  get as getConfig,
-  apvVersionNumber,
-  netenv,
-  EXECUTE_PATH,
-  WIN_GAME_PATH,
-} from "../../config";
+import { get as getConfig } from "../../config";
 import path from "path";
 import fs from "fs";
-import Headless from "../headless/headless";
 import lockfile from "lockfile";
 import { spawn as spawnPromise } from "child-process-promise";
 import { playerUpdate } from "./player-update";
-import { getDownloadUrl, decodeLocalAPV } from "./util";
+import { IUpdateContext, checkCompatible } from "./check";
 
 const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
-
-export interface Update {
-  current?: number;
-  newer: number;
-  extras: string;
-}
-
-export async function checkForUpdates(
-  standalone: Headless
-): Promise<Update | null> {
-  const peerInfos: string[] = getConfig("PeerStrings");
-  if (peerInfos.length > 0) {
-    const peerApvToken = standalone.apv.query(peerInfos[0]);
-    if (peerApvToken !== null) {
-      if (
-        standalone.apv.verify(
-          getConfig("TrustedAppProtocolVersionSigners"),
-          peerApvToken
-        )
-      ) {
-        const peerApv = standalone.apv.analyze(peerApvToken);
-        const localApvToken = getConfig("AppProtocolVersion");
-        const localApv = standalone.apv.analyze(localApvToken);
-
-        return {
-          current: localApv.version,
-          newer: peerApv.version,
-          extras: encode(peerApv.extra).toString("hex"),
-        };
-      } else {
-        console.log(
-          `Ignore APV[${peerApvToken}] due to failure to validating.`
-        );
-      }
-    }
-  }
-  return null;
-}
 
 export interface IUpdateOptions {
   downloadStarted(): Promise<void>;
@@ -67,55 +21,19 @@ export interface IUpdateOptions {
   getWindow(): Electron.BrowserWindow | null;
 }
 
-export async function update(update: Update, listeners: IUpdateOptions) {
+export async function update(
+  context: IUpdateContext,
+  listeners: IUpdateOptions
+) {
   if (!getConfig("UseUpdate", process.env.NODE_ENV === "production")) {
     console.log("`UseUpdate` option is false, Do not proceed update!");
     return;
   }
 
-  const localVersionNumber: number = update.current ?? apvVersionNumber;
-  const peerVersionNumber: number = update.newer;
-  const peerVersionExtra: string = update.extras;
-
   const win = listeners.getWindow();
 
   if (win === null) {
     console.log("Stop update process because win is null.");
-    return;
-  }
-
-  console.log("peerVersionExtra (hex):", peerVersionExtra);
-  const buffer = Buffer.from(peerVersionExtra, "hex");
-  console.log("peerVersionExtra (bytes):", buffer);
-  const extra = decode(buffer) as BencodexDict;
-  console.log("peerVersionExtra (decoded):", JSON.stringify(extra)); // Stringifies the JSON for extra clarity in the log
-
-  // FIXME: project version number hard coding: 1.
-  const launcherDownloadUrl = getDownloadUrl(
-    netenv,
-    peerVersionNumber,
-    "launcher",
-    1,
-    process.platform
-  );
-  // FIXME: project version number hard coding: 1.
-  const playerDownloadUrl = getDownloadUrl(
-    netenv,
-    peerVersionNumber,
-    "player",
-    1,
-    process.platform
-  );
-
-  console.log("launcherDownloadUrl: ", launcherDownloadUrl);
-  console.log("playerDownloadUrl: ", playerDownloadUrl);
-
-  if (peerVersionNumber <= localVersionNumber) {
-    const executePath = EXECUTE_PATH[process.platform] || WIN_GAME_PATH;
-
-    if (!fs.existsSync(executePath)) {
-      await playerUpdate(playerDownloadUrl, win);
-    }
     return;
   }
 
@@ -139,19 +57,7 @@ export async function update(update: Update, listeners: IUpdateOptions) {
 
   await listeners.downloadStarted();
 
-  // if (launcherDownloadUrl == null) {
-  //   console.log(`Stop update process. Not support ${process.platform}.`);
-  //   return;
-  // }
-
-  const compatVersion = BigInt(
-    (extra.get("CompatiblityVersion") as string | number) ?? 0
-  );
-  const currentCompatVersion = BigInt(
-    (decodeLocalAPV()?.get("CompatiblityVersion") as string | number) ?? 0
-  );
-
-  if (compatVersion > currentCompatVersion) {
+  if (!checkCompatible(context.newApv, context.oldApv)) {
     console.log(
       `Stop update process. CompatiblityVersion is higher than current.`
     );
@@ -181,19 +87,19 @@ export async function update(update: Update, listeners: IUpdateOptions) {
     onProgress: (status: IDownloadProgress) => {
       const percent = (status.percent * 100) | 0;
       console.log(
-        `Downloading ${launcherDownloadUrl}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
+        `Downloading ${context.urls.launcher}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
       );
       win?.webContents.send("update download progress", status);
     },
     directory: app.getPath("temp"),
   };
-  console.log("Starts to download:", launcherDownloadUrl);
+  console.log("Starts to download:", context.urls.launcher);
   let dl: DownloadItem | null | undefined;
   try {
-    dl = await download(win, launcherDownloadUrl, options);
+    dl = await download(win, context.urls.launcher, options);
   } catch (error) {
     win.webContents.send("go to error page", "download-binary-failed");
-    throw new DownloadBinaryFailedError(launcherDownloadUrl);
+    throw new DownloadBinaryFailedError(context.urls.launcher);
   }
 
   win.webContents.send("update download complete");
@@ -202,7 +108,7 @@ export async function update(update: Update, listeners: IUpdateOptions) {
   console.log("Finished to download:", dlPath);
 
   const extractPath =
-    process.platform == "darwin" // we should check whether it was executed from .app or from yarn dev.
+    process.platform === "darwin" // we should check whether it was executed from .app or from yarn dev.
       ? path.dirname(path.dirname(path.dirname(path.dirname(app.getAppPath()))))
       : path.dirname(path.dirname(app.getAppPath()));
   console.log("The 9C app installation path:", extractPath);
@@ -218,7 +124,7 @@ export async function update(update: Update, listeners: IUpdateOptions) {
   );
   console.log("The existing configuration:", bakConfig);
 
-  if (process.platform == "win32") {
+  if (process.platform === "win32") {
     // Windows can't replace or remove executable file
     // while process is up, so we should change name instead
     const src = app.getPath("exe");
@@ -252,7 +158,7 @@ export async function update(update: Update, listeners: IUpdateOptions) {
     } catch (e) {
       console.warn("Failed to remove temporary files from", tempDir, "\n", e);
     }
-  } else if (process.platform == "darwin" || process.platform == "linux") {
+  } else if (process.platform === "darwin" || process.platform === "linux") {
     // untar .tar.{gz,bz2}
     const lowerFname = dlFname.toLowerCase();
     const bz2 = lowerFname.endsWith(".tar.bz2") || lowerFname.endsWith(".tbz");
@@ -307,9 +213,7 @@ export async function update(update: Update, listeners: IUpdateOptions) {
     config
   );
 
-  if (playerDownloadUrl) {
-    await playerUpdate(playerDownloadUrl, win);
-  }
+  await playerUpdate(context.urls.player, win);
 
   lockfile.unlockSync(lockfilePath);
   console.log(

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -11,7 +11,7 @@ import fs from "fs";
 import lockfile from "lockfile";
 import { spawn as spawnPromise } from "child-process-promise";
 import { playerUpdate } from "./player-update";
-import { IUpdateContext } from "./check";
+import { IUpdate } from "./check";
 
 const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
 
@@ -22,7 +22,7 @@ export interface IUpdateOptions {
 }
 
 export async function launcherUpdate(
-  context: IUpdateContext,
+  update: IUpdate,
   listeners: IUpdateOptions
 ) {
   if (!getConfig("UseUpdate", process.env.NODE_ENV === "production")) {
@@ -66,19 +66,19 @@ export async function launcherUpdate(
     onProgress: (status: IDownloadProgress) => {
       const percent = (status.percent * 100) | 0;
       console.log(
-        `Downloading ${context.urls.launcher}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
+        `Downloading ${update.urls.launcher}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
       );
       win?.webContents.send("update download progress", status);
     },
     directory: app.getPath("temp"),
   };
-  console.log("Starts to download:", context.urls.launcher);
+  console.log("Starts to download:", update.urls.launcher);
   let dl: DownloadItem | null | undefined;
   try {
-    dl = await download(win, context.urls.launcher, options);
+    dl = await download(win, update.urls.launcher, options);
   } catch (error) {
     win.webContents.send("go to error page", "download-binary-failed");
-    throw new DownloadBinaryFailedError(context.urls.launcher);
+    throw new DownloadBinaryFailedError(update.urls.launcher);
   }
 
   win.webContents.send("update download complete");

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -1,4 +1,4 @@
-import { DownloadItem, app, dialog, shell } from "electron";
+import { DownloadItem, app } from "electron";
 import { download, Options as ElectronDLOptions } from "electron-dl";
 import extractZip from "extract-zip";
 import * as utils from "../../utils";

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -2,18 +2,11 @@ import { DownloadItem, app } from "electron";
 import { download, Options as ElectronDLOptions } from "electron-dl";
 import { IDownloadProgress } from "src/interfaces/ipc";
 import { DownloadBinaryFailedError } from "../exceptions/download-binary-failed";
-import path from "path";
 import fs from "fs";
 import extractZip from "extract-zip";
 import { spawn as spawnPromise } from "child-process-promise";
 import { cleanupOldPlayer } from "./util";
 import { playerPath } from "../../config";
-import lockfile from "lockfile";
-
-const lockfilePath = path.join(
-  path.dirname(app.getPath("exe")),
-  "player-lockfile"
-);
 
 export async function playerUpdate(
   downloadUrl: string,
@@ -22,24 +15,6 @@ export async function playerUpdate(
   if (win === null) {
     console.log("Stop update process because win is null.");
     return;
-  }
-
-  if (lockfile.checkSync(lockfilePath)) {
-    console.log(
-      "[player] 'encounter different version' event seems running already. Stop this flow."
-    );
-    return;
-  }
-
-  try {
-    lockfile.lockSync(lockfilePath);
-    console.log(
-      "[player] Created 'encounter different version' lockfile at ",
-      lockfilePath
-    );
-  } catch (e) {
-    console.error("[player] Error occurred during trying lock.");
-    throw e;
   }
 
   win.webContents.send("update player download started");
@@ -131,10 +106,4 @@ export async function playerUpdate(
   win.webContents.send("update player extract complete");
 
   await fs.promises.unlink(dlPath);
-
-  lockfile.unlockSync(lockfilePath);
-  console.log(
-    "[player] Removed 'encounter different version' lockfile at ",
-    lockfilePath
-  );
 }

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -17,8 +17,13 @@ const lockfilePath = path.join(
 
 export async function playerUpdate(
   downloadUrl: string,
-  win: Electron.BrowserWindow
+  win: Electron.BrowserWindow | null
 ) {
+  if (win === null) {
+    console.log("Stop update process because win is null.");
+    return;
+  }
+
   if (lockfile.checkSync(lockfilePath)) {
     console.log(
       "[player] 'encounter different version' event seems running already. Stop this flow."

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -74,11 +74,13 @@ export async function playerUpdate(
   const dlPath = dl?.getSavePath();
   console.log("[player] Finished to download:", dlPath);
 
-  if (fs.existsSync(playerPath)) {
+  const exists = await fs.promises.stat(playerPath).catch(() => false);
+
+  if (exists) {
     await fs.promises.rmdir(playerPath, { recursive: true });
-  } else {
-    await fs.promises.mkdir(playerPath, { recursive: true });
   }
+
+  await fs.promises.mkdir(playerPath, { recursive: true });
 
   console.log("[player] Clean up exists player");
 

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { app, dialog, shell } from "electron";
 
-import { IUpdateContext, checkCompatible } from "./check";
+import { IUpdateContext, checkCompatiblity } from "./check";
 import { launcherUpdate } from "./launcher-update";
 import { playerUpdate } from "./player-update";
 
@@ -30,7 +30,7 @@ export async function update(
 ) {
   const win = updateOptions.getWindow();
   if (context) {
-    if (!checkCompatible(context.newApv, context.oldApv)) {
+    if (!checkCompatiblity(context.newApv, context.oldApv)) {
       console.log(
         `Stop update process. CompatiblityVersion is higher than current.`
       );

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -53,6 +53,8 @@ export async function performUpdate(
   const win = updateOptions.getWindow();
 
   if (context) {
+    console.log(`Start launcher update, First check compatiblity.`);
+
     if (!checkCompatiblity(context.newApv, context.oldApv)) {
       console.log(
         `Stop update process. CompatiblityVersion is higher than current.`
@@ -79,9 +81,13 @@ export async function performUpdate(
 
     updateOptions.relaunchRequired();
   } else {
+    console.log(`Not required launcher update, Check player path.`);
+
     const exists = await fs.promises.stat(executePath).catch(() => false);
 
     if (!exists) {
+      console.log(`Player not exists. Start player update`);
+
       await playerUpdate(
         buildDownloadUrl(
           baseURL,

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { app, dialog, shell } from "electron";
 
-import { IUpdateContext, checkCompatiblity } from "./check";
+import { IUpdate, checkCompatiblity } from "./check";
 import { launcherUpdate } from "./launcher-update";
 import { playerUpdate } from "./player-update";
 
@@ -24,8 +24,8 @@ export interface IUpdateOptions {
 const baseURL = getConfig("DownloadBaseURL", DEFAULT_DOWNLOAD_BASE_URL);
 const executePath = EXECUTE_PATH[process.platform] || WIN_GAME_PATH;
 
-export async function update(
-  context: IUpdateContext | null,
+export async function performUpdate(
+  context: IUpdate | null,
   updateOptions: IUpdateOptions
 ) {
   const win = updateOptions.getWindow();

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -1,0 +1,70 @@
+import fs from "fs";
+import { app, dialog, shell } from "electron";
+
+import { IUpdateContext, checkCompatible } from "./check";
+import { launcherUpdate } from "./launcher-update";
+import { playerUpdate } from "./player-update";
+
+import {
+  DEFAULT_DOWNLOAD_BASE_URL,
+  get as getConfig,
+  WIN_GAME_PATH,
+  EXECUTE_PATH,
+  netenv,
+  apvVersionNumber,
+} from "../../config";
+import { buildDownloadUrl } from "../../utils/url";
+
+export interface IUpdateOptions {
+  downloadStarted(): Promise<void>;
+  relaunchRequired(): void;
+  getWindow(): Electron.BrowserWindow | null;
+}
+
+const baseURL = getConfig("DownloadBaseURL", DEFAULT_DOWNLOAD_BASE_URL);
+const executePath = EXECUTE_PATH[process.platform] || WIN_GAME_PATH;
+
+export async function update(
+  context: IUpdateContext | null,
+  updateOptions: IUpdateOptions
+) {
+  const win = updateOptions.getWindow();
+  if (context) {
+    if (!checkCompatible(context.newApv, context.oldApv)) {
+      console.log(
+        `Stop update process. CompatiblityVersion is higher than current.`
+      );
+      win?.webContents.send("compatiblity-version-higher-than-current");
+      if (win) {
+        const { checkboxChecked } = await dialog.showMessageBox(win, {
+          type: "error",
+          message:
+            "Nine Chronicles has been updated but the update needs reinstallation due to techincal issues. Sorry for inconvenience.",
+          title: "Reinstallation required",
+          checkboxChecked: true,
+          checkboxLabel: "Open the installer page in browser",
+        });
+        if (checkboxChecked)
+          shell.openExternal("https://bit.ly/9c-manual-update");
+        app.exit(0);
+      }
+      return;
+    }
+
+    await launcherUpdate(context, updateOptions);
+  } else {
+    if (!fs.existsSync(executePath)) {
+      await playerUpdate(
+        buildDownloadUrl(
+          baseURL,
+          netenv,
+          apvVersionNumber,
+          "player",
+          1,
+          process.platform
+        ),
+        win
+      );
+    }
+  }
+}

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -52,6 +52,9 @@ export async function update(
     }
 
     await launcherUpdate(context, updateOptions);
+    await playerUpdate(context.urls.player, win);
+
+    updateOptions.relaunchRequired();
   } else {
     const exists = await fs.promises.stat(executePath).catch(() => false);
 

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -53,7 +53,9 @@ export async function update(
 
     await launcherUpdate(context, updateOptions);
   } else {
-    if (!fs.existsSync(executePath)) {
+    const exists = await fs.promises.stat(executePath).catch(() => false);
+
+    if (!exists) {
       await playerUpdate(
         buildDownloadUrl(
           baseURL,

--- a/src/main/update/util.ts
+++ b/src/main/update/util.ts
@@ -1,49 +1,6 @@
-import { NotSupportedPlatformError } from "../exceptions/not-supported-platform";
-import { decode, BencodexDict } from "bencodex";
-import { DEFAULT_DOWNLOAD_BASE_URL, get as getConfig } from "../../config";
 import path from "path";
 import { app } from "electron";
 import fs from "fs";
-
-export function decodeLocalAPV(): BencodexDict | undefined {
-  const localApvToken = getConfig("AppProtocolVersion");
-  const extra = Buffer.from(localApvToken.split("/")[1], "hex");
-
-  if (!extra.length) return;
-
-  return decode(extra) as BencodexDict | undefined;
-}
-
-export function getDownloadUrl(
-  env: string,
-  rc: number,
-  project: "player" | "launcher",
-  projectVersion: number,
-  platform: NodeJS.Platform
-): string {
-  const fn = FILENAME_MAP[platform];
-
-  if (fn === null) {
-    throw new NotSupportedPlatformError(platform);
-  }
-
-  const baseURL = getConfig("DownloadBaseURL") || DEFAULT_DOWNLOAD_BASE_URL;
-
-  return `${baseURL}/${env}/v${rc}/${project}/v${projectVersion}/${fn}`;
-}
-
-const FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {
-  aix: null,
-  android: null,
-  darwin: "macOS.tar.gz",
-  freebsd: null,
-  linux: "Linux.tar.gz",
-  openbsd: null,
-  sunos: null,
-  win32: "Windows.zip",
-  cygwin: "Windows.zip",
-  netbsd: null,
-};
 
 export async function cleanupOldPlayer() {
   const OLD_MAC_GAME_PATH = "9c.app/Contents/MacOS/9c";

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,7 +31,6 @@ import RPCSpinner from "./components/RPCSpinner/RPCSpinner";
 import { PreloadEndedDocument, PreloadEndedQuery } from "src/generated/graphql";
 import { GenesisHashDocument, GenesisHashQuery } from "src/generated/graphql";
 import _refiner from "refiner-js";
-import { decodeApvExtra } from "../utils/apv";
 
 const Store: IStoreContainer = {
   accountStore: new AccountStore(),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -29,7 +29,6 @@ import { LocaleProvider } from "./i18n";
 import type { NodeInfo } from "../config";
 import RPCSpinner from "./components/RPCSpinner/RPCSpinner";
 import { PreloadEndedDocument, PreloadEndedQuery } from "src/generated/graphql";
-import { Update } from "src/main/update/launcher-update";
 import { GenesisHashDocument, GenesisHashQuery } from "src/generated/graphql";
 import _refiner from "refiner-js";
 
@@ -124,10 +123,7 @@ function App() {
                 .then(({ data }) => {
                   const apv = data!.nodeStatus.appProtocolVersion;
                   if (!apv) return;
-                  ipcRenderer.send("encounter different version", {
-                    newer: apv.version,
-                    extras: apv.extra,
-                  } as Update);
+                  ipcRenderer.send("encounter different version", apv);
                 });
             },
           },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,6 +31,7 @@ import RPCSpinner from "./components/RPCSpinner/RPCSpinner";
 import { PreloadEndedDocument, PreloadEndedQuery } from "src/generated/graphql";
 import { GenesisHashDocument, GenesisHashQuery } from "src/generated/graphql";
 import _refiner from "refiner-js";
+import { decodeApvExtra } from "../utils/apv";
 
 const Store: IStoreContainer = {
   accountStore: new AccountStore(),

--- a/src/renderer/DifferentAppProtocolVersionSubscriptionProvider.tsx
+++ b/src/renderer/DifferentAppProtocolVersionSubscriptionProvider.tsx
@@ -76,6 +76,7 @@ export const DifferentAppProtocolVersionSubscriptionProvider: React.FC = ({
       ipcRenderer.send(
         "encounter different version",
         differentAppProtocolVersionEncounter
+          .differentAppProtocolVersionEncounter.peerVersion
       );
     };
   }, []);

--- a/src/renderer/DifferentAppProtocolVersionSubscriptionProvider.tsx
+++ b/src/renderer/DifferentAppProtocolVersionSubscriptionProvider.tsx
@@ -7,7 +7,6 @@ import {
 } from "../generated/graphql";
 import { IDownloadProgress } from "../interfaces/ipc";
 import UpdateView from "./views/update/UpdateView";
-import { Update } from "src/main/update/launcher-update";
 
 export const DifferentAppProtocolVersionSubscriptionProvider: React.FC = ({
   children,
@@ -90,11 +89,10 @@ export const DifferentAppProtocolVersionSubscriptionProvider: React.FC = ({
       null !== data?.differentAppProtocolVersionEncounter &&
       undefined !== data?.differentAppProtocolVersionEncounter
     ) {
-      ipcRenderer.send("encounter different version", {
-        current: data.differentAppProtocolVersionEncounter.localVersion.version,
-        newer: data.differentAppProtocolVersionEncounter.peerVersion.version,
-        extras: data.differentAppProtocolVersionEncounter.peerVersion.extra,
-      } as Update);
+      ipcRenderer.send(
+        "encounter different version",
+        data.differentAppProtocolVersionEncounter.peerVersion
+      );
     }
   }, [loading, data]);
 

--- a/src/utils/apv.ts
+++ b/src/utils/apv.ts
@@ -1,7 +1,11 @@
 import { encode, decode, BencodexDict } from "bencodex";
 
-export function decodeAPV(token: string): BencodexDict | undefined {
-  const extra = Buffer.from(token.split("/")[1], "hex");
+export function decodeApv(token: string): BencodexDict | undefined {
+  return decodeApvExtra(token.split("/")[1]);
+}
+
+export function decodeApvExtra(rawExtra: string): BencodexDict | undefined {
+  const extra = Buffer.from(rawExtra, "hex");
 
   if (!extra.length) return;
 
@@ -10,15 +14,6 @@ export function decodeAPV(token: string): BencodexDict | undefined {
 
 export function encodeExtra(extra: { [key: string]: string }): string {
   return encode(extra).toString("hex");
-}
-
-export function parseExtraData(raw: { [key: string]: string }): BencodexDict {
-  const buffer = Buffer.from(encodeExtra(raw), "hex");
-  console.log("peerVersionExtra (bytes):", buffer);
-  const extra = decode(buffer) as BencodexDict;
-  console.log("peerVersionExtra (decoded):", JSON.stringify(extra)); // Stringifies the JSON for extra clarity in the log
-
-  return extra;
 }
 
 export function parseVersionNumber(apv: string): number {

--- a/src/utils/apv.ts
+++ b/src/utils/apv.ts
@@ -1,0 +1,27 @@
+import { encode, decode, BencodexDict } from "bencodex";
+
+export function decodeAPV(token: string): BencodexDict | undefined {
+  const extra = Buffer.from(token.split("/")[1], "hex");
+
+  if (!extra.length) return;
+
+  return decode(extra) as BencodexDict | undefined;
+}
+
+export function encodeExtra(extra: { [key: string]: string }): string {
+  return encode(extra).toString("hex");
+}
+
+export function parseExtraData(raw: { [key: string]: string }): BencodexDict {
+  const buffer = Buffer.from(encodeExtra(raw), "hex");
+  console.log("peerVersionExtra (bytes):", buffer);
+  const extra = decode(buffer) as BencodexDict;
+  console.log("peerVersionExtra (decoded):", JSON.stringify(extra)); // Stringifies the JSON for extra clarity in the log
+
+  return extra;
+}
+
+export function parseVersionNumber(apv: string): number {
+  const [version] = apv.split("/");
+  return parseInt(version, 10);
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -47,13 +47,13 @@ export function buildDownloadUrl(
   projectVersion: number,
   platform: NodeJS.Platform
 ): string {
-  const fn = BINARY_FILENAME_MAP[platform];
+  const filename = BINARY_FILENAME_MAP[platform];
 
-  if (fn === null) {
+  if (filename === null) {
     throw new NotSupportedPlatformError(platform);
   }
 
-  return `${baseUrl}/${env}/v${rc}/${project}/v${projectVersion}/${fn}`;
+  return `${baseUrl}/${env}/v${rc}/${project}/v${projectVersion}/${filename}`;
 }
 
 export const BINARY_FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,4 +1,4 @@
-import { NotSupportedPlatformError } from "src/main/exceptions/not-supported-platform";
+import { NotSupportedPlatformError } from "../main/exceptions/not-supported-platform";
 
 export interface IDownloadUrls {
   launcher: string;

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,9 @@
 import { NotSupportedPlatformError } from "../main/exceptions/not-supported-platform";
 
+const MACOS_FILE_NAME = "macOS.tar.gz";
+const LINUX_FILE_NAME = "Linux.tar.gz";
+const WINDOWS_FILE_NAME = "Windows.zip";
+
 export interface IDownloadUrls {
   launcher: string;
   player: string;
@@ -55,12 +59,12 @@ export function buildDownloadUrl(
 export const BINARY_FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {
   aix: null,
   android: null,
-  darwin: "macOS.tar.gz",
+  darwin: MACOS_FILE_NAME,
   freebsd: null,
-  linux: "Linux.tar.gz",
+  linux: LINUX_FILE_NAME,
   openbsd: null,
   sunos: null,
-  win32: "Windows.zip",
-  cygwin: "Windows.zip",
+  win32: WINDOWS_FILE_NAME,
+  cygwin: WINDOWS_FILE_NAME,
   netbsd: null,
 };

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -53,7 +53,9 @@ export function buildDownloadUrl(
     throw new NotSupportedPlatformError(platform);
   }
 
-  return [baseUrl, env, rc, project, "v" + projectVersion, filename].join("/");
+  return [baseUrl, env, `v${rc}`, project, `v${projectVersion}`, filename].join(
+    "/"
+  );
 }
 
 export const BINARY_FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -53,7 +53,7 @@ export function buildDownloadUrl(
     throw new NotSupportedPlatformError(platform);
   }
 
-  return `${baseUrl}/${env}/v${rc}/${project}/v${projectVersion}/${filename}`;
+  return [baseUrl, env, rc, project, "v" + projectVersion, filename].join("/");
 }
 
 export const BINARY_FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,66 @@
+import { NotSupportedPlatformError } from "src/main/exceptions/not-supported-platform";
+
+export interface IDownloadUrls {
+  launcher: string;
+  player: string;
+}
+
+export function getDownloadUrls(
+  baseUrl: string,
+  netenv: string,
+  apvVersion: number,
+  platform: NodeJS.Platform
+): IDownloadUrls {
+  // TODO: fix project version number hard coding: 1.
+  const launcherUrl = buildDownloadUrl(
+    baseUrl,
+    netenv,
+    apvVersion,
+    "launcher",
+    1,
+    platform
+  );
+  const playerUrl = buildDownloadUrl(
+    baseUrl,
+    netenv,
+    apvVersion,
+    "player",
+    1,
+    platform
+  );
+
+  return {
+    launcher: launcherUrl,
+    player: playerUrl,
+  };
+}
+
+export function buildDownloadUrl(
+  baseUrl: string,
+  env: string,
+  rc: number,
+  project: "player" | "launcher",
+  projectVersion: number,
+  platform: NodeJS.Platform
+): string {
+  const fn = BINARY_FILENAME_MAP[platform];
+
+  if (fn === null) {
+    throw new NotSupportedPlatformError(platform);
+  }
+
+  return `${baseUrl}/${env}/v${rc}/${project}/v${projectVersion}/${fn}`;
+}
+
+export const BINARY_FILENAME_MAP: { [k in NodeJS.Platform]: string | null } = {
+  aix: null,
+  android: null,
+  darwin: "macOS.tar.gz",
+  freebsd: null,
+  linux: "Linux.tar.gz",
+  openbsd: null,
+  sunos: null,
+  win32: "Windows.zip",
+  cygwin: "Windows.zip",
+  netbsd: null,
+};

--- a/src/v2/utils/APVSubscriptionProvider.tsx
+++ b/src/v2/utils/APVSubscriptionProvider.tsx
@@ -6,6 +6,7 @@ import { ipcRenderer } from "electron";
 import { IDownloadProgress } from "src/interfaces/ipc";
 import UpdateView from "../views/UpdateView";
 import machine from "../machines/updateMachine";
+import { decodeApvExtra } from "../../utils/apv";
 
 export default function APVSubscriptionProvider({
   children,
@@ -17,7 +18,10 @@ export default function APVSubscriptionProvider({
   useEffect(() => {
     if (loading) return;
     if (data?.differentAppProtocolVersionEncounter) {
-      ipcRenderer.send("encounter different version", data);
+      ipcRenderer.send(
+        "encounter different version",
+        data.differentAppProtocolVersionEncounter.peerVersion
+      );
     }
   }, [data, loading]);
 

--- a/src/v2/utils/apolloClient.ts
+++ b/src/v2/utils/apolloClient.ts
@@ -20,7 +20,6 @@ import {
   PreloadEndedDocument,
   PreloadEndedQuery,
 } from "../generated/graphql";
-import type { Update } from "src/main/update/launcher-update";
 import { captureException } from "@sentry/electron";
 
 type Client = ApolloClient<NormalizedCacheObject>;
@@ -54,10 +53,7 @@ export default function useApolloClient(): Client | null {
               .then(({ data }) => {
                 const apv = data!.nodeStatus.appProtocolVersion;
                 if (!apv) return;
-                ipcRenderer.send("encounter different version", {
-                  newer: apv.version,
-                  extras: apv.extra,
-                } as Update);
+                ipcRenderer.send("encounter different version", apv);
               });
           },
         },

--- a/src/v2/utils/apolloClient.ts
+++ b/src/v2/utils/apolloClient.ts
@@ -21,6 +21,7 @@ import {
   PreloadEndedQuery,
 } from "../generated/graphql";
 import { captureException } from "@sentry/electron";
+import { decodeApvExtra } from "../../utils/apv";
 
 type Client = ApolloClient<NormalizedCacheObject>;
 


### PR DESCRIPTION
Related to https://github.com/planetarium/9c-launcher/issues/1829

This refactoring focused on two tasks. The rest tasks open another PR
1. separate CompatVersion check.
2. separate APV check.

I separate `check update required` and `check compat version`, Because existing code combined `CompatVersion check` and `launcher update` and `check for update` it's to heavy works

First. I create check.ts file for `checkCompatible`, `checkUpdateRequired` ... etc and some general utils move to `src/utils/~`
Second. `encounter different version` send only new peers apv data