### PR TITLE
Check node tip when selecting an RPC node

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -363,6 +363,9 @@ mutation StageTxV2($encodedTx: String!) {
 query PreloadEnded {
   nodeStatus {
     preloadEnded
+    tip {
+      index
+    }
     appProtocolVersion {
       version
       extra

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,8 @@ export class NodeInfo {
   readonly graphqlPort: number;
   readonly rpcPort: number;
   readonly nodeNumber: number;
-  clientCount: number = 0;
+  clientCount = 0;
+  tip = 0;
 
   public GraphqlServer(): string {
     return `${this.HeadlessUrl()}/graphql`;
@@ -78,6 +79,7 @@ export class NodeInfo {
       const ended = await headlessGraphQLSDK.PreloadEnded();
       if (ended.status == 200) {
         this.clientCount = ended.data!.rpcInformation.totalCount;
+        this.tip = ended.data!.nodeStatus.tip.index;
         return ended.data!.nodeStatus.preloadEnded;
       }
     } catch (e) {
@@ -232,7 +234,9 @@ export async function initializeNode(): Promise<NodeInfo> {
     throw Error("can't find available remote node.");
   }
   nodeList.sort((a, b) => {
-    return a.clientCount - b.clientCount;
+    const baseA = a.tip - a.clientCount / 10;
+    const baseB = b.tip - b.clientCount / 10;
+    return baseA - baseB;
   });
   console.log("config initialize complete");
   const nodeInfo = nodeList[0];

--- a/src/config.ts
+++ b/src/config.ts
@@ -234,7 +234,7 @@ export async function initializeNode(): Promise<NodeInfo> {
     throw Error("can't find available remote node.");
   }
   nodeList.sort((a, b) => {
-    const rate = get("RemoteClientSamplingRate", 10) ?? Infinity;
+    const rate = get("RemoteClientSamplingRate", 10) || Infinity;
     const baseA = a.tip - a.clientCount / rate;
     const baseB = b.tip - b.clientCount / rate;
     return baseB - baseA;

--- a/src/config.ts
+++ b/src/config.ts
@@ -234,8 +234,9 @@ export async function initializeNode(): Promise<NodeInfo> {
     throw Error("can't find available remote node.");
   }
   nodeList.sort((a, b) => {
-    const baseA = a.tip - a.clientCount / 10;
-    const baseB = b.tip - b.clientCount / 10;
+    const rate = get("RemoteClientSamplingRate", 10) ?? Infinity;
+    const baseA = a.tip - a.clientCount / rate;
+    const baseB = b.tip - b.clientCount / rate;
     return baseA - baseB;
   });
   console.log("config initialize complete");

--- a/src/config.ts
+++ b/src/config.ts
@@ -237,7 +237,7 @@ export async function initializeNode(): Promise<NodeInfo> {
     const rate = get("RemoteClientSamplingRate", 10) ?? Infinity;
     const baseA = a.tip - a.clientCount / rate;
     const baseB = b.tip - b.clientCount / rate;
-    return baseA - baseB;
+    return baseB - baseA;
   });
   console.log("config initialize complete");
   const nodeInfo = nodeList[0];

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -28,6 +28,7 @@ export interface IConfig {
   UseRemoteHeadless: boolean;
   LaunchPlayer: boolean;
   RemoteNodeList: string[];
+  RemoteClientSamplingRate: number | null;
   PreferLegacyInterface: boolean;
   DownloadBaseURL: string;
   UseUpdate: boolean;

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -28,7 +28,7 @@ export interface IConfig {
   UseRemoteHeadless: boolean;
   LaunchPlayer: boolean;
   RemoteNodeList: string[];
-  RemoteClientSamplingRate: number | null;
+  RemoteClientSamplingRate: number;
   PreferLegacyInterface: boolean;
   DownloadBaseURL: string;
   UseUpdate: boolean;


### PR DESCRIPTION
This PR proposes an alternative method to select an RPC node to connect using both the tip index and client counts. The configurator may specify the sampling rate to adjust how much client counts influence the node selection.

# New `config.json` field
## `RemoteClientSamplingRate: number`
The sampling rate to adjust the client count's influence on the node selection. The higher the number, the less impact the client count makes on the node selection.
If you want to completely disable this behaviour and use only the tip index to select the node, you can put `0`.