### PR TITLE
Fix account related bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,4 +133,5 @@ workflows:
           filters:
             branches:
               only: development
-      - chromatic
+      # FIXME we should restore this job after fixing system module import problems
+      # - chromatic

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/styles": "^4.10.0",
     "@noble/secp256k1": "^1.7.0",
-    "@planetarium/account-local": "^0.0.31",
+    "@planetarium/account-local": "^0.0.37",
     "@planetarium/account-raw": "^0.0.3",
     "@planetarium/check-free-space": "^0.0.2",
     "@planetarium/sign": "^0.0.11",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@planetarium/account-local": "^0.0.37",
     "@planetarium/account-raw": "^0.0.3",
     "@planetarium/check-free-space": "^0.0.2",
-    "@planetarium/sign": "^0.0.11",
+    "@planetarium/sign": "^0.0.12",
     "@radix-ui/react-radio-group": "^0.1.5",
     "@radix-ui/react-scroll-area": "^0.1.4",
     "@reach/alert-dialog": "^0.17.0",

--- a/src/renderer/components/core/Layout/InfoText.tsx
+++ b/src/renderer/components/core/Layout/InfoText.tsx
@@ -8,6 +8,7 @@ import { styled } from "src/renderer/stitches.config";
 import toast from "react-hot-toast";
 import { T } from "@transifex/react";
 import { useTip } from "src/utils/useTip";
+import { useLoginSession } from "src/utils/useLoginSession";
 
 const awsSinkGuid: string | undefined = ipcRenderer.sendSync(
   "get-aws-sink-cloudwatch-guid"
@@ -21,21 +22,21 @@ const InfoTextStyled = styled("div", {
 });
 
 function InfoText() {
-  const account = useStore("account");
+  const { address } = useLoginSession();
   const [node, setNode] = useState<string>("loading");
 
   const debugValue = useMemo(
     () =>
       [
         `APV: ${getConfig("AppProtocolVersion")}`,
-        account.isLogin && `Account: ${account.address}`,
+        address && `Account: ${address}`,
         `Node: ${node}`,
         awsSinkGuid && `Client ID: ${awsSinkGuid}`,
         `Commit: ${GIT_HASH}`,
       ]
         .filter(Boolean)
         .join("\n"),
-    [account.isLogin, account.address, node, awsSinkGuid]
+    [address, node, awsSinkGuid]
   );
 
   const onClick = () => {

--- a/src/renderer/components/core/Layout/StatusBar.tsx
+++ b/src/renderer/components/core/Layout/StatusBar.tsx
@@ -25,28 +25,25 @@ const StatusMessage = styled("span", {
 
 function StatusBar() {
   const isAvailable = useIsHeadlessAvailable();
-  const { account, game } = useStore();
-  const { loading, activated } = useActivation();
+  const { account: accountStore, game } = useStore();
+  const { loading, activated } = useActivation(false);
+  const loginSession = accountStore.loginSession;
 
   return (
     <StatusBarStyled>
       <StatusMessage>
-        {isAvailable && account.isLogin && !game.isGameStarted ? (
+        {isAvailable && loginSession && !game.isGameStarted ? (
           <Button
             data-testid="play"
             variant="primary"
             disabled={loading || !activated}
-            onClick={() =>
-              account
-                .getPrivateKeyAndForget(false)
-                .then((privateKey) => game.startGame(privateKey))
-            }
+            onClick={() => game.startGame(loginSession.privateKey)}
           >
             <T _str="Start" _tags="v2/start-game" />
           </Button>
         ) : (
           <span data-testid="status">
-            {account.isLogin ? "Done" : "Loading..."}
+            {!loginSession ? "Done" : "Loading..."}
           </span>
         )}
       </StatusMessage>

--- a/src/renderer/views/ClaimCollectionRewardsOverlay/index.tsx
+++ b/src/renderer/views/ClaimCollectionRewardsOverlay/index.tsx
@@ -1,14 +1,12 @@
 import { observer } from "mobx-react";
 import React from "react";
-import { Reward } from "src/interfaces/collection";
 import { T } from "src/renderer/i18n";
 import OverlayBase from "src/renderer/components/core/OverlayBase";
 import H1 from "src/renderer/components/ui/H1";
 import { useGetAvatarAddressQuery } from "src/generated/graphql";
-import { styled } from "src/renderer/stitches.config";
 import { OverlayProps } from "src/utils/types";
-import { useStore } from "src/utils/useStore";
 import ClaimContent, { Avatar } from "./ClaimContent";
+import { useLoginSession } from "src/utils/useLoginSession";
 
 export interface ClaimCollectionRewardsOverlayProps extends OverlayProps {
   tip: number;
@@ -22,11 +20,12 @@ function ClaimCollectionRewardsOverlay({
   onClose,
   ...collectionData
 }: ClaimCollectionRewardsOverlayProps) {
-  const { account } = useStore();
+  const { address } = useLoginSession();
   const { loading, data } = useGetAvatarAddressQuery({
     variables: {
-      address: account.address,
+      address,
     },
+    skip: !address,
   });
 
   if (loading) {

--- a/src/renderer/views/ForgotPasswordView/index.tsx
+++ b/src/renderer/views/ForgotPasswordView/index.tsx
@@ -29,8 +29,8 @@ function ForgotPasswordView() {
   const account = useStore("account");
   const history = useHistory();
 
-  const onSubmit: SubmitHandler<FormData> = async (data) => {
-    account.setPrivateKey(data.privateKey);
+  const onSubmit: SubmitHandler<FormData> = (data) => {
+    account.beginRecovery(data.privateKey);
     history.push("/recover");
   };
 

--- a/src/renderer/views/ImportView/index.tsx
+++ b/src/renderer/views/ImportView/index.tsx
@@ -26,7 +26,8 @@ function ImportView() {
       setError(t("Invalid private key"));
       return;
     }
-    account.setPrivateKey(key.key);
+
+    account.beginRecovery(key.key);
     history.push("/recover");
   };
 

--- a/src/renderer/views/LobbyView/index.tsx
+++ b/src/renderer/views/LobbyView/index.tsx
@@ -12,7 +12,7 @@ const isFirst = (state: string): boolean => {
 
 function LobbyView() {
   const { account, game } = useStore();
-  const { loading, activated, error } = useActivation(account.activationKey);
+  const { loading, activated, error } = useActivation(true);
   const history = useHistory();
   const onboardingRequired = useMemo(
     () => isFirst(history.location.search),
@@ -26,12 +26,10 @@ function LobbyView() {
   }, [loading, activated, account.activationKey]);
 
   useEffect(() => {
-    if (account.isLogin && activated) {
-      account
-        .getPrivateKeyAndForget(false)
-        .then((privateKey) => game.startGame(privateKey));
+    if (account.loginSession && activated) {
+      game.startGame(account.loginSession.privateKey);
     }
-  }, [account.isLogin, activated]);
+  }, [account.loginSession, activated, game]);
 
   useEffect(() => {
     if (error) history.push("/error/relaunch");

--- a/src/renderer/views/LoginView/index.tsx
+++ b/src/renderer/views/LoginView/index.tsx
@@ -36,8 +36,8 @@ function LoginView() {
       ipcRenderer.send("mixpanel-alias", address);
       trackEvent("Launcher/Login");
 
-      transfer.trySetSenderAddress(address);
-      transfer.updateBalance(address);
+      await transfer.trySetSenderAddress(address);
+      await transfer.updateBalance(address);
 
       _refiner("setProject", "43e75b10-c10d-11ec-a73a-958e7574f4fc");
       _refiner("identifyUser", {

--- a/src/renderer/views/LoginView/index.tsx
+++ b/src/renderer/views/LoginView/index.tsx
@@ -20,48 +20,45 @@ import { trackEvent } from "src/utils/mixpanel";
 const transifexTags = "v2/login-view";
 
 function LoginView() {
-  const { account, transfer } = useStore();
+  const { account: accountStore, transfer } = useStore();
   const [password, setPassword] = useState("");
   const [invalid, setInvalid] = useState(false);
   const [address, setAddress] = useState<Address>(
-    localStorage.getItem("lastAddress") ?? account.keyring[0].address
+    localStorage.getItem("lastAddress") ?? accountStore.keyring[0].address
   );
   const history = useHistory();
 
-  const handleLogin = () => {
-    account.getAccount(address, password).then(
-      (acc) => {
-        account.setAccount(acc);
-        account.setPrivateKeyFromAddress(address, password);
-        account.setLoginStatus(true);
-        ipcRenderer.send("mixpanel-alias", address);
-        trackEvent("Launcher/Login");
+  const handleLogin = async () => {
+    try {
+      const account = await accountStore.getAccount(address, password);
+      await accountStore.login(account, password);
+      accountStore.setLoginStatus(true);
+      ipcRenderer.send("mixpanel-alias", address);
+      trackEvent("Launcher/Login");
 
-        transfer.trySetSenderAddress(account.address);
-        transfer.updateBalance(account.address);
+      transfer.trySetSenderAddress(address);
+      transfer.updateBalance(address);
 
-        _refiner("setProject", "43e75b10-c10d-11ec-a73a-958e7574f4fc");
-        _refiner("identifyUser", {
-          id: address,
-          config: {
-            rpc: true,
-            locale: get("Locale"),
-          },
-        });
-        localStorage.setItem("lastAddress", address);
-        history.push("/lobby");
-      },
-      (reject) => {
-        setInvalid(true);
-        trackEvent("Launcher/LoginFailed");
-        console.error(reject);
-      }
-    );
+      _refiner("setProject", "43e75b10-c10d-11ec-a73a-958e7574f4fc");
+      _refiner("identifyUser", {
+        id: address,
+        config: {
+          rpc: true,
+          locale: get("Locale"),
+        },
+      });
+      localStorage.setItem("lastAddress", address);
+      history.push("/lobby");
+    } catch (error) {
+      setInvalid(true);
+      trackEvent("Launcher/LoginFailed");
+      console.error(error);
+    }
   };
 
   useEffect(() => {
     async function isInKeyring(address: string) {
-      return await account
+      return await accountStore
         .findKeyByAddress(address)
         .catch(() => {
           return false;
@@ -71,7 +68,7 @@ function LoginView() {
         });
     }
     isInKeyring(address).then((v) => {
-      if (!v) setAddress(account.keyring[0].address);
+      if (!v) setAddress(accountStore.keyring[0].address);
     });
   }, []);
 
@@ -85,7 +82,7 @@ function LoginView() {
       </p>
       <Form onSubmit={(e) => e.preventDefault()}>
         <Select defaultValue={address} onChange={(v) => setAddress(v)}>
-          {account.keyring.map((key) => (
+          {accountStore.keyring.map((key) => (
             <SelectOption key={key.address} value={key.address}>
               {"0x" + key.address}
             </SelectOption>

--- a/src/renderer/views/MissingActivationView.tsx
+++ b/src/renderer/views/MissingActivationView.tsx
@@ -35,11 +35,11 @@ function MissingActivationView() {
   const history = useHistory();
   const account = useStore("account");
 
-  const { activated } = useActivation(account.activationKey);
+  const { activated } = useActivation(false);
 
   const onSubmit = ({ activationKey }: { activationKey: string }) => {
     account.setActivationKey(activationKey!);
-    history.push("/lobby?first");
+    history.push("/lobby");
   };
 
   useEffect(

--- a/src/renderer/views/RecoverView/index.tsx
+++ b/src/renderer/views/RecoverView/index.tsx
@@ -11,17 +11,14 @@ import { T } from "src/renderer/i18n";
 const transifexTags = "v2/recover-view";
 
 function RecoverView() {
-  const account = useStore("account");
-  const address = account.address;
+  const accountStore = useStore("account");
   const history = useHistory();
 
-  const onSubmit = ({ password }: { password: string }) => {
+  const onSubmit = async ({ password }: { password: string }) => {
     try {
-      account.removeKeyByAddress(address);
+      const newAccount = await accountStore.completeRecovery(password);
+      await accountStore.login(newAccount, password);
     } finally {
-      account
-        .getPrivateKeyAndForget()
-        .then((privateKey) => account.importRaw(privateKey, password));
       history.push("/");
     }
   };
@@ -34,7 +31,7 @@ function RecoverView() {
       <H2>
         <T _str="Found your account!" _tags={transifexTags} />
       </H2>
-      <RetypePasswordForm address={address} onSubmit={onSubmit} />
+      <RetypePasswordForm onSubmit={onSubmit} />
     </Layout>
   );
 }

--- a/src/renderer/views/RevokeView.tsx
+++ b/src/renderer/views/RevokeView.tsx
@@ -8,12 +8,16 @@ import { useStore } from "src/utils/useStore";
 import { Address } from "src/interfaces/keystore";
 import Button from "src/renderer/components/ui/Button";
 import { useHistory } from "react-router";
+import { useLoginSession } from "src/utils/useLoginSession";
 
 const transifexTags = "v2/revoke-view";
 
 function RevokeView() {
-  const account = useStore("account");
-  const [address, setAddress] = useState<Address>(account.address);
+  const accountStore = useStore("account");
+  const { address: loggedinAddress } = useLoginSession();
+  const [address, setAddress] = useState<Address>(
+    loggedinAddress ?? accountStore.keyring[0].address
+  );
   const history = useHistory();
 
   return (
@@ -31,7 +35,7 @@ function RevokeView() {
         _tags={transifexTags}
       />
       <Select value={address} onChange={(v) => setAddress(v)}>
-        {account.keyring.map((key) => (
+        {accountStore.keyring.map((key) => (
           <SelectOption key={key.address} value={key.address}>
             {key.address}
           </SelectOption>
@@ -41,7 +45,7 @@ function RevokeView() {
         variant="primary"
         centered
         onClick={() => {
-          account.removeKeyByAddress(address);
+          accountStore.removeKeyByAddress(address);
           history.push("/");
         }}
       >

--- a/src/renderer/views/TransferAssetOverlay/swap.tsx
+++ b/src/renderer/views/TransferAssetOverlay/swap.tsx
@@ -72,7 +72,7 @@ const SwapButton = styled(Button)({
 
 function SwapPage() {
   const transfer = useStore("transfer");
-  const { address, publicKey, account } = useLoginSession();
+  const { publicKey, account } = useLoginSession();
   const [recipient, setRecipient] = useState<string>("");
   const [amount, setAmount] = useState<Decimal>(new Decimal(0));
   const [recipientWarning, setRecipientWarning] = useState<boolean>(false);
@@ -123,18 +123,21 @@ function SwapPage() {
     );
     setTx(tx);
 
-    transfer.confirmTransaction(tx, undefined, listener);
+    setCurrentPhase(TransferPhase.SENDING);
+
+    await transfer.confirmTransaction(tx, undefined, listener);
   };
 
   return (
     <SwapContainer>
+      <SwapTitle>
+        <T _str="ETH Address" _tags={transifexTags} />
+      </SwapTitle>
+      <SwapSecondTitle>
+        <T _str="Enter the ETH Address." _tags={transifexTags} />
+      </SwapSecondTitle>
+
       <FormControl fullWidth>
-        <SwapTitle>
-          <T _str="ETH Address" _tags={transifexTags} />
-        </SwapTitle>
-        <SwapSecondTitle>
-          <T _str="Enter the ETH Address." _tags={transifexTags} />
-        </SwapSecondTitle>
         <SwapInput
           type="text"
           name="address"
@@ -143,24 +146,26 @@ function SwapPage() {
           onBlur={() => setRecipientWarning(!addressVerify(recipient, true))}
           onFocus={() => setRecipientWarning(false)}
         />
-        <SwapTitle>
-          <T _str="NCG Amount" _tags={transifexTags} />
-        </SwapTitle>
-        <SwapSecondTitle>
-          <T _str="Enter the amount of NCG to send." _tags={transifexTags} />
-          &nbsp;
-          <b>
-            <T
-              _str="(Your balance: {ncg} NCG)"
-              _tags={transifexTags}
-              ncg={transfer.balance}
-            />
-          </b>
-          <Button
-            startIcon={<img src={refreshIcon} alt="refresh" />}
-            onClick={() => transfer.updateBalance(transfer.senderAddress)}
+      </FormControl>
+      <SwapTitle>
+        <T _str="NCG Amount" _tags={transifexTags} />
+      </SwapTitle>
+      <SwapSecondTitle>
+        <T _str="Enter the amount of NCG to send." _tags={transifexTags} />
+        &nbsp;
+        <b>
+          <T
+            _str="(Your balance: {ncg} NCG)"
+            _tags={transifexTags}
+            ncg={transfer.balance}
           />
-        </SwapSecondTitle>
+        </b>
+        <Button
+          startIcon={<img src={refreshIcon} alt="refresh" />}
+          onClick={() => transfer.updateBalance(transfer.senderAddress)}
+        />
+      </SwapSecondTitle>
+      <FormControl fullWidth>
         <SwapInput
           type="number"
           name="amount"
@@ -173,43 +178,43 @@ function SwapPage() {
           endAdornment={<InputAdornment position="end">NCG</InputAdornment>}
           defaultValue={0}
         />
-        <SwapNoticeTitle>
-          <T _str="Notice" _tags={transifexTags} />
-        </SwapNoticeTitle>
-        <ul style={{ listStyleType: "none", padding: 0, marginTop: "5px" }}>
-          <li>
-            <SwapNoticeLabel>
-              <T _str="* Minimum 100 NCG per transfer" _tags={transifexTags} />
-            </SwapNoticeLabel>
-          </li>
-          <li>
-            <SwapNoticeLabel>
-              <T
-                _str="* Maximum {max, number, integer} NCG per day"
-                _tags={transifexTags}
-                max={5000}
-              />
-            </SwapNoticeLabel>
-          </li>
-          <li>
-            <SwapNoticeLabel>
-              <T
-                _str="* 1% fee deducted to operate bridge (ETH gas fee & development cost)"
-                _tags={transifexTags}
-              />
-            </SwapNoticeLabel>
-          </li>
-        </ul>
-        <SwapButton
-          variant="contained"
-          color="primary"
-          onClick={handleButton}
-          disabled={amountWarning || recipientWarning}
-        >
-          {" "}
-          Send{" "}
-        </SwapButton>
       </FormControl>
+      <SwapNoticeTitle>
+        <T _str="Notice" _tags={transifexTags} />
+      </SwapNoticeTitle>
+      <ul style={{ listStyleType: "none", padding: 0, marginTop: "5px" }}>
+        <li>
+          <SwapNoticeLabel>
+            <T _str="* Minimum 100 NCG per transfer" _tags={transifexTags} />
+          </SwapNoticeLabel>
+        </li>
+        <li>
+          <SwapNoticeLabel>
+            <T
+              _str="* Maximum {max, number, integer} NCG per day"
+              _tags={transifexTags}
+              max={5000}
+            />
+          </SwapNoticeLabel>
+        </li>
+        <li>
+          <SwapNoticeLabel>
+            <T
+              _str="* 1% fee deducted to operate bridge (ETH gas fee & development cost)"
+              _tags={transifexTags}
+            />
+          </SwapNoticeLabel>
+        </li>
+      </ul>
+      <SwapButton
+        variant="contained"
+        color="primary"
+        onClick={handleButton}
+        disabled={amountWarning || recipientWarning}
+      >
+        {" "}
+        Send{" "}
+      </SwapButton>
 
       <SendingDialog
         open={currentPhase === TransferPhase.SENDING}

--- a/src/renderer/views/TransferAssetOverlay/swap.tsx
+++ b/src/renderer/views/TransferAssetOverlay/swap.tsx
@@ -20,6 +20,7 @@ import { useStore } from "src/utils/useStore";
 import { TransactionConfirmationListener } from "src/stores/transfer";
 import { handleDetailView, TransferPhase } from "src/utils/transfer/utils";
 import refreshIcon from "src/renderer/resources/refreshIcon.png";
+import { useLoginSession } from "src/utils/useLoginSession";
 
 const transifexTags = "Transfer/Transfer";
 
@@ -70,7 +71,8 @@ const SwapButton = styled(Button)({
 });
 
 function SwapPage() {
-  const { transfer, account } = useStore();
+  const transfer = useStore("transfer");
+  const { address, publicKey, account } = useLoginSession();
   const [recipient, setRecipient] = useState<string>("");
   const [amount, setAmount] = useState<Decimal>(new Decimal(0));
   const [recipientWarning, setRecipientWarning] = useState<boolean>(false);
@@ -106,15 +108,18 @@ function SwapPage() {
       return;
     }
 
+    if (!publicKey || !account) {
+      return;
+    }
+
     setCurrentPhase(TransferPhase.SENDTX);
 
-    const publickey = await account.getPublicKeyString();
     const tx = await transfer.swapToWNCG(
       transfer.senderAddress,
       recipient,
       amount,
-      publickey,
-      account.account
+      publicKey,
+      account
     );
     setTx(tx);
 

--- a/src/renderer/views/TransferAssetOverlay/transfer.tsx
+++ b/src/renderer/views/TransferAssetOverlay/transfer.tsx
@@ -125,7 +125,9 @@ function TransferPage() {
     );
     setTx(tx);
 
-    transfer.confirmTransaction(tx, undefined, listener);
+    setCurrentPhase(TransferPhase.SENDING);
+
+    await transfer.confirmTransaction(tx, undefined, listener);
     event.preventDefault();
   };
 
@@ -137,7 +139,7 @@ function TransferPage() {
 
   return (
     <TransferContainer>
-      <FormControl fullWidth>
+      <div>
         <TransferTitle>
           <T _str="User Address" _tags={transifexTags} />
         </TransferTitle>
@@ -150,14 +152,16 @@ function TransferPage() {
             <T _str="Not the ETH address." _tags={transifexTags} />
           </b>
         </TransferSecondTitle>
-        <TransferInput
-          type="text"
-          name="address"
-          error={recipientWarning}
-          onChange={(e) => setRecipient(e.target.value)}
-          onBlur={() => setRecipientWarning(!addressVerify(recipient, true))}
-          onFocus={() => setRecipientWarning(false)}
-        />
+        <FormControl fullWidth>
+          <TransferInput
+            type="text"
+            name="address"
+            error={recipientWarning}
+            onChange={(e) => setRecipient(e.target.value)}
+            onBlur={() => setRecipientWarning(!addressVerify(recipient, true))}
+            onFocus={() => setRecipientWarning(false)}
+          />
+        </FormControl>
         <TransferTitle>
           <T _str="NCG Amount" _tags={transifexTags} />
         </TransferTitle>
@@ -173,42 +177,52 @@ function TransferPage() {
           </b>
           <Button
             startIcon={<img src={refreshIcon} alt="refresh" />}
-            onClick={() => transfer.updateBalance(transfer.senderAddress)}
+            onClick={async () =>
+              await transfer.updateBalance(transfer.senderAddress)
+            }
           />
         </TransferSecondTitle>
-        <TransferInput
-          type="number"
-          name="amount"
-          onChange={(e) =>
-            setAmount(new Decimal(e.target.value === "" ? -1 : e.target.value))
-          }
-          onBlur={() => setAmountWarning(!amount.gt(0))}
-          onFocus={() => setAmountWarning(false)}
-          error={amountWarning}
-          endAdornment={<InputAdornment position="end">NCG</InputAdornment>}
-          defaultValue={0}
-        />
+        <FormControl fullWidth>
+          <TransferInput
+            type="number"
+            name="amount"
+            onChange={(e) =>
+              setAmount(
+                new Decimal(e.target.value === "" ? -1 : e.target.value)
+              )
+            }
+            onBlur={() => setAmountWarning(!amount.gt(0))}
+            onFocus={() => setAmountWarning(false)}
+            error={amountWarning}
+            endAdornment={<InputAdornment position="end">NCG</InputAdornment>}
+            defaultValue={0}
+          />
+        </FormControl>
         <TransferTitle>
           <T _str="Memo" _tags={transifexTags} />
         </TransferTitle>
         <TransferSecondTitle>
           <T _str="Enter an additional note." _tags={transifexTags} />
         </TransferSecondTitle>
-        <TransferInput
-          type="text"
-          name="memo"
-          onChange={(e) => setMemo(e.target.value)}
-        />
-        <TransferButton
-          variant="contained"
-          color="primary"
-          onClick={handleButton}
-          disabled={disabled}
-        >
-          {loading && <CircularProgress />}
-          Send
-        </TransferButton>
-      </FormControl>
+        <FormControl fullWidth>
+          <TransferInput
+            type="text"
+            name="memo"
+            onChange={(e) => setMemo(e.target.value)}
+          />
+        </FormControl>
+        <FormControl fullWidth>
+          <TransferButton
+            variant="contained"
+            color="primary"
+            onClick={handleButton}
+            disabled={disabled}
+          >
+            {loading && <CircularProgress />}
+            Send
+          </TransferButton>
+        </FormControl>
+      </div>
 
       <SendingDialog
         open={currentPhase === TransferPhase.SENDING}

--- a/src/renderer/views/TransferAssetOverlay/transfer.tsx
+++ b/src/renderer/views/TransferAssetOverlay/transfer.tsx
@@ -21,6 +21,7 @@ import { TransactionConfirmationListener } from "src/stores/transfer";
 import refreshIcon from "src/renderer/resources/refreshIcon.png";
 import { useStore } from "src/utils/useStore";
 import { handleDetailView, TransferPhase } from "src/utils/transfer/utils";
+import { useLoginSession } from "src/utils/useLoginSession";
 
 const transifexTags = "Transfer/Transfer";
 
@@ -65,7 +66,8 @@ const CircularProgress = styled(OriginCircularProgress)({
 });
 
 function TransferPage() {
-  const { transfer, account } = useStore();
+  const { transfer } = useStore();
+  const { publicKey, account } = useLoginSession();
   const [recipient, setRecipient] = useState<string>("");
   const [memo, setMemo] = useState<string>("");
   const [amount, setAmount] = useState<Decimal>(new Decimal(0));
@@ -106,16 +108,20 @@ function TransferPage() {
       alert(errorMessage);
       return;
     }
+
+    if (!publicKey || !account) {
+      return;
+    }
+
     setCurrentPhase(TransferPhase.SENDTX);
 
-    const publickey = await account.getPublicKeyString();
     const tx = await transfer.transferAsset(
       transfer.senderAddress,
       recipient,
       amount,
       memo,
-      publickey,
-      account.account
+      publicKey,
+      account
     );
     setTx(tx);
 

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -9,6 +9,9 @@ import {
 } from "@planetarium/account-local";
 import { createAccount } from "@planetarium/account-raw";
 import { Account, deriveAddress } from "@planetarium/sign";
+// FIXME these imports cause matter since file-system related features aren't
+// possible on some targets (e.g., browser). thus we should extract them from
+// this store to the dedicated backend, and inject that into this.
 import fs from "fs";
 import path from "path";
 import { action, observable } from "mobx";

--- a/src/utils/monsterCollection/index.ts
+++ b/src/utils/monsterCollection/index.ts
@@ -14,6 +14,7 @@ import {
 } from "src/interfaces/collection";
 import { useStore } from "../useStore";
 import { mapSheetResponseToSheet } from "./internal";
+import { useLoginSession } from "../useLoginSession";
 
 const getTotalDepositedGold = (
   sheet: CollectionSheetItem[],
@@ -27,12 +28,12 @@ const getTotalDepositedGold = (
 };
 
 export function useMonsterCollection() {
-  const account = useStore("account");
+  const { address } = useLoginSession();
   const commonQuery = {
     variables: {
-      address: account.address,
+      address,
     },
-    skip: !account.isLogin,
+    skip: !address,
   };
 
   const { data: collectionStatusQuery } =
@@ -40,8 +41,8 @@ export function useMonsterCollection() {
   const { data: collectionStatus } =
     useCollectionStatusByAgentSubscription(commonQuery);
   const { data: collectionStateQuery } = useStateQueryMonsterCollectionQuery({
-    variables: { agentAddress: account.address },
-    skip: !account.isLogin,
+    variables: { agentAddress: address },
+    skip: !address,
   });
   const { data: collectionState } =
     useCollectionStateByAgentSubscription(commonQuery);

--- a/src/utils/staking.ts
+++ b/src/utils/staking.ts
@@ -1,14 +1,15 @@
 import { useCurrentStakingQuery } from "src/generated/graphql";
 import { useStore } from "./useStore";
 import { useTip } from "./useTip";
+import { useLoginSession } from "./useLoginSession";
 
 export function useStaking() {
-  const account = useStore("account");
+  const { address } = useLoginSession();
   const commonQuery = {
     variables: {
-      address: account.address,
+      address,
     },
-    skip: !account.isLogin,
+    skip: !address,
   };
 
   const { data: current, refetch } = useCurrentStakingQuery(commonQuery);

--- a/src/utils/useActivation.ts
+++ b/src/utils/useActivation.ts
@@ -30,7 +30,7 @@ export function useActivation(doActivate: boolean): ActivationResult {
   const isAvailable = useIsHeadlessAvailable();
   const [activateAccountTxId, setActivateAccountTxId] = useState<string>();
   const [txError, setTxError] = useState<Error | undefined>();
-  const { loading, data, error } = useActivationAddressQuery({
+  const { loading, data, error, stopPolling } = useActivationAddressQuery({
     variables: {
       address,
     },
@@ -97,7 +97,8 @@ export function useActivation(doActivate: boolean): ActivationResult {
         },
       });
     }
-  }, [
+ if(activated) stopPolling();
+   }, [
     accountStore.activationKey,
     requestActivateAccountTx,
     nonceData,

--- a/src/utils/useActivation.ts
+++ b/src/utils/useActivation.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { unstable_batchedUpdates } from "react-dom";
 import {
   useActivateAccountLazyQuery,
   useActivationAddressQuery,
@@ -7,6 +6,8 @@ import {
 } from "src/generated/graphql";
 import { useIsHeadlessAvailable } from "./useIsHeadlessAvailable";
 import { useStore } from "./useStore";
+import { useTx } from "src/utils/useTx";
+import { useLoginSession } from "./useLoginSession";
 
 interface ActivationResult {
   loading: boolean;
@@ -19,21 +20,25 @@ interface ActivationResult {
  * 1. It queries the activation status of the current account.
  * 2. When the activationKey is provided, it will stage a transaction to activate the account.
  *
- * @param activationKey An activation key to use for automatic activation. Pass `undefined` to disable automatic activation.
  * @returns {ActivationResult} A object with two properties: `loading` and `activated`. They are pretty self-explanatory.
  */
-export function useActivation(activationKey?: string): ActivationResult {
-  const account = useStore("account");
+
+// FIXME Divide this hook onto query and mutation instead of flag
+export function useActivation(doActivate: boolean): ActivationResult {
+  const { address, publicKey } = useLoginSession();
+  const accountStore = useStore("account");
   const isAvailable = useIsHeadlessAvailable();
-  const [isPolling, setPolling] = useState(false);
+  const [activateAccountTxId, setActivateAccountTxId] = useState<string>();
   const [txError, setTxError] = useState<Error | undefined>();
   const { loading, data, error } = useActivationAddressQuery({
     variables: {
-      address: account.address,
+      address,
     },
-    pollInterval: isPolling ? 1000 : undefined,
-    skip: !account.isLogin,
+    pollInterval: activateAccountTxId ? 1000 : undefined,
+    skip: !address,
   });
+  const tx = useTx();
+  const activated = data?.activationStatus.addressActivated ?? false;
 
   const {
     loading: nonceLoading,
@@ -41,53 +46,72 @@ export function useActivation(activationKey?: string): ActivationResult {
     error: nonceError,
   } = useActivationKeyNonceQuery({
     variables: {
-      // @ts-expect-error The query will not run if activationKey is undefined due to the skip option.
-      encodedActivationKey: activationKey,
+      encodedActivationKey: accountStore.activationKey,
     },
-    skip: !activationKey,
+    skip: !accountStore.activationKey,
   });
-  const [tx] = useActivateAccountLazyQuery();
+  const [
+    requestActivateAccountTx,
+    {
+      called: activateAccountTxCalled,
+      loading: activateAccountTxLoading,
+      error: activateAccountTxError,
+    },
+  ] = useActivateAccountLazyQuery({
+    fetchPolicy: "network-only",
+    onCompleted: ({ actionTxQuery: { activateAccount } }) => {
+      tx(activateAccount)
+        .then((res) => {
+          if (res.data?.stageTransaction) {
+            setActivateAccountTxId(res.data.stageTransaction);
+          }
+        })
+        .catch((e) => {
+          setTxError(e);
+        });
+    },
+  });
 
   useEffect(() => {
     if (nonceData?.activated) {
       setTxError(new Error("Already activated."));
       return;
     }
-    if (
-      !data?.activationStatus.addressActivated &&
-      activationKey &&
-      nonceData?.activationKeyNonce &&
-      !isPolling
-    ) {
-      unstable_batchedUpdates(() => {
-        setPolling(true);
-        setTxError(undefined);
-      });
-      account
-        .getPublicKeyString()
-        .then((v) =>
-          tx({
-            variables: {
-              publicKey: v,
-              activationCode: activationKey,
-            },
-          })
-        )
-        .catch((e) => {
-          setTxError(e);
-          console.error(e);
-        })
-        .then(() => setPolling(false));
-    }
-  }, [activationKey, tx, nonceData, isPolling]);
 
-  useEffect(() => {
-    if (data?.activationStatus.addressActivated) setPolling(false);
-  }, [data]);
+    if (!doActivate) {
+      return;
+    }
+
+    if (
+      !activated &&
+      !activateAccountTxCalled &&
+      !activateAccountTxLoading &&
+      publicKey &&
+      accountStore.activationKey &&
+      nonceData?.activationKeyNonce
+    ) {
+      requestActivateAccountTx({
+        variables: {
+          publicKey,
+          activationCode: accountStore.activationKey,
+        },
+      });
+    }
+  }, [
+    accountStore.activationKey,
+    requestActivateAccountTx,
+    nonceData,
+    activated,
+    publicKey,
+    activateAccountTxCalled,
+    doActivate,
+    activateAccountTxLoading,
+  ]);
 
   return {
-    loading: loading || nonceLoading || !isAvailable,
-    error: Boolean(txError || error || nonceError),
-    activated: data?.activationStatus.addressActivated ?? false,
+    loading:
+      loading || nonceLoading || !isAvailable || activateAccountTxLoading,
+    error: Boolean(txError || error || nonceError || activateAccountTxError),
+    activated,
   };
 }

--- a/src/utils/useBalance.ts
+++ b/src/utils/useBalance.ts
@@ -3,21 +3,21 @@ import {
   useGetNcgBalanceQuery,
   useBalanceByAgentSubscription,
 } from "src/generated/graphql";
-import { useStore } from "./useStore";
+import { useLoginSession } from "./useLoginSession";
 
 export function useBalance() {
-  const account = useStore("account");
+  const { address } = useLoginSession();
   const { data: ncgBalanceQuery } = useGetNcgBalanceQuery({
     variables: {
-      address: account.address,
+      address,
     },
-    skip: !account.isLogin,
+    skip: !address,
   });
   const { data: balance } = useBalanceByAgentSubscription({
     variables: {
-      address: account.address,
+      address,
     },
-    skip: !account.isLogin,
+    skip: !address,
   });
 
   return useMemo(

--- a/src/utils/useLoginSession.ts
+++ b/src/utils/useLoginSession.ts
@@ -1,0 +1,11 @@
+import { useStore } from "./useStore";
+
+export function useLoginSession() {
+  const accountStore = useStore("account");
+
+  return {
+    address: accountStore.loginSession?.address,
+    account: accountStore.loginSession?.account,
+    publicKey: accountStore.loginSession?.publicKey,
+  };
+}

--- a/src/utils/useTx.ts
+++ b/src/utils/useTx.ts
@@ -8,9 +8,9 @@ import { useStore } from "./useStore";
  * You can use this value in place of another argument to specify that the value will be provided later.
  *
  * ```ts
- * const tx = useTx("stake", placeholder);
+ * const tx = useTx();
  *
- * return <button onClick={() => tx(1)}>Stake</button>
+ * return <button onClick={() => tx(hexEncodedstakeTxPayload)}>Stake</button>
  * ```
  */
 
@@ -19,29 +19,25 @@ type Result = ReturnType<ReturnType<typeof useStageTransactionMutation>[0]>;
 /**
  * A helper hook that creates and stages a transaction.
  *
- * @param event An action to stage.
- * @param args Arguments to pass to the action.
  * @returns A async function that stages the transaction when called.
  */
 export function useTx(): (tx: string) => Result {
+  const accountStore = useStore("account");
   const inProgress = useRef(false);
-  const account = useStore("account");
   const [stage] = useStageTransactionMutation();
+
   return async (tx: string) => {
+    const account = accountStore.loginSession?.account;
     if (inProgress.current) throw new Error("Already in progress.");
+    if (!account) throw new Error("There is no logged in account.");
     else inProgress.current = true;
 
     try {
-      const encodedTx = await signTransaction(tx, account.account);
+      const encodedTx = await signTransaction(tx, account);
       return await stage({
         variables: {
           payload: encodedTx,
         },
-      }).then((res) => {
-        if (res.data) {
-          console.log(res.data.stageTransaction);
-        }
-        return res;
       });
     } finally {
       inProgress.current = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3379,9 +3379,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@planetarium/account-local@npm:^0.0.31":
-  version: 0.0.31
-  resolution: "@planetarium/account-local@npm:0.0.31"
+"@planetarium/account-local@npm:^0.0.37":
+  version: 0.0.37
+  resolution: "@planetarium/account-local@npm:0.0.37"
   dependencies:
     "@noble/hashes": ^1.1.5
     "@noble/secp256k1": ^1.7.0
@@ -3392,7 +3392,7 @@ __metadata:
     uuid: ^9.0.0
   peerDependencies:
     "@planetarium/sign": ^0.0.11
-  checksum: 307dbfd4fa20ac5555e282f07fbe050a0ee82122a4e274563c58f460cbfec4305ae2653b1c8aa64afeeda719f3b2f918ed4efb54d6442d27ac751c9cbca6f426
+  checksum: 30775690dc610c7c2fe08efc258c285cca24a93544604d99bf1e5b20e1bf1d321c9a94e040fd25d2678f287811539de3f4e6290e6d14ceb918cbfcee81d199e6
   languageName: node
   linkType: hard
 
@@ -7103,7 +7103,7 @@ __metadata:
     "@material-ui/lab": ^4.0.0-alpha.56
     "@material-ui/styles": ^4.10.0
     "@noble/secp256k1": ^1.7.0
-    "@planetarium/account-local": ^0.0.31
+    "@planetarium/account-local": ^0.0.37
     "@planetarium/account-raw": ^0.0.3
     "@planetarium/check-free-space": ^0.0.2
     "@planetarium/cli": ^0.40.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,14 +3490,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@planetarium/sign@npm:^0.0.11":
-  version: 0.0.11
-  resolution: "@planetarium/sign@npm:0.0.11"
+"@planetarium/sign@npm:^0.0.12":
+  version: 0.0.12
+  resolution: "@planetarium/sign@npm:0.0.12"
   dependencies:
     "@noble/hashes": ^1.1.2
     bencodex: ^0.1.2
     buffer: ^6.0.3
-  checksum: 71be8b55f1ea237b9bd426568671b880da217f723597a21c3b50f08a625d470414ec8dd3fc69a244e6299355d5b99f2927ca91082c9144698627e1db85bfd717
+  checksum: fd8bf1f4ea990d10d07bfd43994662ce7d5e01f1475a01711053dc6e0510837f324f8d6eaa4dfc802df3f64fb16c67450df0e626f661f9485e55f28d90dbae59
   languageName: node
   linkType: hard
 
@@ -7107,7 +7107,7 @@ __metadata:
     "@planetarium/account-raw": ^0.0.3
     "@planetarium/check-free-space": ^0.0.2
     "@planetarium/cli": ^0.40.0
-    "@planetarium/sign": ^0.0.11
+    "@planetarium/sign": ^0.0.12
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
     "@radix-ui/react-radio-group": ^0.1.5
     "@radix-ui/react-scroll-area": ^0.1.4


### PR DESCRIPTION
This PR mainly addresses `src/stores/account.ts` and features related to it.

- Fixed various bugs had occurred when the keystore directory path didn't exist on the system (see also https://github.com/planetarium/sphere/pull/38)
- Fixed malformed behaviors on activation by correcting and limiting `useActivation()` custom hook's mutation.
- Fixed bugs related to `account` store caused by invalid assumptions and implementations. 
  - To achieve this, some methods (actions) that assume a logged-in user was removed from the `acocunt` store, and a new login session interface (`ILoginSession`) was introduced.
  - Also, fixed a bug where @planetarium/sign would return an incorrect address for accounts created with v3.
- (minor) Fixed an error caused by incorrect markup in the NCG transfer/exchange UI.

In addition, the direct import of `fs` module by the `account` store is breaking CI, and I consider this not simply a CI issue, but a significant disturbance in portability to platforms other than electron.
However, introducing a new abstraction interface to resolve this in the current unit of work would make the scope of work too large, so first of all, I temporarily removed the offending CI job and left only comments on the `account` store.