### PR TITLE
[Feature] Add code signing scripts for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         shell: bash
         run: |
           yarn run pack-local
+          rm -R ./dist/*-unpacked
 
       - name: Cache electron-gyp
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,12 @@ jobs:
       - name: Copy builder config
         shell: bash
         run: |
+          sh scripts/download-codesigner.sh
+
           if [[ "${{ startsWith(github.event.ref, 'refs/tags/') }}" != true ]]
             timestamp=$(date +%s)
             jq --arg version "0.0.$timestamp" '.version = $version' package.json > tmp.$$.json && mv tmp.$$.json package.json
+            mv ./signing/sandbox_code_sign_tool.properties ./tmp/codesign/conf/code_sign_tool.properties
           fi
 
       - uses: actions/setup-node@v3

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ report.html
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# tmp dir
+/tmp

--- a/electron-builder.internal.yml
+++ b/electron-builder.internal.yml
@@ -13,6 +13,7 @@ win:
       arch:
         - "x64"
   icon: "app.ico"
+  sign: "./scripts/sign.js"
 mac:
   icon: "AppIcon.icns"
   target:

--- a/electron-builder.main.yml
+++ b/electron-builder.main.yml
@@ -13,6 +13,7 @@ win:
       arch:
         - "x64"
   icon: "app.ico"
+  sign: "./scripts/sign.js"
 mac:
   icon: "AppIcon.icns"
   target:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NineChronicles",
-  "productName": "NineChronicles",
+  "productName": "Nine Chronicles",
   "version": "0.0.1",
   "description": "Game Launcher for Nine Chronicles",
   "author": "Planetarium <engineering@planetariumhq.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NineChronicles",
-  "productName": "Nine Chronicles",
+  "productName": "NineChronicles",
   "version": "0.0.1",
   "description": "Game Launcher for Nine Chronicles",
   "author": "Planetarium <engineering@planetariumhq.com>",

--- a/scripts/download-codesigner.sh
+++ b/scripts/download-codesigner.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+PLATFORM=$1
+
+mkdir -p "./tmp"
+
+if [ "$PLATFORM" == "windows" ]; then
+  DOWNLOAD_URL="https://www.ssl.com/download/codesigntool-for-windows/"
+else
+  DOWNLOAD_URL="https://www.ssl.com/download/codesigntool-for-linux-and-macos/"
+fi
+
+curl -L "$DOWNLOAD_URL" -o "./tmp/CodeSignTool.zip"
+if [ ! -f "./tmp/CodeSignTool.zip" ]; then
+  echo "Failed to download CodeSignTool.zip"
+  exit 1
+fi
+
+unzip -q "./tmp/CodeSignTool.zip" -d "./tmp"
+rm "./tmp/CodeSignTool.zip"
+
+if [ "$PLATFORM" == "windows" ]; then
+  CODESIGN_DIR="CodeSignTool-v1.2.7-windows"
+else
+  CODESIGN_DIR="CodeSignTool-v1.2.7"
+fi
+
+mv "./tmp/$CODESIGN_DIR" "./tmp/codesign"
+if [ ! -d "./tmp/codesign" ]; then
+  echo "Failed to extract CodeSignTool"
+  exit 1
+fi
+
+if [ "$PLATFORM" != "windows" ]; then
+  chmod +x "./tmp/codesign/CodeSignTool.sh"
+fi
+
+echo "CodeSignTool installation completed"

--- a/scripts/sign.js
+++ b/scripts/sign.js
@@ -1,0 +1,27 @@
+/* eslint @typescript-eslint/no-var-requires: "off" */
+const child_process = require("child_process");
+const path = require("path");
+
+const rootPath = path.resolve(__dirname, "../");
+
+exports.default = async function (configuration) {
+  const OS = process.env.OS;
+  const ESIGNER_CREDENTIAL_ID = process.env.ESIGNER_CREDENTIAL_ID;
+  const ESIGNER_USERNAME = process.env.ESIGNER_USERNAME;
+  const ESIGNER_PASSWORD = process.env.ESIGNER_PASSWORD;
+  const ESIGNER_TOTP_SECRET = process.env.ESIGNER_TOTP_SECRET;
+
+  const runner =
+    OS === "windows"
+      ? ".\\signing\\window-signing.bat"
+      : "./signing/linux-signing.sh";
+  var dirname = path.dirname(configuration.path);
+  // var filename = path.basename(configuration.path);
+
+  child_process.execSync(
+    `${runner} ${ESIGNER_CREDENTIAL_ID} ${ESIGNER_USERNAME} ${ESIGNER_PASSWORD} ${ESIGNER_TOTP_SECRET} "${rootPath}" "${configuration.path}" "${dirname}"`,
+    {
+      stdio: "inherit",
+    }
+  );
+};

--- a/signing/linux-signing.sh
+++ b/signing/linux-signing.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+ESIGNER_CREDENTIAL_ID=$1
+ESIGNER_USERNAME=$2
+ESIGNER_PASSWORD=$3
+ESIGNER_TOTP_SECRET=$4
+ROOT_DIR_PATH=$5
+INPUT_FILE_PATH=$6
+OUTPUT_DIR_PATH=$7
+
+if [ ! -d "$ROOT_DIR_PATH/tmp/beforeSign" ]; then
+  mkdir "$ROOT_DIR_PATH/tmp/beforeSign"
+fi
+
+INPUT_FILE_NAME=$(basename "$INPUT_FILE_PATH")
+BEFORE_SIGN_FILE_NAME="forsigning.${INPUT_FILE_NAME##*.}"
+BEFORE_SIGN_FILE_PATH="$ROOT_DIR_PATH/tmp/beforeSign/$BEFORE_SIGN_FILE_NAME"
+mv "$INPUT_FILE_PATH" "$BEFORE_SIGN_FILE_PATH"
+
+echo "Copy to before folder: $BEFORE_SIGN_FILE_PATH"
+echo ""
+
+cd "$ROOT_DIR_PATH/tmp/codesign"
+./CodeSignTool.sh sign -credential_id="$ESIGNER_CREDENTIAL_ID" -username="$ESIGNER_USERNAME" -password="$ESIGNER_PASSWORD" -totp_secret="$ESIGNER_TOTP_SECRET" -output_dir_path="$OUTPUT_DIR_PATH" -input_file_path="$BEFORE_SIGN_FILE_PATH"
+
+echo "Finish signing: $OUTPUT_DIR_PATH/$BEFORE_SIGN_FILE_NAME"
+echo ""
+
+AFTER_SIGN_FILE_PATH="$OUTPUT_DIR_PATH/$BEFORE_SIGN_FILE_NAME"
+mv "$AFTER_SIGN_FILE_PATH" "$INPUT_FILE_PATH"
+
+echo "Rename to final file: $AFTER_SIGN_FILE_PATH -> $INPUT_FILE_PATH"
+echo ""

--- a/signing/sandbox_code_sign_tool.properties
+++ b/signing/sandbox_code_sign_tool.properties
@@ -1,0 +1,4 @@
+CLIENT_ID=qOUeZCCzSqgA93acB3LYq6lBNjgZdiOxQc-KayC3UMw
+OAUTH2_ENDPOINT=https://oauth-sandbox.ssl.com/oauth2/token
+CSC_API_ENDPOINT=https://cs-try.ssl.com
+TSA_URL=http://ts.ssl.com

--- a/signing/window-signing.bat
+++ b/signing/window-signing.bat
@@ -1,0 +1,32 @@
+@echo off
+
+set "ESIGNER_CREDENTIAL_ID=%1"
+set "ESIGNER_USERNAME=%2"
+set "ESIGNER_PASSWORD=%3"
+set "ESIGNER_TOTP_SECRET=%4"
+set "ROOT_DIR_PATH=%5"
+set "INPUT_FILE_PATH=%6"
+set "OUTPUT_DIR_PATH=%7"
+
+if not exist "%ROOT_DIR_PATH%\tmp\beforeSign" mkdir "%ROOT_DIR_PATH%\tmp\beforeSign"
+
+for %%F in ("%INPUT_FILE_PATH%") do set "INPUT_FILE_NAME=%%~nxF"
+set "BEFORE_SIGN_FILE_NAME=forsigning.%INPUT_FILE_NAME%"
+set "BEFORE_SIGN_FILE_PATH=%ROOT_DIR_PATH%\tmp\beforeSign%BEFORE_SIGN_FILE_NAME%"
+
+move "%INPUT_FILE_PATH%" "%BEFORE_SIGN_FILE_PATH%"
+
+echo Copy to before folder: %BEFORE_SIGN_FILE_PATH%
+echo.
+
+cd "%ROOT_DIR_PATH%\tmp\codesign"
+CodeSignTool.bat sign -credential_id="%ESIGNER_CREDENTIAL_ID%" -username="%ESIGNER_USERNAME%" -password="%ESIGNER_PASSWORD%" -totp_secret="%ESIGNER_TOTP_SECRET%" -output_dir_path="%OUTPUT_DIR_PATH%" -input_file_path="%BEFORE_SIGN_FILE_PATH%"
+
+echo Finish signing: %OUTPUT_DIR_PATH%%BEFORE_SIGN_FILE_NAME%
+echo.
+
+set "AFTER_SIGN_FILE_PATH=%OUTPUT_DIR_PATH%%BEFORE_SIGN_FILE_NAME%"
+move "%AFTER_SIGN_FILE_PATH%" "%INPUT_FILE_PATH%"
+
+echo Rename to final file: %AFTER_SIGN_FILE_PATH% -> %INPUT_FILE_PATH%
+echo.


### PR DESCRIPTION
Introducing codesign scripts for Windows.
Currently, we have been using codesigning from https://github.com/planetarium/9c-toolbelt, but the publish command in Electron Builder doesn't allow for the execution of the toolbelt script.
Hence, I am incorporating a codesign script specifically for Windows into the launcher repository.