### PR TITLE
Remove deb, rpm build

### DIFF
--- a/electron-builder.main.yml
+++ b/electron-builder.main.yml
@@ -39,8 +39,6 @@ linux:
     - "tar.gz"
     - "zip"
     - "AppImage"
-    - "deb"
-    - "rpm"
 publish:
   provider: "s3"
   bucket: "9c-release.planetariumhq.com"


### PR DESCRIPTION
In reference to the GitHub action located at https://github.com/planetarium/9c-launcher/actions/runs/5122240161/jobs/9211095127, we are currently encountering issues with the beta versions of the RPM and DEB builds.
As these builds are causing the action to fail, we have decided to remove them at this time. We aim to rectify the issue and reintroduce the builds when they are stable.