### PR TITLE
[Feature] Replace to remote config in initializeConfig

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,9 +24,6 @@ export const userConfigStore = new Store<IConfig>({
   name: network === "9c-main" ? "config" : `config.${network}`,
 });
 
-export const apvVersionNumber = getVersionNumberFromAPV(
-  get("AppProtocolVersion")
-);
 export const playerPath = path.join(
   app.getPath("userData"),
   `player/${netenv}`
@@ -209,6 +206,9 @@ export const TRANSIFEX_TOKEN = "1/9ac6d0a1efcda679e72e470221e71f4b0497f7ab";
 export const DEFAULT_DOWNLOAD_BASE_URL = "https://release.nine-chronicles.com";
 export const PLAYER_METAFILE_VERSION = 2;
 export const installerName = "NineChroniclesInstaller.exe";
+export const configFileName = "config.json";
+
+export const CONFIG_FILE_PATH = path.join(app.getAppPath(), configFileName);
 
 export const EXECUTE_PATH: {
   [k in NodeJS.Platform]: string | null;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,6 +16,7 @@ import {
   NodeInfo,
   userConfigStore,
   baseUrl,
+  CONFIG_FILE_PATH,
 } from "../config";
 import {
   app,
@@ -183,19 +184,25 @@ if (!app.requestSingleInstanceLock()) {
 
   cleanUp();
 
-  intializeConfig();
+  initializeConfig();
   useRemoteHeadless = getConfig("UseRemoteHeadless");
   initializeApp();
   initializeIpc();
 }
 
-async function intializeConfig() {
+async function initializeConfig() {
   try {
     const res = await axios(REMOTE_CONFIG_URL);
     const remoteConfig: IConfig = res.data;
 
     const localApv = getConfig("AppProtocolVersion");
     const remoteApv = remoteConfig.AppProtocolVersion;
+
+    if (localApv == null) {
+      configStore.store = remoteConfig;
+      return;
+    }
+
     if (localApv !== remoteApv) {
       console.log(
         `APVs are different, ignore. (local: ${localApv}, remote: ${remoteApv})`


### PR DESCRIPTION
If localApv is null, replace to remote config in `initializeConfig` func
and rename