### PR TITLE
[Fix] Delete relaunch after player update

### DIFF
--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -115,9 +115,6 @@ export async function update(update: Update, listeners: IUpdateOptions) {
 
     if (!fs.existsSync(executePath)) {
       await playerUpdate(playerDownloadUrl, win);
-
-      // Restart
-      listeners.relaunchRequired();
     }
     return;
   }


### PR DESCRIPTION
Solved https://github.com/planetarium/9c-launcher/issues/1897

The reason was `playerUpdate` check lockfile and returned immediately, relaunch code was executed during downloading 

The solution is so simple, just delete relaunch code.
We added this code was because of the state problem but it's already solved https://github.com/planetarium/9c-launcher/pull/1885