### PR TITLE
Update Monster Collection UI and It's GQL API Usage

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "react/prop-types": 0,
     "no-underscore-dangle": 0,
     "no-constant-condition": 0,
+    "no-irregular-whitespace": 0,
     "import/first": "error",
     "import/newline-after-import": "error",
     "import/prefer-default-export": 0,

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "child-process-promise": "^2.2.1",
     "core-js": "^3.32.1",
     "decimal.js": "^10.3.1",
+    "deep-equal": "^2.2.2",
     "destr": "^1.1.0",
     "dompurify": "^3.0.3",
     "eip55": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@stitches/react": "^1.2.8",
     "@transifex/native": "^3.0.0",
     "@transifex/react": "^3.0.0",
+    "@types/deep-equal": "^1.0.1",
     "@types/lockfile": "^1.0.1",
     "@types/react-router": "^5.1.7",
     "@types/react-router-dom": "^5.1.5",

--- a/src/api.graphql
+++ b/src/api.graphql
@@ -207,13 +207,11 @@ mutation Transfer(
   )
 }
 
-
 query StagedTx($address: Address!) {
   nodeStatus {
     stagedTxIds(address: $address)
   }
 }
-
 
 mutation StageTx($encodedTx: String!) {
   stageTx(payload: $encodedTx)
@@ -251,7 +249,7 @@ subscription Tip {
   }
 }
 
-query CurrentStaking($address: Address!) {
+query UserStaking($address: Address!) {
   stateQuery {
     stakeState(address: $address) {
       deposit
@@ -259,6 +257,43 @@ query CurrentStaking($address: Address!) {
       receivedBlockIndex
       cancellableBlockIndex
       claimableBlockIndex
+      stakeRewards {
+        orderedList {
+          level
+          requiredGold
+          rewards {
+            itemId
+            decimalRate
+            type
+            currencyTicker
+          }
+          bonusRewards {
+            itemId
+            count
+          }
+        }
+      }
+    }
+  }
+}
+
+query LatestStakingSheet {
+  stateQuery {
+    latestStakeRewards {
+      orderedList {
+        level
+        requiredGold
+        rewards {
+          itemId
+          decimalRate
+          type
+          currencyTicker
+        }
+        bonusRewards {
+          itemId
+          count
+        }
+      }
     }
   }
 }
@@ -284,7 +319,7 @@ query StakingSheet {
   }
 }
 
-query LegacyCollectionState($address: Address!) {
+query V1CollectionState($address: Address!) {
   stateQuery {
     monsterCollectionSheet {
       orderedList {
@@ -348,17 +383,17 @@ query MigrateMonsterCollection($publicKey: String!, $avatarAddress: Address) {
   }
 }
 
-query CheckContracted($agentAddress: Address!){
-  stateQuery{
-    pledge(agentAddress: $agentAddress){
-			approved
+query CheckContracted($agentAddress: Address!) {
+  stateQuery {
+    pledge(agentAddress: $agentAddress) {
+      approved
       patronAddress
     }
   }
 }
 
-query approvePledge($publicKey: String!){
-	actionTxQuery(publicKey: $publicKey){
+query approvePledge($publicKey: String!) {
+  actionTxQuery(publicKey: $publicKey) {
     approvePledge(patronAddress: "0xc64c7cBf29BF062acC26024D5b9D1648E8f8D2e1")
   }
 }

--- a/src/renderer/.gitignore
+++ b/src/renderer/.gitignore
@@ -1,1 +1,0 @@
-/generated

--- a/src/renderer/components/core/Layout/UserInfo/StakeStatus.tsx
+++ b/src/renderer/components/core/Layout/UserInfo/StakeStatus.tsx
@@ -1,0 +1,18 @@
+import React, { MouseEvent, useCallback } from "react";
+import FileCopyIcon from "@material-ui/icons/FileCopy";
+
+interface StakeStatusButtonProps {
+  onClick: () => void;
+}
+
+export function StakeStatusButton({ onClick }: StakeStatusButtonProps) {
+  const eventListener = useCallback<(e: MouseEvent) => void>(
+    (e) => {
+      e.stopPropagation();
+      onClick();
+    },
+    [onClick],
+  );
+
+  return <FileCopyIcon onClick={eventListener} />;
+}

--- a/src/renderer/components/core/Layout/UserInfo/index.tsx
+++ b/src/renderer/components/core/Layout/UserInfo/index.tsx
@@ -9,6 +9,7 @@ import { motion } from "framer-motion";
 import { styled } from "src/renderer/stitches.config";
 import {
   TxStatus,
+  useLatestStakingSheetQuery,
   useClaimStakeRewardLazyQuery,
   useTransactionResultLazyQuery,
 } from "src/generated/graphql";
@@ -33,6 +34,8 @@ import { trackEvent } from "src/utils/mixpanel";
 import { useLoginSession } from "src/utils/useLoginSession";
 import { Avatar } from "src/renderer/views/ClaimCollectionRewardsOverlay/ClaimContent";
 import { ExportOverlay } from "./ExportOverlay";
+import deepEqual from "deep-equal";
+import { StakeStatusButton } from "./StakeStatus";
 
 const UserInfoStyled = styled(motion.ul, {
   position: "fixed",
@@ -62,20 +65,30 @@ const UserInfoItem = styled(motion.li, {
 
 export default function UserInfo() {
   const loginSession = useLoginSession();
+  const { data: latestSheet } = useLatestStakingSheetQuery();
   const {
     canClaim,
     tip,
     startedBlockIndex,
+    receivedBlockIndex,
+    cancellableBlockIndex,
     claimableBlockIndex,
     deposit,
+    stakeRewards,
     refetch,
   } = useUserStaking();
   const [fetchResult, { data: result, stopPolling }] =
     useTransactionResultLazyQuery({
       pollInterval: 1000,
     });
-
+  const isCollecting = !!startedBlockIndex && startedBlockIndex > 0;
   const [claimLoading, setClaimLoading] = useState<boolean>(false);
+  const [isMigratable, setIsMigratable] = useState<boolean>(
+    isCollecting &&
+      !deepEqual(stakeRewards, latestSheet?.stateQuery.latestStakeRewards, {
+        strict: true,
+      }),
+  );
   useEffect(() => {
     const txStatus = result?.transaction.transactionResult.txStatus;
     if (!txStatus || txStatus === TxStatus.Staging) return;
@@ -85,11 +98,10 @@ export default function UserInfo() {
     if (txStatus === TxStatus.Success) refetch();
     else console.error("Claim transaction failed: ", result);
   }, [result]);
-  const isCollecting = !!startedBlockIndex && startedBlockIndex > 0;
   const remainingText = useMemo(() => {
     if (!claimableBlockIndex) return 0;
     const minutes = Math.round((claimableBlockIndex - tip) / 5);
-    return getRemain(minutes);
+    return `${getRemain(minutes)} (${claimableBlockIndex - tip} Blocks)`;
   }, [claimableBlockIndex, tip]);
 
   const claimedAvatar = useRef<Avatar>();
@@ -131,6 +143,38 @@ export default function UserInfo() {
     }
   }, [loginSession]);
 
+  const stakingStastics = useCallback(() => {
+    if (isCollecting) {
+      clipboard.writeText(`
+      Tip: ${tip}
+      Staking Status: ${
+        isCollecting
+          ? isMigratable
+            ? canClaim
+              ? "Claimable"
+              : "Migratable"
+            : "Staked"
+          : "Not Staking"
+      }
+      isLocked : ${
+        cancellableBlockIndex !== undefined && tip >= cancellableBlockIndex!
+          ? "true"
+          : "false"
+      }
+      {
+      "stakeState": {
+        "deposit": "${deposit}",
+        "startedBlockIndex": ${startedBlockIndex},
+        "receivedBlockIndex": ${receivedBlockIndex},
+        "cancellableBlockIndex": ${cancellableBlockIndex},
+        "claimableBlockIndex": ${claimableBlockIndex},
+      }
+    }
+    `);
+      toast("Staking Status Copied!");
+    }
+  }, [isCollecting]);
+
   const t = useT();
 
   const [isCollectionOpen, setCollectionOpen] = useState<boolean>(false);
@@ -157,13 +201,16 @@ export default function UserInfo() {
       <UserInfoItem onClick={() => setCollectionOpen(true)}>
         <img src={monsterIconUrl} width={28} alt="monster collection icon" />
         <strong>{deposit?.replace(/\.0+$/, "") || "0"}</strong>
-        {isCollecting ? ` (Remaining ${remainingText})` : " (-)"}
+        {isCollecting ? ` - Remaining: ${remainingText}` : " (-)"}
         <LaunchIcon />
         {canClaim && (
           <ClaimButton
             loading={claimLoading}
             onClick={() => setOpenDialog(true)}
           />
+        )}
+        {isCollecting && (
+          <StakeStatusButton onClick={() => stakingStastics()} />
         )}
         <ClaimCollectionRewardsOverlay
           isOpen={openDialog}

--- a/src/renderer/components/core/Layout/UserInfo/index.tsx
+++ b/src/renderer/components/core/Layout/UserInfo/index.tsx
@@ -27,7 +27,7 @@ import { toast } from "react-hot-toast";
 import { useT } from "@transifex/react";
 import { useBalance } from "src/utils/useBalance";
 import MonsterCollectionOverlay from "src/renderer/views/MonsterCollectionOverlay";
-import { useStaking } from "src/utils/staking";
+import { useUserStaking } from "src/utils/staking";
 import { useTx } from "src/utils/useTx";
 import { trackEvent } from "src/utils/mixpanel";
 import { useLoginSession } from "src/utils/useLoginSession";
@@ -69,7 +69,7 @@ export default function UserInfo() {
     claimableBlockIndex,
     deposit,
     refetch,
-  } = useStaking();
+  } = useUserStaking();
   const [fetchResult, { data: result, stopPolling }] =
     useTransactionResultLazyQuery({
       pollInterval: 1000,

--- a/src/renderer/views/MonsterCollectionOverlay/Migration.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/Migration.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useReducer } from "react";
 import {
-  LegacyCollectionStateQuery,
+  V1CollectionStateQuery,
   useMigrateMonsterCollectionLazyQuery,
 } from "src/generated/graphql";
 import { MigrationAlert, MigrationAlertItem } from "./dialog";
@@ -12,9 +12,9 @@ import { useLoginSession } from "src/utils/useLoginSession";
 interface MigrationProps {
   tip: number;
   collectionState: NonNullable<
-    LegacyCollectionStateQuery["stateQuery"]["monsterCollectionState"]
+    V1CollectionStateQuery["stateQuery"]["monsterCollectionState"]
   >;
-  collectionSheet: LegacyCollectionStateQuery["stateQuery"]["monsterCollectionSheet"];
+  collectionSheet: V1CollectionStateQuery["stateQuery"]["monsterCollectionSheet"];
   onActionTxId(txId: string): void;
   onClose?(): void;
 }

--- a/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -313,9 +313,14 @@ export function MonsterCollectionContent({
               </DepositLeftButton>
               <DepositRightButton
                 disabled={
-                  amountDecimal.gt(availableNCG) ||
-                  (deposit && deposit.eq(0) && amountDecimal.eq(0)) ||
-                  (isLockedUp && amountDecimal.lt(stakeState.deposit))
+                  amountDecimal.gt(availableNCG) || // exceed balance
+                  (deposit && deposit.eq(0) && amountDecimal.eq(0)) || // 0 to 0
+                  (isLockedUp &&
+                    isMigratable &&
+                    amountDecimal.lt(stakeState.deposit)) || // lockup limit handle on migratable
+                  (isLockedUp &&
+                    !isMigratable &&
+                    amountDecimal.lte(stakeState.deposit)) // lockup limit handle on non-migratable
                 }
               >
                 Save

--- a/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -230,6 +230,7 @@ export function MonsterCollectionContent({
     <>
       <CloseButton onClick={() => onClose()} />
       <Title src={titleImg} />
+      // Loading Part
       <AnimatePresence>
         {isLoading && (
           <LoadingBackdrop
@@ -242,6 +243,7 @@ export function MonsterCollectionContent({
           </LoadingBackdrop>
         )}
       </AnimatePresence>
+      // Input Part
       <DepositHolder>
         <DepositForm
           onSubmit={(e) => {
@@ -331,6 +333,7 @@ export function MonsterCollectionContent({
           </DepositDescription>
         )}
       </DepositHolder>
+      // Levels in "Latest Sheet"
       <Levels>
         {levels.map((item, index) => (
           <Level
@@ -346,6 +349,7 @@ export function MonsterCollectionContent({
           />
         ))}
       </Levels>
+      // Reward Enumerate
       <AnimatePresence exitBeforeEnter>
         {currentRewards ? (
           <RewardSheet>
@@ -377,6 +381,7 @@ export function MonsterCollectionContent({
           <RewardSheetPlaceholder />
         )}
       </AnimatePresence>
+      // Alert Overlays
       <Alert
         title="Information"
         onCancel={() => setIsAlertOpen(null)}

--- a/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -1,8 +1,8 @@
 import Decimal from "decimal.js";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
-  DepositButton2,
-  DepositCancelButton,
+  DepositRightButton,
+  DepositLeftButton,
   DepositContent,
   DepositDescription,
   DepositForm,
@@ -14,6 +14,7 @@ import {
   Title,
 } from "./base";
 import { Item, ItemGroup, RewardSheet, RewardSheetPlaceholder } from "./reward";
+import deepEqual from "deep-equal";
 
 import BareInput from "src/renderer/components/ui/BareInput";
 import titleImg from "src/renderer/resources/collection/title.png";
@@ -146,6 +147,7 @@ export function MonsterCollectionContent({
     [stakeState],
   );
   const amountDecimal = useMemo(() => new Decimal(amount || 0), [amount]);
+
   const levels = useMemo(
     () => sheet?.orderedList.filter((v) => v.level !== 0),
     [sheet],
@@ -280,7 +282,7 @@ export function MonsterCollectionContent({
                 />
                 <sub>/{availableNCG.toNumber().toLocaleString()}</sub>
               </DepositContent>
-              <DepositCancelButton
+              <DepositLeftButton
                 type="button"
                 onClick={(e) => {
                   e.preventDefault();
@@ -288,8 +290,8 @@ export function MonsterCollectionContent({
                 }}
               >
                 Cancel
-              </DepositCancelButton>
-              <DepositButton2
+              </DepositLeftButton>
+              <DepositRightButton
                 disabled={
                   amountDecimal.gt(availableNCG) ||
                   (deposit && amountDecimal.eq(deposit)) ||
@@ -297,7 +299,7 @@ export function MonsterCollectionContent({
                 }
               >
                 Save
-              </DepositButton2>
+              </DepositRightButton>
             </>
           ) : (
             <>
@@ -305,7 +307,7 @@ export function MonsterCollectionContent({
                 {stakeState?.deposit?.replace(/\.0+$/, "") ?? 0}
                 <sub>/{availableNCG.toNumber().toLocaleString()}</sub>
               </DepositContent>
-              <DepositButton2
+              <DepositRightButton
                 type="button"
                 onClick={(e) => {
                   e.preventDefault();
@@ -313,7 +315,7 @@ export function MonsterCollectionContent({
                 }}
               >
                 Edit
-              </DepositButton2>
+              </DepositRightButton>
             </>
           )}
         </DepositForm>

--- a/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -33,7 +33,10 @@ import itemMetadata from "src/utils/monsterCollection/items";
 import systemRewards from "src/utils/monsterCollection/systemRewards";
 
 import { AnimatePresence } from "framer-motion";
-import { CurrentStakingQuery, StakingSheetQuery } from "src/generated/graphql";
+import {
+  UserStakingQuery,
+  LatestStakingSheetQuery,
+} from "src/generated/graphql";
 import { CloseButton } from "src/renderer/components/core/OverlayBase";
 import { getRemain } from "src/utils/monsterCollection/utils";
 import { useEvent } from "src/utils/useEvent";
@@ -46,8 +49,8 @@ declare global {
 }
 
 interface MonsterCollectionOverlayProps {
-  sheet: StakingSheetQuery;
-  current: CurrentStakingQuery;
+  sheet: LatestStakingSheetQuery;
+  current: UserStakingQuery;
   isEditing?: boolean;
   currentNCG: number;
   onChangeAmount(amount: Decimal): void;
@@ -68,7 +71,9 @@ const images = [
 ];
 
 type LevelList =
-  | NonNullable<StakingSheetQuery["stateQuery"]["stakeRewards"]>["orderedList"]
+  | NonNullable<
+      LatestStakingSheetQuery["stateQuery"]["latestStakeRewards"]
+    >["orderedList"]
   | null
   | undefined;
 
@@ -118,7 +123,7 @@ type Alerts = "lower-deposit" | "confirm-changes" | "unclaimed" | "minimum";
 
 export function MonsterCollectionContent({
   sheet: {
-    stateQuery: { stakeRewards: sheet },
+    stateQuery: { latestStakeRewards: sheet },
   },
   current: {
     stateQuery: { stakeState },

--- a/src/renderer/views/MonsterCollectionOverlay/base.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/base.tsx
@@ -232,6 +232,42 @@ export const DepositLeftButton = styled("button", {
   },
 });
 
+export const MigrateLeftButton = styled("button", {
+  appearance: "none",
+  border: "none",
+  backgroundColor: "transparent",
+
+  backgroundImage: theme.images.depositButton,
+  borderRadius: "50%",
+  color: theme.colors.depositButton,
+  transition: "all 0.2s ease",
+
+  gridColumn: 1,
+  gridRow: "1 / span 2",
+  justifySelf: "center",
+  alignSelf: "center",
+
+  width: 118,
+  height: 118,
+  fontWeight: "$bold",
+  fontSize: 24,
+  textShadow: theme.shadows.embossed,
+
+  position: "relative",
+  top: -3,
+  left: 3,
+
+  "&:hover": {
+    backgroundImage: theme.images.depositButtonHover,
+    transform: "scale(1.1)",
+  },
+
+  "&:disabled": {
+    backgroundImage: theme.images.depositButtonDisabled,
+    cursor: "not-allowed",
+  },
+});
+
 export const LoadingBackdrop = styled(motion.div, {
   display: "flex",
   justifyContent: "center",

--- a/src/renderer/views/MonsterCollectionOverlay/base.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/base.tsx
@@ -166,7 +166,7 @@ export const DepositContent = styled("div", {
   },
 });
 
-export const DepositButton2 = styled("button", {
+export const DepositRightButton = styled("button", {
   appearance: "none",
   border: "none",
   backgroundColor: "transparent",
@@ -202,7 +202,7 @@ export const DepositButton2 = styled("button", {
   },
 });
 
-export const DepositCancelButton = styled("button", {
+export const DepositLeftButton = styled("button", {
   appearance: "none",
   border: "none",
   backgroundColor: "transparent",

--- a/src/renderer/views/MonsterCollectionOverlay/index.stories.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/index.stories.tsx
@@ -620,16 +620,16 @@ function MonsterCollectionOverlay(
   return (
     <MonsterCollectionOverlayBase as="main">
       <MonsterCollectionContent
-        sheet={sheet}
+        latestSheet={sheet}
         current={current}
         currentNCG={500}
         isLoading={loading}
         onClose={() => {}}
         tip={100}
         {...props}
-        onChangeAmount={async (amount) => {
+        onStake={async (amount) => {
           setLoading(true);
-          await props.onChangeAmount?.(amount);
+          await props.onStake?.(amount);
           await new Promise((res) => setTimeout(res, 1000));
           client.writeQuery({
             query: UserStakingDocument,

--- a/src/renderer/views/MonsterCollectionOverlay/index.stories.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/index.stories.tsx
@@ -5,21 +5,21 @@ import { MonsterCollectionContent } from "./MonsterCollectionContent";
 import { MonsterCollectionOverlayBase } from "./base";
 
 import {
-  CurrentStakingDocument,
-  CurrentStakingQuery,
+  UserStakingDocument,
+  UserStakingQuery,
   StakeRewardType,
-  StakingSheetDocument,
-  StakingSheetQuery,
-  useCurrentStakingQuery,
-  useStakingSheetQuery,
+  LatestStakingSheetDocument,
+  LatestStakingSheetQuery,
+  useUserStakingQuery,
+  useLatestStakingSheetQuery,
 } from "src/generated/graphql";
 
 const mocks: [
-  MockedResponse<CurrentStakingQuery>,
-  MockedResponse<StakingSheetQuery>,
+  MockedResponse<UserStakingQuery>,
+  MockedResponse<LatestStakingSheetQuery>,
 ] = [
   {
-    request: { query: CurrentStakingDocument },
+    request: { query: UserStakingDocument },
     result: {
       data: {
         stateQuery: {
@@ -29,17 +29,291 @@ const mocks: [
             claimableBlockIndex: 50400,
             receivedBlockIndex: 0,
             startedBlockIndex: 0,
+            stakeRewards: {
+              orderedList: [
+                {
+                  level: 1,
+                  requiredGold: 50,
+                  rewards: [
+                    {
+                      itemId: 400000,
+                      decimalRate: 10,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 500000,
+                      decimalRate: 800,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 20001,
+                      decimalRate: 6000,
+                      type: StakeRewardType.Rune,
+                      currencyTicker: "",
+                    },
+                  ],
+                  bonusRewards: [
+                    {
+                      itemId: 500000,
+                      count: 1,
+                    },
+                  ],
+                },
+                {
+                  level: 2,
+                  requiredGold: 500,
+                  rewards: [
+                    {
+                      itemId: 400000,
+                      decimalRate: 4,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 500000,
+                      decimalRate: 600,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 20001,
+                      decimalRate: 6000,
+                      type: StakeRewardType.Rune,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 0,
+                      decimalRate: 0.1,
+                      type: StakeRewardType.Currency,
+                      currencyTicker: "CRYSTAL",
+                    },
+                  ],
+                  bonusRewards: [
+                    {
+                      itemId: 500000,
+                      count: 2,
+                    },
+                  ],
+                },
+                {
+                  level: 3,
+                  requiredGold: 5000,
+                  rewards: [
+                    {
+                      itemId: 400000,
+                      decimalRate: 2,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 500000,
+                      decimalRate: 400,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 20001,
+                      decimalRate: 6000,
+                      type: StakeRewardType.Rune,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 0,
+                      decimalRate: 0.1,
+                      type: StakeRewardType.Currency,
+                      currencyTicker: "CRYSTAL",
+                    },
+                  ],
+                  bonusRewards: [
+                    {
+                      itemId: 500000,
+                      count: 2,
+                    },
+                  ],
+                },
+                {
+                  level: 4,
+                  requiredGold: 50000,
+                  rewards: [
+                    {
+                      itemId: 400000,
+                      decimalRate: 2,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 500000,
+                      decimalRate: 400,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 20001,
+                      decimalRate: 6000,
+                      type: StakeRewardType.Rune,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 0,
+                      decimalRate: 0.1,
+                      type: StakeRewardType.Currency,
+                      currencyTicker: "CRYSTAL",
+                    },
+                  ],
+                  bonusRewards: [
+                    {
+                      itemId: 500000,
+                      count: 2,
+                    },
+                  ],
+                },
+                {
+                  level: 5,
+                  requiredGold: 500000,
+                  rewards: [
+                    {
+                      itemId: 400000,
+                      decimalRate: 1,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 500000,
+                      decimalRate: 200,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 20001,
+                      decimalRate: 3000,
+                      type: StakeRewardType.Rune,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 0,
+                      decimalRate: 0.05,
+                      type: StakeRewardType.Currency,
+                      currencyTicker: "CRYSTAL",
+                    },
+                  ],
+                  bonusRewards: [
+                    {
+                      itemId: 500000,
+                      count: 2,
+                    },
+                  ],
+                },
+                {
+                  level: 6,
+                  requiredGold: 5000000,
+                  rewards: [
+                    {
+                      itemId: 400000,
+                      decimalRate: 1,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 500000,
+                      decimalRate: 200,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 20001,
+                      decimalRate: 3000,
+                      type: StakeRewardType.Rune,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 800201,
+                      decimalRate: 100,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 0,
+                      decimalRate: 0.05,
+                      type: StakeRewardType.Currency,
+                      currencyTicker: "CRYSTAL",
+                    },
+                  ],
+                  bonusRewards: [
+                    {
+                      itemId: 500000,
+                      count: 2,
+                    },
+                  ],
+                },
+                {
+                  level: 7,
+                  requiredGold: 10000000,
+                  rewards: [
+                    {
+                      itemId: 400000,
+                      decimalRate: 0.4,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 500000,
+                      decimalRate: 80,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 20001,
+                      decimalRate: 1200,
+                      type: StakeRewardType.Rune,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 600201,
+                      decimalRate: 50,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 800201,
+                      decimalRate: 50,
+                      type: StakeRewardType.Item,
+                      currencyTicker: "",
+                    },
+                    {
+                      itemId: 0,
+                      decimalRate: 100,
+                      type: StakeRewardType.Currency,
+                      currencyTicker: "GARAGE",
+                    },
+                    {
+                      itemId: 0,
+                      decimalRate: 0.01,
+                      type: StakeRewardType.Currency,
+                      currencyTicker: "CRYSTAL",
+                    },
+                  ],
+                  bonusRewards: [
+                    {
+                      itemId: 500000,
+                      count: 2,
+                    },
+                  ],
+                },
+              ],
+            },
           },
         },
       },
     },
   },
   {
-    request: { query: StakingSheetDocument },
+    request: { query: LatestStakingSheetDocument },
     result: {
       data: {
         stateQuery: {
-          stakeRewards: {
+          latestStakeRewards: {
             orderedList: [
               {
                 level: 1,
@@ -337,8 +611,8 @@ interface Args {
 function MonsterCollectionOverlay(
   props: Partial<ComponentPropsWithRef<typeof MonsterCollectionContent>> & Args,
 ) {
-  const { data: sheet } = useStakingSheetQuery();
-  const { data: current, client } = useCurrentStakingQuery();
+  const { data: sheet } = useLatestStakingSheetQuery();
+  const { data: current, client } = useUserStakingQuery();
   const [loading, setLoading] = useState(false);
 
   if (!sheet || !current) return null;
@@ -358,7 +632,7 @@ function MonsterCollectionOverlay(
           await props.onChangeAmount?.(amount);
           await new Promise((res) => setTimeout(res, 1000));
           client.writeQuery({
-            query: CurrentStakingDocument,
+            query: UserStakingDocument,
             data: {
               stateQuery: {
                 stakeState: {

--- a/src/renderer/views/MonsterCollectionOverlay/index.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/index.tsx
@@ -15,7 +15,7 @@ import { useBalance } from "src/utils/useBalance";
 import { useLoginSession } from "src/utils/useLoginSession";
 import { useTip } from "src/utils/useTip";
 import { useTx } from "src/utils/useTx";
-import Migration from "./Migration";
+// import Migration from "./Migration";
 import { MonsterCollectionContent } from "./MonsterCollectionContent";
 import { MonsterCollectionOverlayBase } from "./base";
 
@@ -27,11 +27,12 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
       variables: { address: loginSession?.address?.toString() },
       skip: !loginSession,
     });
-  const { data: V1Collection, refetch: refetchV1Collection } =
+  /*  const { data: V1Collection, refetch: refetchV1Collection } =
     useV1CollectionStateQuery({
       variables: { address: loginSession?.address?.toString() },
       skip: !loginSession,
     });
+*/
   const balance = useBalance();
   const tip = useTip();
 
@@ -50,7 +51,7 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
     if (!txStatus) return;
     if (txStatus.transaction.transactionResult.txStatus === TxStatus.Success) {
       refetchUserStaking();
-      refetchV1Collection();
+      //refetchV1Collection();
     }
     if (txStatus.transaction.transactionResult.txStatus !== TxStatus.Staging) {
       stopPolling?.();
@@ -58,7 +59,12 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
     }
   }, [txStatus]);
 
-  if (!latestSheet || !userStaking || !V1Collection || !tip || !loginSession)
+  if (
+    !latestSheet ||
+    !userStaking /* || !V1Collection */ ||
+    !tip ||
+    !loginSession
+  )
     return null;
 
   return (
@@ -96,25 +102,7 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
         onClose={onClose}
         tip={tip}
         isLoading={isLoading}
-      >
-        {V1Collection.stateQuery.monsterCollectionState && !isLoading && (
-          <Migration
-            tip={tip}
-            collectionState={V1Collection.stateQuery.monsterCollectionState}
-            collectionSheet={V1Collection.stateQuery.monsterCollectionSheet}
-            onActionTxId={(txId) => {
-              setLoading(true);
-              trackEvent("Staking/Migration", {
-                txId,
-                tip,
-                level: V1Collection.stateQuery.monsterCollectionState?.level,
-              });
-              fetchStatus({ variables: { txId } });
-            }}
-            onClose={onClose}
-          />
-        )}
-      </MonsterCollectionContent>
+      ></MonsterCollectionContent>
     </MonsterCollectionOverlayBase>
   );
 }

--- a/src/renderer/views/MonsterCollectionOverlay/index.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/index.tsx
@@ -70,10 +70,10 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
   return (
     <MonsterCollectionOverlayBase isOpen={isOpen} onDismiss={onClose}>
       <MonsterCollectionContent
-        sheet={latestSheet}
+        latestSheet={latestSheet}
         current={userStaking}
         currentNCG={balance}
-        onChangeAmount={(amount) => {
+        onStake={(amount) => {
           setLoading(true);
           trackEvent("Staking/AmountChange", {
             amount: amount.toString(),

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -176,7 +176,13 @@ type StateQuery {
     agentAddress: Address!
   ): MonsterCollectionStateType
   monsterCollectionSheet: MonsterCollectionSheetType
+
+  # The latest stake rewards based on StakePolicySheet.
+  latestStakeRewards: StakeRewardsType
   stakeRewards: StakeRewardsType
+    @deprecated(
+      reason: "Since stake3, claim_stake_reward9 actions, each stakers have their own contracts."
+    )
   crystalMonsterCollectionMultiplierSheet: CrystalMonsterCollectionMultiplierSheetType
 
   # List of unlocked equipment recipe sheet row ids.
@@ -290,6 +296,9 @@ type AvatarStateType {
   # Avatar inventory.
   inventory: InventoryType!
 
+  # Avatar inventory address.
+  inventoryAddress: Address!
+
   # Rune list of avatar
   runes: [RuneStateType!]!
 
@@ -336,6 +345,15 @@ type InventoryType {
   equipments(
     # filter equipped inventory item
     equipped: Boolean
+
+    # An item subtype for fetching only equipment where its subtype is the same. If it wasn't given, you'll get all equipment without relationship to the subtype.
+    itemSubType: ItemSubType
+
+    # ItemIds for fetching only equipment where itemId (Guid) is in the given argument.
+    itemIds: [Guid!]
+
+    # Ids for fetching only equipment where id (number) is in the given argument.
+    ids: [Int!]
   ): [EquipmentType!]!
 
   # List of Costumes.
@@ -471,6 +489,7 @@ type EquipmentType {
   equipped: Boolean!
   itemId: Guid!
   level: Int!
+  exp: Int!
   skills: [SkillType]
   buffSkills: [SkillType]
   statsMap: StatsMapType!
@@ -812,10 +831,10 @@ type StakeStateType {
   deposit: String!
 
   # The block index the user started to stake.
-  startedBlockIndex: Int!
+  startedBlockIndex: Long!
 
   # The block index the user received rewards.
-  receivedBlockIndex: Int!
+  receivedBlockIndex: Long!
 
   # The block index the user can cancel the staking.
   cancellableBlockIndex: Long!
@@ -824,37 +843,14 @@ type StakeStateType {
   claimableBlockIndex: Long!
 
   # The staking achievements.
-  achievements: StakeAchievementsType!
+  achievements: StakeAchievementsType
+    @deprecated(reason: "Since StakeStateV2, the achievement became removed.")
+  stakeRewards: StakeRewardsType!
 }
 
 type StakeAchievementsType {
   # The address of current state.
   achievementsByLevel(level: Int!): Int!
-}
-
-type MonsterCollectionStateType {
-  address: Address!
-  level: Long!
-  expiredBlockIndex: Long!
-  startedBlockIndex: Long!
-  receivedBlockIndex: Long!
-  rewardLevel: Long!
-  claimableBlockIndex: Long!
-}
-
-type MonsterCollectionSheetType {
-  orderedList: [MonsterCollectionRowType]
-}
-
-type MonsterCollectionRowType {
-  level: Int!
-  requiredGold: Int!
-  rewards: [MonsterCollectionRewardInfoType]!
-}
-
-type MonsterCollectionRewardInfoType {
-  itemId: Int!
-  quantity: Int!
 }
 
 type StakeRewardsType {
@@ -886,6 +882,31 @@ enum StakeRewardType {
 type StakeRegularFixedRewardInfoType {
   itemId: Int!
   count: Int!
+}
+
+type MonsterCollectionStateType {
+  address: Address!
+  level: Long!
+  expiredBlockIndex: Long!
+  startedBlockIndex: Long!
+  receivedBlockIndex: Long!
+  rewardLevel: Long!
+  claimableBlockIndex: Long!
+}
+
+type MonsterCollectionSheetType {
+  orderedList: [MonsterCollectionRowType]
+}
+
+type MonsterCollectionRowType {
+  level: Int!
+  requiredGold: Int!
+  rewards: [MonsterCollectionRewardInfoType]!
+}
+
+type MonsterCollectionRewardInfoType {
+  itemId: Int!
+  quantity: Int!
 }
 
 type CrystalMonsterCollectionMultiplierSheetType {
@@ -1070,6 +1091,7 @@ enum CurrencyEnum {
   CRYSTAL
   NCG
   GARAGE
+  MEAD
 }
 
 type TransferNCGHistoryType {
@@ -1530,6 +1552,16 @@ type TransactionHeadlessQuery {
     # transaction id.
     txId: TxId!
   ): TransactionType
+  ncTransactions(
+    # start block index for query tx.
+    startingBlockIndex: Long!
+
+    # number of block to query.
+    limit: Long!
+
+    # filter tx by having actions' type
+    actionType: String!
+  ): [TransactionType]
   createUnsignedTx(
     # The base64-encoded public key for Transaction.
     publicKey: String!
@@ -1819,8 +1851,8 @@ type ActionQuery {
     # Target item ID to enhance
     itemId: Guid!
 
-    # Material ID to enhance
-    materialId: Guid!
+    # Material IDs to enhance
+    materialIds: [Guid!]!
   ): ByteString!
   rapidCombination(
     # Avatar address to execute rapid combination
@@ -2187,8 +2219,8 @@ type ActionTxQuery {
     # Target item ID to enhance
     itemId: Guid!
 
-    # Material ID to enhance
-    materialId: Guid!
+    # Material IDs to enhance
+    materialIds: [Guid!]!
   ): ByteString!
   rapidCombination(
     # Avatar address to execute rapid combination
@@ -2433,8 +2465,8 @@ type ActionMutation {
     # Equipment Guid for upgrade.
     itemId: Guid!
 
-    # Material Guid for equipment upgrade.
-    materialId: Guid!
+    # Material Guids for equipment upgrade.
+    materialIds: [Guid!]!
 
     # The empty combination slot index to upgrade equipment. 0 ~ 3
     slotIndex: Int!
@@ -2479,6 +2511,10 @@ type ActionMutation {
 
 type StandaloneSubscription {
   tipChanged: TipChanged
+  tx(
+    # A type of action in transaction.
+    actionType: String!
+  ): TxType
   preloadProgress: PreloadStateType
   nodeStatus: NodeStatusType
   differentAppProtocolVersionEncounter: DifferentAppProtocolVersionEncounterType!
@@ -2493,6 +2529,11 @@ type StandaloneSubscription {
 type TipChanged {
   index: Long!
   hash: ByteString
+}
+
+type TxType {
+  transaction: TransactionType!
+  txResult: TxResultType
 }
 
 type PreloadStateType {

--- a/src/utils/staking.ts
+++ b/src/utils/staking.ts
@@ -1,9 +1,9 @@
-import { useCurrentStakingQuery } from "src/generated/graphql";
+import { useUserStakingQuery } from "src/generated/graphql";
 import { useTip } from "./useTip";
 import { useLoginSession } from "./useLoginSession";
 import { Address } from "@planetarium/account";
 
-export function useStaking() {
+export function useUserStaking() {
   const address: Address | undefined = useLoginSession()?.address;
   const commonQuery = {
     variables: {
@@ -12,15 +12,15 @@ export function useStaking() {
     skip: !address,
   };
 
-  const { data: current, refetch } = useCurrentStakingQuery(commonQuery);
+  const { data: userStake, refetch } = useUserStakingQuery(commonQuery);
   const tip = useTip();
 
   return {
-    ...current?.stateQuery.stakeState,
+    ...userStake?.stateQuery.stakeState,
     tip,
     canClaim:
-      !!current?.stateQuery.stakeState?.claimableBlockIndex &&
-      current.stateQuery.stakeState.claimableBlockIndex <= tip,
+      !!userStake?.stateQuery.stakeState?.claimableBlockIndex &&
+      userStake.stateQuery.stakeState.claimableBlockIndex <= tip,
     refetch,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8968,6 +8968,7 @@ __metadata:
     core-js: ^3.32.1
     css-loader: ^6.8.1
     decimal.js: ^10.3.1
+    deep-equal: ^2.2.2
     destr: ^1.1.0
     dompurify: ^3.0.3
     dotenv: ^8.2.0
@@ -12274,6 +12275,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-equal@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "deep-equal@npm:2.2.2"
+  dependencies:
+    array-buffer-byte-length: ^1.0.0
+    call-bind: ^1.0.2
+    es-get-iterator: ^1.1.3
+    get-intrinsic: ^1.2.1
+    is-arguments: ^1.1.1
+    is-array-buffer: ^3.0.2
+    is-date-object: ^1.0.5
+    is-regex: ^1.1.4
+    is-shared-array-buffer: ^1.0.2
+    isarray: ^2.0.5
+    object-is: ^1.1.5
+    object-keys: ^1.1.1
+    object.assign: ^4.1.4
+    regexp.prototype.flags: ^1.5.0
+    side-channel: ^1.0.4
+    which-boxed-primitive: ^1.0.2
+    which-collection: ^1.0.1
+    which-typed-array: ^1.1.9
+  checksum: eb61c35157b6ecb96a5359b507b083fbff8ddb4c86a78a781ee38485f77a667465e45d63ee2ebd8a00e86d94c80e499906900cd82c2debb400237e1662cd5397
+  languageName: node
+  linkType: hard
+
 "deep-extend@npm:^0.6.0":
   version: 0.6.0
   resolution: "deep-extend@npm:0.6.0"
@@ -13284,6 +13311,23 @@ __metadata:
     unbox-primitive: ^1.0.2
     which-typed-array: ^1.1.10
   checksum: 614e2c1c3717cb8d30b6128ef12ea110e06fd7d75ad77091ca1c5dbfb00da130e62e4bbbbbdda190eada098a22b27fe0f99ae5a1171dac2c8663b1e8be8a3a9b
+  languageName: node
+  linkType: hard
+
+"es-get-iterator@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "es-get-iterator@npm:1.1.3"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.3
+    has-symbols: ^1.0.3
+    is-arguments: ^1.1.1
+    is-map: ^2.0.2
+    is-set: ^2.0.2
+    is-string: ^1.0.7
+    isarray: ^2.0.5
+    stop-iteration-iterator: ^1.0.0
+  checksum: 8fa118da42667a01a7c7529f8a8cca514feeff243feec1ce0bb73baaa3514560bd09d2b3438873cf8a5aaec5d52da248131de153b28e2638a061b6e4df13267d
   languageName: node
   linkType: hard
 
@@ -16099,7 +16143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"internal-slot@npm:^1.0.5":
+"internal-slot@npm:^1.0.4, internal-slot@npm:^1.0.5":
   version: 1.0.5
   resolution: "internal-slot@npm:1.0.5"
   dependencies:
@@ -16189,6 +16233,16 @@ __metadata:
   version: 1.0.4
   resolution: "is-arguments@npm:1.0.4"
   checksum: a40ce1580cbb28b67790afe91d9c39a9016f165e724021f2c61da016d7382a1b04a202d9d4ea1c8b5d7fda7c15144aa5c4e92ea4ed0896e2b95f4f665a966cd5
+  languageName: node
+  linkType: hard
+
+"is-arguments@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "is-arguments@npm:1.1.1"
+  dependencies:
+    call-bind: ^1.0.2
+    has-tostringtag: ^1.0.0
+  checksum: 7f02700ec2171b691ef3e4d0e3e6c0ba408e8434368504bb593d0d7c891c0dbfda6d19d30808b904a6cb1929bca648c061ba438c39f296c2a8ca083229c49f27
   languageName: node
   linkType: hard
 
@@ -16289,6 +16343,15 @@ __metadata:
   version: 1.0.1
   resolution: "is-date-object@npm:1.0.1"
   checksum: 4ce962ecb46d31e48652a247ba9a31697199308926ec8e330426f5de41007781c28617c7c972f188e9aa2dd3d77f725eaba7755d207cecdd49f32fc0beca4fed
+  languageName: node
+  linkType: hard
+
+"is-date-object@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "is-date-object@npm:1.0.5"
+  dependencies:
+    has-tostringtag: ^1.0.0
+  checksum: baa9077cdf15eb7b58c79398604ca57379b2fc4cf9aa7a9b9e295278648f628c9b201400c01c5e0f7afae56507d741185730307cbe7cad3b9f90a77e5ee342fc
   languageName: node
   linkType: hard
 
@@ -16428,6 +16491,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-map@npm:^2.0.1, is-map@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-map@npm:2.0.2"
+  checksum: ace3d0ecd667bbdefdb1852de601268f67f2db725624b1958f279316e13fecb8fa7df91fd60f690d7417b4ec180712f5a7ee967008e27c65cfd475cc84337728
+  languageName: node
+  linkType: hard
+
 "is-nan@npm:^1.2.1":
   version: 1.3.2
   resolution: "is-nan@npm:1.3.2"
@@ -16563,6 +16633,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-set@npm:^2.0.1, is-set@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "is-set@npm:2.0.2"
+  checksum: b64343faf45e9387b97a6fd32be632ee7b269bd8183701f3b3f5b71a7cf00d04450ed8669d0bd08753e08b968beda96fca73a10fd0ff56a32603f64deba55a57
+  languageName: node
+  linkType: hard
+
 "is-shared-array-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-shared-array-buffer@npm:1.0.2"
@@ -16652,12 +16729,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-weakmap@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "is-weakmap@npm:2.0.1"
+  checksum: 1222bb7e90c32bdb949226e66d26cb7bce12e1e28e3e1b40bfa6b390ba3e08192a8664a703dff2a00a84825f4e022f9cd58c4599ff9981ab72b1d69479f4f7f6
+  languageName: node
+  linkType: hard
+
 "is-weakref@npm:^1.0.2":
   version: 1.0.2
   resolution: "is-weakref@npm:1.0.2"
   dependencies:
     call-bind: ^1.0.2
   checksum: 95bd9a57cdcb58c63b1c401c60a474b0f45b94719c30f548c891860f051bc2231575c290a6b420c6bc6e7ed99459d424c652bd5bf9a1d5259505dc35b4bf83de
+  languageName: node
+  linkType: hard
+
+"is-weakset@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "is-weakset@npm:2.0.2"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.1
+  checksum: 5d8698d1fa599a0635d7ca85be9c26d547b317ed8fd83fc75f03efbe75d50001b5eececb1e9971de85fcde84f69ae6f8346bc92d20d55d46201d328e4c74a367
   languageName: node
   linkType: hard
 
@@ -19047,7 +19141,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-is@npm:^1.0.1":
+"object-is@npm:^1.0.1, object-is@npm:^1.1.5":
   version: 1.1.5
   resolution: "object-is@npm:1.1.5"
   dependencies:
@@ -22745,6 +22839,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stop-iteration-iterator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "stop-iteration-iterator@npm:1.0.0"
+  dependencies:
+    internal-slot: ^1.0.4
+  checksum: d04173690b2efa40e24ab70e5e51a3ff31d56d699550cfad084104ab3381390daccb36652b25755e420245f3b0737de66c1879eaa2a8d4fc0a78f9bf892fcb42
+  languageName: node
+  linkType: hard
+
 "store2@npm:^2.14.2":
   version: 2.14.2
   resolution: "store2@npm:2.14.2"
@@ -25038,6 +25141,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"which-collection@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "which-collection@npm:1.0.1"
+  dependencies:
+    is-map: ^2.0.1
+    is-set: ^2.0.1
+    is-weakmap: ^2.0.1
+    is-weakset: ^2.0.1
+  checksum: c815bbd163107ef9cb84f135e6f34453eaf4cca994e7ba85ddb0d27cea724c623fae2a473ceccfd5549c53cc65a5d82692de418166df3f858e1e5dc60818581c
+  languageName: node
+  linkType: hard
+
 "which-module@npm:^2.0.0":
   version: 2.0.0
   resolution: "which-module@npm:2.0.0"
@@ -25045,7 +25160,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.10, which-typed-array@npm:^1.1.11, which-typed-array@npm:^1.1.2":
+"which-typed-array@npm:^1.1.10, which-typed-array@npm:^1.1.11, which-typed-array@npm:^1.1.2, which-typed-array@npm:^1.1.9":
   version: 1.1.11
   resolution: "which-typed-array@npm:1.1.11"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7587,6 +7587,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/deep-equal@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@types/deep-equal@npm:1.0.1"
+  checksum: 689b5737dd0a37d173d9e1231c07f70a1a9a989087b757422e1d167ec3640fd7eb8a538bd6008b3df400c4c11ed07a6c2a92d9aafc1f98ffaa04731a9442c781
+  languageName: node
+  linkType: hard
+
 "@types/detect-port@npm:^1.3.0":
   version: 1.3.3
   resolution: "@types/detect-port@npm:1.3.3"
@@ -8932,6 +8939,7 @@ __metadata:
     "@transifex/react": ^3.0.0
     "@types/bytes": ^3.1.1
     "@types/child-process-promise": ^2.2.1
+    "@types/deep-equal": ^1.0.1
     "@types/dompurify": ^3
     "@types/dotenv": ^8.2.0
     "@types/lockfile": ^1.0.1


### PR DESCRIPTION
This resolves #2282.

Priorities are marked 1 to 3, 

- [x] 1 Update GQL API 
- [ ] Monster Collection UI
  - [ ] 2 Display Reward Items in Table form
  - [x] 1 Implement Migration
  (Make deposit === amount stake-able.)
  - [x] 1 Handle following states in case of SheetUpdate.
    - [x] 1. Delta, 
    - [x] 2. Input limit, 
    - [x] 3. Migrate Button
    - Always use Latest for Delta
      (Because, if migratable, need to display delta for **LatestSheet**.
      else, **LatestSheet** would be same as ### Users. so just use **LatestSheet** again!)
    - if UserStakingRewardSheet !== LatestRewardSheet, Display delta and migrate in index
    - else, Display delta for greater than current deposit, and... prevent user from accidentally reset their cancellableIndex I guess?) 
- [ ] Claim Stake Reward UI
    - [x] 1 More Staking Informations
    - [x] 1 Left Time Until Claim -> Display Blocks Too
    - [x] 1 Cancellable Index -> on click? hover?
    - [ ] 2 New Reward Table Notify on Table Update -> Link to MC UI