### PR TITLE
Use first two part of version from original package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,8 @@ jobs:
         shell: bash
         run: |
           timestamp=$(date +%s)
-          jq --arg version "0.0.$timestamp" '.version = $version' package.json > tmp.$$.json && mv tmp.$$.json package.json
+          version=$(jq -r .version package.json | awk -F'.' '{print $1"."$2}')
+          jq --arg version "$version.$timestamp" '.version = $version' package.json > tmp.$$.json && mv tmp.$$.json package.json
           jq --arg suffix " Internal" '.productName += $suffix' package.json > tmp.$$.json && mv tmp.$$.json package.json
 
       - name: Cache electron-gyp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,9 @@ jobs:
 
           if [[ "${{ startsWith(github.event.ref, 'refs/tags/') }}" != true ]]
           then
-            timestamp=$(date +%s)
-            jq --arg version "0.0.$timestamp" '.version = $version' package.json > tmp.$$.json && mv tmp.$$.json package.json
+          timestamp=$(date +%s)
+          version=$(jq -r .version package.json | awk -F'.' '{print $1"."$2}')
+          jq --arg version "$version.$timestamp" '.version = $version' package.json > tmp.$$.json && mv tmp.$$.json package.json
             jq --arg suffix " Internal" '.productName += $suffix' package.json > tmp.$$.json && mv tmp.$$.json package.json
             jq --arg suffix "Internal" '.name += $suffix' package.json > tmp.$$.json && mv tmp.$$.json package.json
             sed 's/NineChronicles@workspace/NineChroniclesInternal@workspace/g' yarn.lock > temp.txt


### PR DESCRIPTION
Um. bit dirty, but it works.
it works for any number/value provided as long as it's "a.b.c" format.

I guess it's enough.

if Input is "1.2.3", awk -F'.' '{print $1"."$2} returns "1.2"
so "1.2" + "." + "$timestamp".

to test, `echo '1.2.3' | awk -F'.' '{print $1"."$2}'`