### PR TITLE
[TEMP FIX] Filter all reward with CURRENCY Type

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -272,6 +272,7 @@ query StakingSheet {
         rewards {
           itemId
           rate
+          type
         }
         bonusRewards {
           itemId

--- a/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -96,12 +96,14 @@ function useRewards(levels: LevelList, index: number = 0) {
     [bonusRewards]
   );
 
-  return rewards?.map((v) => ({
-    ...v,
-    count(amount: Decimal) {
-      return amount.divToInt(v.rate).add(bonusRewardMap?.get(v.itemId) || 0);
-    },
-  }));
+  return rewards
+    ?.filter((v) => v.type !== "CURRENCY") // For filtering GARAGE Token temporarily.
+    .map((v) => ({
+      ...v,
+      count(amount: Decimal) {
+        return amount.divToInt(v.rate).add(bonusRewardMap?.get(v.itemId) || 0);
+      },
+    }));
 }
 
 type Alerts = "lower-deposit" | "confirm-changes" | "unclaimed" | "minimum";

--- a/src/renderer/views/MonsterCollectionOverlay/index.stories.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/index.stories.tsx
@@ -8,6 +8,7 @@ import { MonsterCollectionOverlayBase } from "./base";
 import {
   CurrentStakingDocument,
   CurrentStakingQuery,
+  StakeRewardType,
   StakingSheetDocument,
   StakingSheetQuery,
   useCurrentStakingQuery,
@@ -27,6 +28,7 @@ const result = {
               {
                 itemId: 10121000,
                 rate: 20,
+                type: StakeRewardType.Item,
               },
             ],
             bonusRewards: [],
@@ -38,6 +40,7 @@ const result = {
               {
                 itemId: 10121000,
                 rate: 20,
+                type: StakeRewardType.Item,
               },
             ],
             bonusRewards: [],
@@ -49,6 +52,7 @@ const result = {
               {
                 itemId: 10121000,
                 rate: 20,
+                type: StakeRewardType.Item,
               },
             ],
             bonusRewards: [],


### PR DESCRIPTION
This commit filters all kind of reward that has "CURRENCY" as it's type from displayed on MonsterCollection UI. (Such as GARAGE)

This is temporary fix until plans for extra rewards are laid.