### PR TITLE
Add PlayerUpdateRetryCount in config.json and Prevent Infinite Restart

### DIFF
--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -27,4 +27,5 @@ export interface IConfig {
   DiscordUrl: string;
   MarketServiceUrl: string;
   TrayOnClose: boolean;
+  PlayerUpdateRetryCount: number;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3,9 +3,7 @@ import {
   configStore,
   get as getConfig,
   getBlockChainStorePath,
-  WIN_GAME_PATH,
   playerPath,
-  EXECUTE_PATH,
   MIXPANEL_TOKEN,
   initializeNode,
   NodeInfo,
@@ -73,13 +71,6 @@ import {
   enable as webEnable,
 } from "@electron/remote/main";
 import { fork } from "child_process";
-import {
-  KeyId,
-  PassphraseEntry,
-  Web3Account,
-  Web3KeyStore,
-  getDefaultWeb3KeyStorePath,
-} from "@planetarium/account-web3-secret-storage";
 
 initializeSentry();
 
@@ -195,6 +186,10 @@ async function initializeConfig() {
     // Replace config
     console.log("Replace config with remote config:", remoteConfig);
     remoteConfig.Locale = getConfig("Locale");
+    remoteConfig.PlayerUpdateRetryCount = getConfig(
+      "PlayerUpdateRetryCount",
+      0
+    );
     remoteConfig.TrayOnClose = getConfig("TrayOnClose", true);
     console.log(remoteConfig.Locale);
     configStore.store = remoteConfig;
@@ -296,11 +291,18 @@ function initializeIpc() {
     }
 
     if (utils.getExecutePath() === "PLAYER_UPDATE") {
+      configStore.set(
+        // Update Retry Counter
+        "PlayerUpdateRetryCount",
+        configStore.get("PlayerUpdateRetryCount") + 1
+      );
       return manualPlayerUpdate();
     }
 
     const node = utils.execute(utils.getExecutePath(), info.args);
-
+    if (node !== null) {
+      configStore.set("PlayerUpdateRetryCount", 0);
+    }
     node.on("close", (code) => {
       // Code 21: ERROR_NOT_READY
       if (code === 21) {
@@ -332,6 +334,7 @@ function initializeIpc() {
   ipcMain.handle("execute launcher update", async (event) => {
     if (appUpdaterInstance === null) throw Error("appUpdaterInstance is null");
     setV2Quitting(true);
+    configStore.set("PlayerUpdateRetryCount", 0);
     await appUpdaterInstance.execute();
   });
 

--- a/src/main/update/player-update.ts
+++ b/src/main/update/player-update.ts
@@ -5,7 +5,7 @@ import { DownloadBinaryFailedError } from "../exceptions/download-binary-failed"
 import fs from "fs";
 import extractZip from "extract-zip";
 import { spawn as spawnPromise } from "child-process-promise";
-import { playerPath } from "src/config";
+import { get, playerPath } from "src/config";
 import { getAvailableDiskSpace } from "src/utils/file";
 import lockfile from "lockfile";
 import path from "path";
@@ -23,6 +23,14 @@ export async function performPlayerUpdate(
     console.log(
       "'encounter different version' event seems running already. Stop this flow."
     );
+    return;
+  }
+
+  if (get("PlayerUpdateRetryCount", 0) > 3) {
+    console.error("[ERROR] Player Update Failed 3 Times.");
+    win.webContents.send("go to error page", "player", {
+      url: "reinstall",
+    });
     return;
   }
 


### PR DESCRIPTION
Addded PlayerUpdateRetryCount in config.json
I tested all "Logical" cases, it's carefully conditioned to NOT overly prevent things.
So it's little bit complicated for just retry counter. it was necessary.

Unless user manipulate config.json directly, worst case possible can be mitigated by reinstalling launcher.

## State / Logic Flow
### Create
- Set Default `PlayerUpdateRetryCount` as 0 if key doesn't exists in config.json. 
## Logic
- Update Prevention Condition
  - Counter > 3
  - Stop performPlayerUpdate() and route to "/error/reinstall", guide user to reinstall launcher.
  - This affects both automatic update AND manual update pressed by user.

- Counter Increment Condition
  - Add 1 **ONLY** if player updater is triggered because of game binary not found during launch game procedure.
  - Addition is after launch attempt, not before.
  - **USER PUSHING MANUAL UPDATE DOES NOT ADD COUNTER**, 
    this is intended behavior, so only "player start failure" attempt to be counted.

- Counter Reset Condition
  - PlayerUpdateRetryCount will be cleared to 0 on following condition.
  - Launch game procedure successfully spawned unity process.
  - Launcher update executed (to prevent launcher reinstall not resetting this value)
  
---
in short, Pseudocode:
```
if (config.json has no 'PlayerUpdateRetryCount' entry){
   make "PlayerUpdateRetryCount" entry, set it 0.
}

GameLaunchProcedure(){
  if PlayerNotFound 
    PlayerUpdateRetryCount = PlayerUpdateRetryCount + 1
    PlayerUpdate()
  
 
  SpawnPlayerProcess()
  if ProcessSpawned() 
    PlayerUpdateRetryCount = 0  
}

ManualPlayerUpdateButtonPushed{
  PlayerUpdate()
  // So, user pressing Manual Player Update in Settings
  // Does NOT Increment retry counter.
}

LauncherUpdate(){
  PlayerUpdateRetryCount = 0
}

PlayerUpdate(){
  if PlayerUpdateRetryCount > 3 
     stop update, reinstall
     // ...Regardless of Trigger Source (User Press Button vs PlayerNotFound)
  else
     normal player update flow
}

```