### PR TITLE
Prevent Locale Value Overwrite

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -150,6 +150,7 @@ if (!app.requestSingleInstanceLock()) {
   app.on("open-url", (_, url) => win && send(win, IPC_OPEN_URL, url));
 
   let quitTracked = false;
+  // eslint-disable-next-line prefer-const
   let removedAddresses: Array<string> = [];
   app.on("before-quit", async (event) => {
     event.preventDefault();
@@ -225,6 +226,8 @@ async function initializeConfig() {
 
     // Replace config
     console.log("Replace config with remote config:", remoteConfig);
+    remoteConfig.Locale = getConfig("Locale");
+    console.log(remoteConfig.Locale);
     configStore.store = remoteConfig;
   } catch (error) {
     console.error(


### PR DESCRIPTION
This addresses #2259 partially, not fully.

but at least "Locale" value won't get overwritten by remote value.

I think this is safest strategy for now, but we need some proper object separation of systemConfig and userConfig in config.json in long term.