### PR TITLE
[Fix] Check disk space during Player/Launcher update

### DIFF
--- a/src/main/update/launcher-update.ts
+++ b/src/main/update/launcher-update.ts
@@ -101,7 +101,6 @@ export async function launcherUpdate(
       });
     } catch (e) {
       win.webContents.send("go to error page", "player", {
-        size: e.size,
         url: "download-binary-failed-disk-error",
       });
 

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -90,7 +90,6 @@ export async function playerUpdate(
       });
     } catch (e) {
       win.webContents.send("go to error page", "player", {
-        size: e.size,
         url: "download-binary-failed-disk-error",
       });
 

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -25,7 +25,7 @@ export async function playerUpdate(
       const totalBytes = downloadItem.getTotalBytes();
       const totalKB = totalBytes / 1024;
 
-      if (totalKB < available) {
+      if (totalKB > available) {
         win.webContents.send("go to error page", "player", {
           size: totalBytes,
           url: "download-binary-failed-disk-error",

--- a/src/renderer/Routes.tsx
+++ b/src/renderer/Routes.tsx
@@ -1,5 +1,6 @@
 import { observer } from "mobx-react";
 import React, { useEffect } from "react";
+import { useActor } from "@xstate/react";
 import { Redirect, Route, Switch, useHistory } from "react-router";
 import { useStore } from "src/utils/useStore";
 import ErrorView from "./views/ErrorView";
@@ -17,6 +18,7 @@ import {
 } from "./views/RegisterView";
 import RevokeView from "./views/RevokeView";
 import WelcomeView from "./views/WelcomeView";
+import { updateService } from "src/renderer/machines/updateMachine";
 
 const Redirector = observer(() => {
   const account = useStore("account");
@@ -32,6 +34,16 @@ const Redirector = observer(() => {
 });
 
 export default function Routes() {
+  const history = useHistory();
+
+  const [state] = useActor(updateService);
+
+  useEffect(() => {
+    if (state.matches("error") && state.context.data?.url) {
+      history.push(`/error/${state.context.data.url}`);
+    }
+  }, [history, state]);
+
   return (
     <Switch>
       <Route path="/login" component={LoginView} />

--- a/src/renderer/views/ErrorView/index.tsx
+++ b/src/renderer/views/ErrorView/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef, useState } from "react";
 import { observer } from "mobx-react";
-import { preloadService } from "src/renderer/machines/preloadMachine";
 import { useActor } from "@xstate/react";
 import { Redirect, Route, Switch, useRouteMatch } from "react-router";
 import { t } from "@transifex/native";
@@ -16,6 +15,7 @@ import {
   app,
   installerUrl,
 } from "src/config";
+import { updateService } from "src/renderer/machines/updateMachine";
 
 const transifexTags = "v2/ErrorView";
 
@@ -36,7 +36,7 @@ function handleRestart() {
 
 function ErrorView() {
   const { path } = useRouteMatch();
-  const [state] = useActor(preloadService);
+  const [state] = useActor(updateService);
   const checkboxRef = useRef<HTMLInputElement>(null);
 
   const handleRestartClick = useCallback(() => {
@@ -81,6 +81,30 @@ function ErrorView() {
           </Button>
         </ErrorContent>
       </Route>
+
+      <Route path={`${path}/download-binary-failed-disk-error`}>
+        <ErrorContent
+          title={t("Download binary failed", { _tags: transifexTags })}
+        >
+          {/* FIXME: Multi-language support is required. */}
+          <>
+            {`Not enough storage space to update the ${state.context.error}`}{" "}
+            <br />
+            {state.context.data?.size
+              ? `You need a free space of ${bytes.format(
+                  Number(state.context.data.size),
+                  {
+                    unitSeparator: " ",
+                  }
+                )}.`
+              : ""}
+          </>
+          <Button variant="primary" centered onClick={handleRestart}>
+            <T _str="Restart" _tags={transifexTags} />
+          </Button>
+        </ErrorContent>
+      </Route>
+
       <Route path={`${path}/download-binary-failed-error`}>
         <ErrorContent
           title={t("Download binary failed", { _tags: transifexTags })}

--- a/src/renderer/views/UpdateView/index.tsx
+++ b/src/renderer/views/UpdateView/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StateFrom } from "xstate";
-import type machine from "src/renderer/machines/updateMachine";
+import type { updateMachine } from "src/renderer/machines/updateMachine";
 import { styled } from "../../stitches.config";
 import background from "src/renderer/resources/bg-character.png";
 import StatusBar from "./StatusBar";
@@ -13,7 +13,7 @@ import WindowControls from "src/renderer/components/core/Layout/WindowControls";
 const transifexTags = "v2/update";
 
 interface UpdateViewProps {
-  state: StateFrom<typeof machine>;
+  state: StateFrom<typeof updateMachine>;
   progress?: number;
 }
 
@@ -31,7 +31,7 @@ const FixedStatusBar = styled(StatusBar, {
   left: 50,
 });
 
-function getMessage(state: StateFrom<typeof machine>): string {
+function getMessage(state: StateFrom<typeof updateMachine>): string {
   if (state.matches({ launcherUpdate: "download" })) {
     return t("Downloading the new version launcher...", {
       _tags: transifexTags,

--- a/src/utils/APVSubscriptionProvider.tsx
+++ b/src/utils/APVSubscriptionProvider.tsx
@@ -4,13 +4,13 @@ import { useEffect } from "react";
 import { ipcRenderer } from "electron";
 import { IDownloadProgress } from "src/interfaces/ipc";
 import UpdateView from "src/renderer/views/UpdateView";
-import machine from "src/renderer/machines/updateMachine";
+import { updateMachine } from "src/renderer/machines/updateMachine";
 import { useEncounteredAPV } from "./useEncounteredAPV";
 
 export default function APVSubscriptionProvider({
   children,
 }: React.PropsWithChildren<{}>) {
-  const [state, send] = useMachine(machine, { devTools: true });
+  const [state, send] = useMachine(updateMachine, { devTools: true });
   const apv = useEncounteredAPV();
 
   useEffect(() => {
@@ -47,7 +47,7 @@ export default function APVSubscriptionProvider({
     );
   }, []);
 
-  return state.matches("ok") ? (
+  return state.matches("ok") || state.matches("error") ? (
     <>{children}</>
   ) : (
     <UpdateView state={state} progress={state.context.progress} />

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,29 @@
+import { exec } from "child_process";
+
+type OSPlatform = "darwin" | "linux" | "win32";
+
+export function getAvailableDiskSpace(path: string = "/"): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const platform = process.platform as OSPlatform;
+    let cmd: string;
+    if (platform === "darwin" || platform === "linux") {
+      cmd = `df -k ${path} | tail -1 | awk '{print $4}'`;
+    } else if (platform === "win32") {
+      cmd = `for /f "skip=1" %p in ('wmic logicaldisk get FreeSpace^,Size^,Caption /format:list ^| find /i "${path}"') do @echo %p`;
+    } else {
+      return reject(new Error(`Unsupported platform: ${platform}`));
+    }
+
+    exec(cmd, (err, stdout, stderr) => {
+      if (err) {
+        return reject(err);
+      }
+      if (stderr) {
+        return reject(new Error(stderr));
+      }
+
+      const available = parseInt(stdout.trim(), 10);
+      resolve(available);
+    });
+  });
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -2,16 +2,26 @@ import { exec } from "child_process";
 
 type OSPlatform = "darwin" | "linux" | "win32";
 
+function getCommandOfAvailableDisk(path: string): string {
+  const platform = process.platform as OSPlatform;
+
+  let cmd: string = "";
+
+  if (platform === "darwin" || platform === "linux") {
+    cmd = `df -k ${path} | tail -1 | awk '{print $4}'`;
+  } else if (platform === "win32") {
+    cmd = `for /f "skip=1" %p in ('wmic logicaldisk get FreeSpace^,Size^,Caption /format:list ^| find /i "${path}"') do @echo %p`;
+  }
+
+  return cmd;
+}
+
 export function getAvailableDiskSpace(path: string = "/"): Promise<number> {
   return new Promise((resolve, reject) => {
-    const platform = process.platform as OSPlatform;
-    let cmd: string;
-    if (platform === "darwin" || platform === "linux") {
-      cmd = `df -k ${path} | tail -1 | awk '{print $4}'`;
-    } else if (platform === "win32") {
-      cmd = `for /f "skip=1" %p in ('wmic logicaldisk get FreeSpace^,Size^,Caption /format:list ^| find /i "${path}"') do @echo %p`;
-    } else {
-      return reject(new Error(`Unsupported platform: ${platform}`));
+    const cmd = getCommandOfAvailableDisk(path);
+
+    if (!cmd) {
+      return reject(new Error(`Unsupported platform: ${process.platform}`));
     }
 
     exec(cmd, (err, stdout, stderr) => {


### PR DESCRIPTION
Resolve #1679 

In this PR, when a user is unable to update the launcher/player due to insufficient disk space, instead of simply stopping the launcher as before, now the launcher can guide the user through the error situation without stopping.

Initially, I wanted to proceed by checking the disk space before downloading and not even starting the download if there wasn't enough space. However, it was difficult to know the size of the uncompressed file before unpacking the downloaded file. Therefore, I opted to redirect the user to an error page to handle errors during the download process.

To create the error page, I couldn't find an appropriate existing page, so I created a page called `download-binary-failed-disk-error`. This page currently needs to be localized.
![image](https://user-images.githubusercontent.com/56328777/231991086-846e5fcf-b743-46f3-a703-63615d3fc0c4.png)

The three main changes from the previous implementation are as follows:

- Creation of an error page indicating that the update cannot proceed due to insufficient disk space
- In the electron-dl's onStarted event for downloading the Zip file, the remaining disk space is compared to the total file size, and if there is not enough space, the download is stopped and the user is redirected to the error page.
- If there is an error when unpacking the Zip file, the user is redirected to the disk space error page.


Please let me know if I misunderstood the requirements. Thank you.