### PR TITLE
Initial Vesioning Start (2.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "NineChronicles",
   "productName": "Nine Chronicles",
-  "version": "0.0.3",
+  "version": "2.0.0",
   "description": "Game Launcher for Nine Chronicles",
   "author": "Planetarium <engineering@planetariumhq.com>",
   "license": "GPL-3.0",


### PR DESCRIPTION
# Major Release - 2.0.0
- Targeting 9c-unity v200030
- versions initialized to 0.0
- **From now on, release versioning scheme for launcher is in fully effect.**