### PR TITLE
Install dependencies with `--immutable` option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,9 @@ jobs:
 
       - name: Install
         shell: bash
-        run: yarn
+        run: yarn install --immutable
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
       - name: Setup OS variables
         run: bash scripts/configure-artifact.sh ${{ matrix.targetPlatform }}


### PR DESCRIPTION
Since #2129, Circle CI workflow was migrated into GitHub Actions workflow. During the steps, I found something was missing. This pull request recovers the `--immutable` option when installing dependencies with the yarn command.