### PR TITLE
Read APV From Remote Node, not config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,7 @@ export class NodeInfo {
   readonly graphqlPort: number;
   readonly rpcPort: number;
   readonly nodeNumber: number;
+  apv = 0;
   clientCount = 0;
   tip = 0;
 
@@ -88,6 +89,7 @@ export class NodeInfo {
       if (ended.status === 200) {
         this.clientCount = ended.data!.rpcInformation.totalCount;
         this.tip = ended.data!.nodeStatus.tip.index;
+        this.apv = ended.data!.nodeStatus.appProtocolVersion?.version ?? 0;
         return ended.data!.nodeStatus.preloadEnded;
       }
     } catch (e) {

--- a/src/renderer/components/core/Layout/InfoText.tsx
+++ b/src/renderer/components/core/Layout/InfoText.tsx
@@ -23,11 +23,12 @@ const InfoTextStyled = styled("div", {
 function InfoText() {
   const address = useLoginSession()?.address;
   const [node, setNode] = useState<string>("loading");
+  const [apv, setApv] = useState<number>(0);
 
   const debugValue = useMemo(
     () =>
       [
-        `APV: ${getConfig("AppProtocolVersion")}`,
+        `APV: ${apv}`,
         address && `Account: ${address.toString()}`,
         `Node: ${node}`,
         awsSinkGuid && `Client ID: ${awsSinkGuid}`,
@@ -54,6 +55,7 @@ function InfoText() {
         if (node !== "loading") return;
         const nodeInfo: NodeInfo = await ipcRenderer.invoke("get-node-info");
         setNode(nodeInfo.host);
+        setApv(nodeInfo.apv);
       })(),
     [node]
   );
@@ -64,7 +66,7 @@ function InfoText() {
       <br />
       tip: {blockTip}
       <br />
-      {`version: v${getConfig("AppProtocolVersion").split("/")[0]}`}
+      {`version: v${apv}`}
     </InfoTextStyled>
   );
 }


### PR DESCRIPTION
Honestly I think this is almost a bug-like behavior. As we no longer uses APV for updating purposes, what matters most here is the version of connected node, not config.json. isn't it?

Tested on local environment, working perfectly.