### PR TITLE
[Feature] Introduce player version metafile

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -205,6 +205,7 @@ export const CUSTOM_SERVER: boolean =
 export const MIXPANEL_TOKEN = "80a1e14b57d050536185c7459d45195a";
 export const TRANSIFEX_TOKEN = "1/9ac6d0a1efcda679e72e470221e71f4b0497f7ab";
 export const DEFAULT_DOWNLOAD_BASE_URL = "https://release.nine-chronicles.com";
+export const PLAYER_METAFILE_VERSION = 1;
 
 export const EXECUTE_PATH: {
   [k in NodeJS.Platform]: string | null;

--- a/src/interfaces/metadata.ts
+++ b/src/interfaces/metadata.ts
@@ -1,0 +1,5 @@
+export interface IVersionMetadata {
+  apvVersion: number;
+  // commitHash: string;
+  timestamp: string;
+}

--- a/src/interfaces/metadata.ts
+++ b/src/interfaces/metadata.ts
@@ -2,4 +2,5 @@ export interface IVersionMetadata {
   apvVersion: number;
   // commitHash: string;
   timestamp: string;
+  schemaVersion: number;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -250,18 +250,19 @@ async function initializeApp() {
     webEnable(win.webContents);
     createTray(path.join(app.getAppPath(), logoImage));
 
-    let update: IUpdate | null = null;
-    try {
-      update = await checkForUpdate(standalone, process.platform);
-    } catch (e) {
-      console.log("An error occurred: ", e);
-    }
+    const update: IUpdate | null = await checkForUpdate(
+      standalone,
+      process.platform
+    ).catch((e) => {
+      console.error("An error has occurred while checking updates", e);
+      return null;
+    });
 
     if (useUpdate && update) {
       if (!isV2) performUpdate(update, updateOptions);
       else
         ipcMain.handle("start update", async () => {
-          if (update) await performUpdate(update, updateOptions);
+          await performUpdate(update, updateOptions);
         });
     }
 
@@ -271,7 +272,7 @@ async function initializeApp() {
     mixpanel?.track("Launcher/Start", {
       isV2,
       useRemoteHeadless,
-      updateAvailable: update && update.updateRequired,
+      updateAvailable: update?.updateRequired ?? false,
     });
 
     try {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -257,7 +257,7 @@ async function initializeApp() {
       console.log("An error occurred: ", e);
     }
 
-    if (useUpdate && update && update.updateRequired) {
+    if (useUpdate && update) {
       if (!isV2) performUpdate(update, updateOptions);
       else
         ipcMain.handle("start update", async () => {

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -66,31 +66,31 @@ export function checkCompatiblity(
 }
 
 export async function checkMetafile(newApvVersion: number, dir: string) {
-  if (await metafileExists(dir)) {
-    console.log(`Player exists. check version metafile`);
-
-    let version;
-    try {
-      version = await readVersion(dir);
-    } catch (e) {
-      console.error(
-        `readVersion Error ocurred, Start player update ${e}:\n`,
-        e.stderr
-      );
-      return true;
-    }
-
-    console.log(
-      `Player version: ${version.apvVersion}, New version: ${newApvVersion}`
-    );
-
-    if (version.apvVersion < newApvVersion) {
-      console.log(`Player update required, Start player update`);
-
-      return true;
-    }
-  } else {
+  if (!(await metafileExists(dir))) {
     console.log(`Player not exists. Start player update`);
+    return true;
+  }
+
+  console.log(`Player exists. check version metafile`);
+
+  let version;
+  try {
+    version = await readVersion(dir);
+  } catch (e) {
+    console.error(
+      `readVersion Error ocurred, Start player update ${e}:\n`,
+      e.stderr
+    );
+    return true;
+  }
+
+  console.log(
+    `Player version: ${version.apvVersion}, New version: ${newApvVersion}`
+  );
+
+  if (version.apvVersion < newApvVersion) {
+    console.log(`Player update required, Start player update`);
+
     return true;
   }
 

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -69,7 +69,16 @@ export async function checkMetafile(newApvVersion: number, dir: string) {
   if (await metafileExists(dir)) {
     console.log(`Player exists. check version metafile`);
 
-    const version = await readVersion(dir);
+    let version;
+    try {
+      version = await readVersion(dir);
+    } catch (e) {
+      console.error(
+        `readVersion Error ocurred, Start player update ${e}:\n`,
+        e.stderr
+      );
+      return true;
+    }
 
     console.log(
       `Player version: ${version.apvVersion}, New version: ${newApvVersion}`

--- a/src/main/update/check.ts
+++ b/src/main/update/check.ts
@@ -2,6 +2,7 @@ import { IApv, ISimpleApv } from "src/interfaces/apv";
 import { IDownloadUrls, getDownloadUrls } from "../../utils/url";
 import Headless from "../headless/headless";
 import { get as getConfig, baseUrl, netenv } from "../../config";
+import { readVersion, exists as metafileExists } from "./metafile";
 
 export class GetPeersApvFailedError extends Error {}
 
@@ -62,6 +63,29 @@ export function checkCompatiblity(
   );
 
   return peersCompatVersion <= localCompatVersion;
+}
+
+export async function checkMetafile(newApvVersion: number, dir: string) {
+  if (await metafileExists(dir)) {
+    console.log(`Player exists. check version metafile`);
+
+    const version = await readVersion(dir);
+
+    console.log(
+      `Player version: ${version.apvVersion}, New version: ${newApvVersion}`
+    );
+
+    if (version.apvVersion < newApvVersion) {
+      console.log(`Player update required, Start player update`);
+
+      return true;
+    }
+  } else {
+    console.log(`Player not exists. Start player update`);
+    return true;
+  }
+
+  return false;
 }
 
 function getPeersApv(

--- a/src/main/update/metafile.ts
+++ b/src/main/update/metafile.ts
@@ -1,0 +1,21 @@
+import fs from "fs";
+import { IVersionMetadata } from "../../interfaces/metadata";
+
+export const FILE_NAME = "version.json";
+
+export async function createVersionMetafile(
+  dir: string,
+  data: IVersionMetadata
+) {
+  await fs.promises.writeFile(`${dir}/${FILE_NAME}`, JSON.stringify(data));
+}
+
+export async function readVersionMetafile(
+  dir: string
+): Promise<IVersionMetadata> {
+  const data = await fs.promises.readFile(`${dir}/${FILE_NAME}`, "utf8");
+
+  const metadata: IVersionMetadata = JSON.parse(data);
+
+  return metadata;
+}

--- a/src/main/update/metafile.ts
+++ b/src/main/update/metafile.ts
@@ -3,19 +3,20 @@ import { IVersionMetadata } from "../../interfaces/metadata";
 
 export const FILE_NAME = "version.json";
 
-export async function createVersionMetafile(
-  dir: string,
-  data: IVersionMetadata
-) {
+export async function createVersion(dir: string, data: IVersionMetadata) {
   await fs.promises.writeFile(`${dir}/${FILE_NAME}`, JSON.stringify(data));
 }
 
-export async function readVersionMetafile(
-  dir: string
-): Promise<IVersionMetadata> {
+export async function readVersion(dir: string): Promise<IVersionMetadata> {
   const data = await fs.promises.readFile(`${dir}/${FILE_NAME}`, "utf8");
 
-  const metadata: IVersionMetadata = JSON.parse(data);
+  const m: IVersionMetadata = JSON.parse(data);
 
-  return metadata;
+  return m;
+}
+
+export async function exists(dir: string) {
+  const e = await fs.promises.stat(`${dir}/${FILE_NAME}`).catch(() => false);
+
+  return e;
 }

--- a/src/main/update/metafile.ts
+++ b/src/main/update/metafile.ts
@@ -15,7 +15,7 @@ export async function readVersion(dir: string): Promise<IVersionMetadata> {
 
   const m = JSON.parse(data);
 
-  if (m["schemaVersion"] < PLAYER_METAFILE_VERSION) {
+  if (m["schemaVersion"] !== PLAYER_METAFILE_VERSION) {
     throw new SchemaNotCompatibilityError(
       `Old version ${m["schemaVersion"]} and New version ${PLAYER_METAFILE_VERSION} are not compatible`
     );

--- a/src/main/update/metafile.ts
+++ b/src/main/update/metafile.ts
@@ -13,7 +13,7 @@ export async function createVersion(dir: string, data: IVersionMetadata) {
 export async function readVersion(dir: string): Promise<IVersionMetadata> {
   const data = await fs.promises.readFile(path.join(dir, FILE_NAME), "utf8");
 
-  const m = JSON.parse(data);
+  const m: IVersionMetadata = JSON.parse(data);
 
   if (m["schemaVersion"] !== PLAYER_METAFILE_VERSION) {
     throw new SchemaNotCompatibilityError(
@@ -21,7 +21,7 @@ export async function readVersion(dir: string): Promise<IVersionMetadata> {
     );
   }
 
-  return m as IVersionMetadata;
+  return m;
 }
 
 export async function exists(dir: string) {

--- a/src/main/update/metafile.ts
+++ b/src/main/update/metafile.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 import { IVersionMetadata } from "../../interfaces/metadata";
 import { PLAYER_METAFILE_VERSION } from "../../config";
 
@@ -6,11 +7,11 @@ export const FILE_NAME = "version.json";
 export class SchemaNotCompatibilityError extends Error {}
 
 export async function createVersion(dir: string, data: IVersionMetadata) {
-  await fs.promises.writeFile(`${dir}/${FILE_NAME}`, JSON.stringify(data));
+  await fs.promises.writeFile(path.join(dir, FILE_NAME), JSON.stringify(data));
 }
 
 export async function readVersion(dir: string): Promise<IVersionMetadata> {
-  const data = await fs.promises.readFile(`${dir}/${FILE_NAME}`, "utf8");
+  const data = await fs.promises.readFile(path.join(dir, FILE_NAME), "utf8");
 
   const m = JSON.parse(data);
 
@@ -24,5 +25,5 @@ export async function readVersion(dir: string): Promise<IVersionMetadata> {
 }
 
 export async function exists(dir: string) {
-  return await fs.promises.stat(`${dir}/${FILE_NAME}`).catch(() => false);
+  return await fs.promises.stat(path.join(dir, FILE_NAME)).catch(() => false);
 }

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -7,7 +7,7 @@ import extractZip from "extract-zip";
 import { spawn as spawnPromise } from "child-process-promise";
 import { cleanupOldPlayer } from "./util";
 import { IUpdate } from "./check";
-import { playerPath } from "../../config";
+import { playerPath, PLAYER_METAFILE_VERSION } from "../../config";
 import { createVersion } from "./metafile";
 
 export async function playerUpdate(
@@ -112,5 +112,6 @@ export async function playerUpdate(
   await createVersion(playerPath, {
     apvVersion: update.newApv.version,
     timestamp: new Date().toISOString(),
+    schemaVersion: PLAYER_METAFILE_VERSION,
   });
 }

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -6,10 +6,12 @@ import fs from "fs";
 import extractZip from "extract-zip";
 import { spawn as spawnPromise } from "child-process-promise";
 import { cleanupOldPlayer } from "./util";
+import { IUpdate } from "./check";
 import { playerPath } from "../../config";
+import { createVersionMetafile } from "./metafile";
 
 export async function playerUpdate(
-  downloadUrl: string,
+  update: IUpdate,
   win: Electron.BrowserWindow | null
 ) {
   if (win === null) {
@@ -29,19 +31,19 @@ export async function playerUpdate(
     onProgress: (status: IDownloadProgress) => {
       const percent = (status.percent * 100) | 0;
       console.log(
-        `[player] Downloading ${downloadUrl}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
+        `[player] Downloading ${update.urls.player}: ${status.transferredBytes}/${status.totalBytes} (${percent}%)`
       );
       win?.webContents.send("update player download progress", status);
     },
     directory: app.getPath("temp"),
   };
-  console.log("[player] Starts to download:", downloadUrl);
+  console.log("[player] Starts to download:", update.urls.player);
   let dl: DownloadItem | null | undefined;
   try {
-    dl = await download(win, downloadUrl, options);
+    dl = await download(win, update.urls.player, options);
   } catch (error) {
     win.webContents.send("go to error page", "download-binary-failed");
-    throw new DownloadBinaryFailedError(downloadUrl);
+    throw new DownloadBinaryFailedError(update.urls.player);
   }
 
   win.webContents.send("update player download complete");
@@ -106,4 +108,9 @@ export async function playerUpdate(
   win.webContents.send("update player extract complete");
 
   await fs.promises.unlink(dlPath);
+
+  await createVersionMetafile(playerPath, {
+    apvVersion: update.newApv.version,
+    timestamp: new Date().toISOString(),
+  });
 }

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -8,7 +8,7 @@ import { spawn as spawnPromise } from "child-process-promise";
 import { cleanupOldPlayer } from "./util";
 import { IUpdate } from "./check";
 import { playerPath } from "../../config";
-import { createVersionMetafile } from "./metafile";
+import { createVersion } from "./metafile";
 
 export async function playerUpdate(
   update: IUpdate,
@@ -109,7 +109,7 @@ export async function playerUpdate(
 
   await fs.promises.unlink(dlPath);
 
-  await createVersionMetafile(playerPath, {
+  await createVersion(playerPath, {
     apvVersion: update.newApv.version,
     timestamp: new Date().toISOString(),
   });

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -5,7 +5,7 @@ import { app, dialog, shell } from "electron";
 import { IUpdate, checkCompatiblity, checkMetafile } from "./check";
 import { launcherUpdate } from "./launcher-update";
 import { playerUpdate } from "./player-update";
-import { playerPath } from "src/config";
+import { playerPath } from "../../config";
 
 export interface IUpdateOptions {
   downloadStarted(): Promise<void>;

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -7,13 +7,7 @@ import { IUpdate, checkCompatiblity } from "./check";
 import { launcherUpdate } from "./launcher-update";
 import { playerUpdate } from "./player-update";
 
-import {
-  DEFAULT_DOWNLOAD_BASE_URL,
-  get as getConfig,
-  WIN_GAME_PATH,
-  EXECUTE_PATH,
-  playerPath,
-} from "../../config";
+import { playerPath } from "../../config";
 import { FILE_NAME as METAFILE_NAME, readVersionMetafile } from "./metafile";
 
 export interface IUpdateOptions {
@@ -21,9 +15,6 @@ export interface IUpdateOptions {
   relaunchRequired(): void;
   getWindow(): Electron.BrowserWindow | null;
 }
-
-const baseURL = getConfig("DownloadBaseURL", DEFAULT_DOWNLOAD_BASE_URL);
-const executePath = EXECUTE_PATH[process.platform] || WIN_GAME_PATH;
 
 const lockfilePath = path.join(path.dirname(app.getPath("exe")), "lockfile");
 
@@ -87,10 +78,19 @@ export async function performUpdate(
       .catch(() => false);
 
     if (exists) {
+      console.log(`Player exists. check version metafile`);
+
       const versionData = await readVersionMetafile(playerPath);
 
-      if (versionData.apvVersion < update.newApv.version)
+      console.log(
+        `Player version: ${versionData.apvVersion}, New version: ${update.newApv.version}`
+      );
+
+      if (versionData.apvVersion < update.newApv.version) {
+        console.log(`Player update required, Start player update`);
+
         await playerUpdate(update, win);
+      }
     } else {
       console.log(`Player not exists. Start player update`);
       await playerUpdate(update, win);

--- a/src/main/update/update.ts
+++ b/src/main/update/update.ts
@@ -1,14 +1,11 @@
-import fs from "fs";
 import lockfile from "lockfile";
 import path from "path";
 import { app, dialog, shell } from "electron";
 
-import { IUpdate, checkCompatiblity } from "./check";
+import { IUpdate, checkCompatiblity, checkMetafile } from "./check";
 import { launcherUpdate } from "./launcher-update";
 import { playerUpdate } from "./player-update";
-
-import { playerPath } from "../../config";
-import { FILE_NAME as METAFILE_NAME, readVersionMetafile } from "./metafile";
+import { playerPath } from "src/config";
 
 export interface IUpdateOptions {
   downloadStarted(): Promise<void>;
@@ -73,26 +70,7 @@ export async function performUpdate(
   } else {
     console.log(`Not required launcher update, Check player path.`);
 
-    const exists = await fs.promises
-      .stat(`${playerPath}/${METAFILE_NAME}`)
-      .catch(() => false);
-
-    if (exists) {
-      console.log(`Player exists. check version metafile`);
-
-      const versionData = await readVersionMetafile(playerPath);
-
-      console.log(
-        `Player version: ${versionData.apvVersion}, New version: ${update.newApv.version}`
-      );
-
-      if (versionData.apvVersion < update.newApv.version) {
-        console.log(`Player update required, Start player update`);
-
-        await playerUpdate(update, win);
-      }
-    } else {
-      console.log(`Player not exists. Start player update`);
+    if (await checkMetafile(update.newApv.version, playerPath)) {
       await playerUpdate(update, win);
     }
   }

--- a/src/v2/machines/updateMachine.ts
+++ b/src/v2/machines/updateMachine.ts
@@ -125,6 +125,10 @@ export default createMachine<MachineContext, MachineEvent, UpdateMachineState>(
                 "LAUNCHER_DOWNLOAD"
               ),
           },
+          {
+            id: "triggerUpdate",
+            src: () => ipcRenderer.invoke("start update"),
+          },
         ],
         on: {
           PLAYER_DOWNLOAD: {


### PR DESCRIPTION
Solve https://github.com/planetarium/9c-launcher/issues/1896

```typescript
export interface IVersionMetadata {
  apvVersion: number;
  // commitHash: string;
  timestamp: string;
}
```
metafile schema, we'll check commitHash only later(FYI https://github.com/planetarium/9c-launcher/issues/1838)
Now, `checkForUpdateFromApv` function is alaways return `IUpdate` and added `updateRequired` option

I solved https://github.com/planetarium/9c-launcher/issues/1911 too, because even when the APV is the same, check update must occured

