### PR TITLE
Temporarily Make Build Action Dispatchable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - mead/*
   pull_request:
     types: [ready_for_review, opened, reopened, auto_merge_enabled]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -49,7 +50,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install
         shell: bash


### PR DESCRIPTION
...For temporarily I guess. it seems not wise to leave this in security-countermeasure perspective.