### PR TITLE
Add getExecutePath() to adapt legacy binary name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "NineChronicles",
   "productName": "Nine Chronicles",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "Game Launcher for Nine Chronicles",
   "author": "Planetarium <engineering@planetariumhq.com>",
   "license": "GPL-3.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -218,6 +218,12 @@ export function getBlockChainStorePath(): string {
 
 export const REQUIRED_DISK_SPACE = 20n * 1000n * 1000n * 1000n;
 export const SNAPSHOT_SAVE_PATH = app.getPath("userData");
+export const LEGACY_MAC_GAME_PATH = path.join(
+  playerPath,
+  "9c.app/Contents/MacOS/9c"
+);
+export const LEGACY_WIN_GAME_PATH = path.join(playerPath, "9c.exe");
+export const LEGACY_LINUX_GAME_PATH = path.join(playerPath, "9c");
 export const MAC_GAME_PATH = path.join(
   playerPath,
   "NineChronicles.app/Contents/MacOS/NineChronicles"
@@ -253,6 +259,21 @@ export const EXECUTE_PATH: {
   sunos: null,
   win32: WIN_GAME_PATH,
   cygwin: WIN_GAME_PATH,
+  netbsd: null,
+};
+export const LEGACY_EXECUTE_PATH: {
+  [k in NodeJS.Platform]: string | null;
+} = {
+  aix: null,
+  android: null,
+  darwin: LEGACY_MAC_GAME_PATH,
+  freebsd: null,
+  haiku: null,
+  linux: LEGACY_LINUX_GAME_PATH,
+  openbsd: null,
+  sunos: null,
+  win32: LEGACY_WIN_GAME_PATH,
+  cygwin: LEGACY_WIN_GAME_PATH,
   netbsd: null,
 };
 export const baseUrl = get("DownloadBaseURL", DEFAULT_DOWNLOAD_BASE_URL);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -295,10 +295,7 @@ function initializeIpc() {
       return;
     }
 
-    const node = utils.execute(
-      EXECUTE_PATH[process.platform] || WIN_GAME_PATH,
-      info.args
-    );
+    const node = utils.execute(utils.getExecutePath(), info.args);
 
     node.on("close", (code) => {
       // Code 21: ERROR_NOT_READY

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,6 +11,12 @@ import extractZip from "extract-zip";
 import { CancellableDownloadFailedError } from "./main/exceptions/cancellable-download-failed";
 import { CancellableExtractFailedError } from "./main/exceptions/cancellable-extract-failed";
 import destr from "destr";
+import {
+  EXECUTE_PATH,
+  LEGACY_EXECUTE_PATH,
+  LEGACY_WIN_GAME_PATH,
+  WIN_GAME_PATH,
+} from "./config";
 
 const pipeline = promisify(stream.pipeline);
 
@@ -271,4 +277,15 @@ export function getType(target: any) {
 export function getVersionNumberFromAPV(apv: string): number {
   const [version] = apv.split("/");
   return parseInt(version, 10);
+}
+
+export function getExecutePath() {
+  const defaultPath = EXECUTE_PATH[process.platform] ?? WIN_GAME_PATH;
+  const legacyPath =
+    LEGACY_EXECUTE_PATH[process.platform] ?? LEGACY_WIN_GAME_PATH;
+
+  if (fs.existsSync(defaultPath)) return defaultPath;
+  if (fs.existsSync(legacyPath)) return legacyPath;
+
+  throw new Error("Player Binary Not Exists.");
 }


### PR DESCRIPTION
This function make execution of game possible by checking if file exists in each path.

It's bit verbose in config.ts and definitely shrinkable,
But I personally think this is safest way possible for now....