### PR TITLE
[Feature] Change config.json path when os is macos

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,6 @@ import path from "path";
 import { IConfig } from "./interfaces/config";
 import { GraphQLClient } from "graphql-request";
 import { getSdk } from "./generated/graphql-request";
-import { getVersionNumberFromAPV } from "./utils";
 
 export const { app } =
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -13,8 +12,15 @@ export const { app } =
 
 if (process.type === "browser") Store.initRenderer();
 
+export function getConfigPath() {
+  if (process.platform === "darwin") return app.getPath("userData");
+  else return app.getAppPath();
+}
+export const configFileName = "config.json";
+export const CONFIG_FILE_PATH = path.join(getConfigPath(), configFileName);
+
 export const configStore = new Store<IConfig>({
-  cwd: app.getAppPath(),
+  cwd: getConfigPath(),
 });
 
 const network = configStore.get("Network");
@@ -234,9 +240,6 @@ export const TRANSIFEX_TOKEN = "1/9ac6d0a1efcda679e72e470221e71f4b0497f7ab";
 export const DEFAULT_DOWNLOAD_BASE_URL = "https://release.nine-chronicles.com";
 export const PLAYER_METAFILE_VERSION = 2;
 export const installerName = "NineChroniclesInstaller.exe";
-export const configFileName = "config.json";
-
-export const CONFIG_FILE_PATH = path.join(app.getAppPath(), configFileName);
 
 export const EXECUTE_PATH: {
   [k in NodeJS.Platform]: string | null;

--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -9,6 +9,7 @@ import { DownloadBinaryFailedError } from "../exceptions/download-binary-failed"
 import fs from "fs";
 import { spawn as spawnPromise } from "child-process-promise";
 import { IUpdate } from "./check";
+import { CONFIG_FILE_PATH } from "../../config";
 
 export async function launcherUpdate(
   update: IUpdate,
@@ -51,12 +52,8 @@ export async function launcherUpdate(
       : path.dirname(path.dirname(app.getAppPath()));
   console.log("The 9C app installation path:", extractPath);
 
-  const appDirName = app.getAppPath();
-  // FIXME: We shouldn't hardcode "config.json"
-  const configFileName = "config.json";
-
   // Pre-decompress existing config file saving, we will merge them with new default values.
-  const configPath = path.join(appDirName, configFileName);
+  const configPath = CONFIG_FILE_PATH;
   const bakConfig = JSON.parse(
     await fs.promises.readFile(configPath, { encoding: "utf-8" })
   );


### PR DESCRIPTION
Related to https://github.com/planetarium/9c-launcher/issues/1907

I've changed `config.json` path when os is macOS, So will work player updater