### PR TITLE
fix: activation view ui bugs

### DIFF
--- a/src/renderer/views/RegisterView/ActivationFailView.tsx
+++ b/src/renderer/views/RegisterView/ActivationFailView.tsx
@@ -20,7 +20,7 @@ function ActivationFailView() {
       <H1>
         <T _str="Activation has failed" _tags={transifexTags} />
       </H1>
-      <Text css={{ fontSize: 14, whiteSpace: "pre-wrap" }}>
+      <Text css={{ fontSize: 14, whiteSpace: "pre" }}>
         <T
           _str="An unknown error has occurred.\nPlease make sure your activation code is valid or try again later."
           _tags={transifexTags}

--- a/src/renderer/views/RegisterView/ActivationFailView.tsx
+++ b/src/renderer/views/RegisterView/ActivationFailView.tsx
@@ -20,7 +20,7 @@ function ActivationFailView() {
       <H1>
         <T _str="Activation has failed" _tags={transifexTags} />
       </H1>
-      <Text css={{ fontSize: 14 }}>
+      <Text css={{ fontSize: 14, whiteSpace: "pre-wrap" }}>
         <T
           _str="An unknown error has occurred.\nPlease make sure your activation code is valid or try again later."
           _tags={transifexTags}

--- a/src/renderer/views/RegisterView/ActivationWaitView.tsx
+++ b/src/renderer/views/RegisterView/ActivationWaitView.tsx
@@ -67,7 +67,12 @@ function ActivationWaitView() {
         layout
         variant="primary"
         centered
-        css={{ width: 200, marginTop: 180 }}
+        css={{
+          width: 200,
+          marginTop: 180,
+          display: "flex",
+          justifyContent: "center",
+        }}
         disabled
       >
         <LoadingImage src={loading} />


### PR DESCRIPTION
There were UI bugs fixed

- The `white-space: pre` was not applied to `Text` in `ActivationFailView`, resulting the newline (`\n`) to be printed.
- The loading circle was not aligned to the middle in `ActivationWaitView`