### PR TITLE
Apply Relative tip comparison and ClientCount-weighted RPC Node Selector

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -129,11 +129,9 @@ const NonStaleNodeList = (
 ): NodeInfo[] => {
   if (staleThreshold < 0) {
     return nodeList;
-  } else {
-    return nodeList
-      .sort((a, b) => b.tip - a.tip)
-      .filter((node) => node.tip >= nodeList[0].tip - staleThreshold);
   }
+  const maxTip = Math.max(...nodeList.map((node) => node.tip));
+  return nodeList.filter((node) => node.tip >= maxTip - staleThreshold);
 };
 
 const clientWeightedSelector = (nodeList: NodeInfo[]): NodeInfo => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,9 +127,13 @@ const NonStaleNodeList = (
   nodeList: NodeInfo[],
   staleThreshold: number
 ): NodeInfo[] => {
-  return nodeList
-    .sort((a, b) => b.tip - a.tip)
-    .filter((node) => node.tip >= nodeList[0].tip - staleThreshold);
+  if (staleThreshold < 0) {
+    return nodeList;
+  } else {
+    return nodeList
+      .sort((a, b) => b.tip - a.tip)
+      .filter((node) => node.tip >= nodeList[0].tip - staleThreshold);
+  }
 };
 
 const clientWeightedSelector = (nodeList: NodeInfo[]): NodeInfo => {
@@ -252,7 +256,7 @@ export const installerUrl = path.join(DEFAULT_DOWNLOAD_BASE_URL, installerName);
 
 export async function initializeNode(): Promise<NodeInfo> {
   console.log("config initialize called");
-  const relativeTipLimit = get("RemoteClientStaleTipLimit", 20) || Infinity;
+  const relativeTipLimit = get("RemoteClientStaleTipLimit", 20) ?? Infinity;
   const nodeList = NonStaleNodeList(await NodeList(), relativeTipLimit);
   if (nodeList.length < 1) {
     throw Error("can't find available remote node.");

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,7 +129,7 @@ const NonStaleNodeList = (
 ): Promise<NodeInfo[]> => {
   return nodeList
     .sort((a, b) => b.tip - a.tip)
-    .filter((node) => node.tip <= nodeList[0].tip - staleThreshold);
+    .filter((node) => node.tip >= nodeList[0].tip - staleThreshold);
 };
 
 const clientWeightedSelector = (

--- a/src/config.ts
+++ b/src/config.ts
@@ -123,7 +123,7 @@ const NodeList = async (): Promise<NodeInfo[]> => {
   return nodeList;
 };
 
-const NonStaleNodeList = async (
+const NonStaleNodeList = (
   nodeList: NodeInfo[],
   staleThreshold: number
 ): Promise<NodeInfo[]> => {
@@ -132,7 +132,7 @@ const NonStaleNodeList = async (
     .filter((node) => node.tip <= nodeList[0].tip - staleThreshold);
 };
 
-const clientWeightedSelector = async (
+const clientWeightedSelector = (
   nodeList: NodeInfo[]
 ): Promise<NodeInfo> => {
   const sum = nodeList

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,7 @@ const NodeList = async (): Promise<NodeInfo[]> => {
   const nodeList: NodeInfo[] = [];
   if (get("UseRemoteHeadless")) {
     const remoteNodeList: string[] = get("RemoteNodeList");
-    await Promise.any(
+    await Promise.all(
       remoteNodeList
         .sort(() => Math.random() - 0.5)
         .map(async (v, index) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -126,15 +126,13 @@ const NodeList = async (): Promise<NodeInfo[]> => {
 const NonStaleNodeList = (
   nodeList: NodeInfo[],
   staleThreshold: number
-): Promise<NodeInfo[]> => {
+): NodeInfo[] => {
   return nodeList
     .sort((a, b) => b.tip - a.tip)
     .filter((node) => node.tip >= nodeList[0].tip - staleThreshold);
 };
 
-const clientWeightedSelector = (
-  nodeList: NodeInfo[]
-): Promise<NodeInfo> => {
+const clientWeightedSelector = (nodeList: NodeInfo[]): NodeInfo => {
   const sum = nodeList
     .map((node) => node.clientCount)
     .reduce((p, c) => p + c, 0);
@@ -255,12 +253,12 @@ export const installerUrl = path.join(DEFAULT_DOWNLOAD_BASE_URL, installerName);
 export async function initializeNode(): Promise<NodeInfo> {
   console.log("config initialize called");
   const relativeTipLimit = get("RemoteClientStaleTipLimit", 20) || Infinity;
-  const nodeList = await NonStaleNodeList(await NodeList(), relativeTipLimit);
+  const nodeList = NonStaleNodeList(await NodeList(), relativeTipLimit);
   if (nodeList.length < 1) {
     throw Error("can't find available remote node.");
   }
   console.log("config initialize complete");
-  const nodeInfo = await clientWeightedSelector(nodeList);
+  const nodeInfo = clientWeightedSelector(nodeList);
   console.log(
     `selected node: ${nodeInfo.HeadlessUrl()}, clients: ${nodeInfo.clientCount}`
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,6 +135,9 @@ const NonStaleNodeList = (
 };
 
 const clientWeightedSelector = (nodeList: NodeInfo[]): NodeInfo => {
+  if (nodeList.length <= 1) {
+    return nodeList[0];
+  }
   const sum = nodeList
     .map((node) => node.clientCount)
     .reduce((p, c) => p + c, 0);

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,8 +138,8 @@ const clientWeightedSelector = (nodeList: NodeInfo[]): NodeInfo => {
   const sum = nodeList
     .map((node) => node.clientCount)
     .reduce((p, c) => p + c, 0);
-  const weightList = nodeList.map((node) => sum / node.clientCount);
-  const target = Math.random() * weightList.reduce((p, v) => p + v, 0);
+  const weightList = nodeList.map((node) => node.clientCount / sum);
+  const target = Math.random();
   let weightSum = 0;
   return nodeList[
     weightList.findIndex(

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,8 +138,8 @@ const clientWeightedSelector = (nodeList: NodeInfo[]): NodeInfo => {
   const sum = nodeList
     .map((node) => node.clientCount)
     .reduce((p, c) => p + c, 0);
-  const weightList = nodeList.map((node) => node.clientCount / sum);
-  const target = Math.random();
+  const weightList = nodeList.map((node) => sum / node.clientCount);
+  const target = Math.random() * weightList.reduce((p, v) => p + v, 0);
   let weightSum = 0;
   return nodeList[
     weightList.findIndex(

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -28,7 +28,7 @@ export interface IConfig {
   UseRemoteHeadless: boolean;
   LaunchPlayer: boolean;
   RemoteNodeList: string[];
-  RemoteClientSamplingRate: number;
+  RemoteClientStaleTipLimit: number;
   PreferLegacyInterface: boolean;
   DownloadBaseURL: string;
   UseUpdate: boolean;


### PR DESCRIPTION
This PR Adds #1973 

- Relative tip comparison between available nodes, 
if node's tip is falling behind under threshold (default: 20 block), it drops from node list.
- ClientCount-weighted random RPC node selection
when selecting node, instead of unconditionally selecting least used node, Use clientCount based weight (more client = less weight) and randomly select based on that. from this, We can stay between "Almost Deterministic Node Selection (but when best node is not actually working it stucks)" and "Purely Random Selection(which possibly select the worst node)".