### PR TITLE
Hide to tray on click X, quit on tray

### DIFF
--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -26,4 +26,5 @@ export interface IConfig {
   UnitySentrySampleRate: number;
   DiscordUrl: string;
   MarketServiceUrl: string;
+  TrayOnClose: boolean;
 }

--- a/src/main/application.ts
+++ b/src/main/application.ts
@@ -42,9 +42,11 @@ export async function createWindow(): Promise<BrowserWindow> {
     }
   });
 
-  win.on("minimize", function (event: any) {
-    event.preventDefault();
-    win.hide();
+  win.on("close", function (event: any) {
+    if (!isQuitting) {
+      event.preventDefault();
+      win.hide();
+    }
   });
 
   if (process.env.NODE_ENV !== "production") {

--- a/src/main/application.ts
+++ b/src/main/application.ts
@@ -42,6 +42,11 @@ export async function createWindow(): Promise<BrowserWindow> {
     }
   });
 
+  win.on("minimize", function (event: any) {
+    event.preventDefault();
+    win.hide();
+  });
+
   if (process.env.NODE_ENV !== "production") {
     await win.loadURL("http://localhost:9000/index.html");
     await win.webContents.openDevTools({ mode: "detach" });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -227,6 +227,7 @@ async function initializeConfig() {
     // Replace config
     console.log("Replace config with remote config:", remoteConfig);
     remoteConfig.Locale = getConfig("Locale");
+    remoteConfig.TrayOnClose = getConfig("TrayOnClose", true);
     console.log(remoteConfig.Locale);
     configStore.store = remoteConfig;
   } catch (error) {
@@ -262,6 +263,8 @@ async function initializeApp() {
         .catch((err) => console.log("An error occurred: ", err));
 
     win = await createV2Window();
+
+    setV2Quitting(!getConfig("TrayOnClose"));
 
     if (useUpdate) {
       appUpdaterInstance = new AppUpdater(win, baseUrl, updateOptions);
@@ -359,6 +362,7 @@ function initializeIpc() {
 
   ipcMain.handle("execute launcher update", async (event) => {
     if (appUpdaterInstance === null) throw Error("appUpdaterInstance is null");
+    setV2Quitting(true);
     await appUpdaterInstance.execute();
   });
 

--- a/src/renderer/views/SettingsOverlay/index.tsx
+++ b/src/renderer/views/SettingsOverlay/index.tsx
@@ -250,6 +250,15 @@ function SettingsOverlay({ onClose, isOpen }: OverlayProps) {
             </FormSection>
             <FormSection>
               <GroupTitle>
+                <T _str="User Interface" _tags={transifexTags} />
+              </GroupTitle>
+              <Checkbox {...register("TrayOnClose")}>
+                <T
+                  _str="Keep launcher on tray when closed"
+                  _tags={transifexTags}
+                />
+              </Checkbox>
+              <GroupTitle>
                 <T _str="Send Information" _tags={transifexTags} />
               </GroupTitle>
               <Checkbox {...register("Mixpanel")}>


### PR DESCRIPTION
This resolves #2180, 
![image](https://github.com/planetarium/9c-launcher/assets/6278999/28741743-f6cd-41f0-be88-0e893245f787)
- Add "Keep launcher on tray" when closed option on Settings (default: true)
- Optionally keep launcher opened at tray when closed
- Tray - Quit Launcher to really close
- Fix launcher updater not affected by optional hide cc @Atralupus 

Tested on mac, working flawlessly.

~~This resolves #2180 in different way, instead of push close to minimize to tray, minimize button simply hide launcher into tray.~~

~~Um, it doesn't work on macOS as I tested? going to test on windows.~~

~~Sorry for late fix, @FioX0.~~