### PR TITLE
Fix IPC event name mismatch on updateMachine

### DIFF
--- a/src/v2/machines/updateMachine.ts
+++ b/src/v2/machines/updateMachine.ts
@@ -92,7 +92,8 @@ const launcherUpdate = {
     copy: {
       entry: "resetProgress",
       invoke: {
-        src: () => invokeIpcEvent<MachineEvent>("update copy complete", "DONE"),
+        src: () =>
+          invokeIpcEvent<MachineEvent>("update copying complete", "DONE"),
       },
     },
   },


### PR DESCRIPTION
https://github.com/planetarium/9c-launcher/blob/e85487b00a6c0aa9a26e330eedc1dbf33d94aa12/src/main/update/launcher-update.ts#L294

The event name doesn't match with the main IPC, causing the event to be ignored.