### PR TITLE
Fix Various problems related to stake state management

### DIFF
--- a/src/renderer/components/core/Layout/UserInfo/index.tsx
+++ b/src/renderer/components/core/Layout/UserInfo/index.tsx
@@ -201,7 +201,7 @@ export default function UserInfo() {
       <UserInfoItem onClick={() => setCollectionOpen(true)}>
         <img src={monsterIconUrl} width={28} alt="monster collection icon" />
         <strong>{deposit?.replace(/\.0+$/, "") || "0"}</strong>
-        {isCollecting ? ` - Remaining: ${remainingText}` : " (-)"}
+        {isCollecting && !canClaim ? ` - Remaining: ${remainingText}` : " (-)"}
         <LaunchIcon />
         {canClaim && (
           <ClaimButton

--- a/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -180,7 +180,7 @@ export function MonsterCollectionContent({
   }, [stakeState]);
 
   const Stake = useEvent(() => {
-    if (amountDecimal.eq(deposit!)) setIsMigratable(false);
+    if (deposit?.eq(amountDecimal)) setIsMigratable(false);
     onStake(amountDecimal);
     setIsAlertOpen(null);
     setIsEditing(false);

--- a/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -193,18 +193,18 @@ export function MonsterCollectionContent({
   const currentRewards = useRewards(latestLevels, userIndex ?? 0);
   const deltaRewards = useRewards(latestLevels, deltaIndex ?? 0);
 
-  function RecurringReward(currentRewards: Rewards, selectedRewards?: Rewards) {
+  function RecurringReward(currentRewards: Rewards, deltaRewards?: Rewards) {
     const targetReward =
-      selectedRewards && selectedRewards.length > currentRewards.length
-        ? selectedRewards
+      deltaRewards && deltaRewards.length > currentRewards.length
+        ? deltaRewards
         : currentRewards;
     return targetReward.map((item, index) => {
       const itemMeta = itemMetadata[item.itemId] ?? {
         name: "Unknown",
       };
       const itemAmount = item.count(deposit ?? new Decimal(0));
-      const selectedAmount = selectedRewards?.[index]
-        ? selectedRewards?.[index].count(amountDecimal)
+      const selectedAmount = deltaRewards?.[index]
+        ? deltaRewards?.[index].count(amountDecimal)
         : new Decimal(0);
 
       return (
@@ -214,7 +214,7 @@ export function MonsterCollectionContent({
           title={itemMeta.name}
           isUpgrade={selectedAmount.gt(itemAmount)}
           updatedAmount={selectedAmount.toString()}
-          isDiff
+          isDiff={!selectedAmount.eq(itemAmount)}
         >
           <img src={itemMeta.img} alt={itemMeta.name} height={48} />
         </Item>
@@ -324,7 +324,7 @@ export function MonsterCollectionContent({
             </>
           ) : (
             <>
-              <DepositContent onClick={() => inputRef.current?.focus()}>
+              <DepositContent>
                 {stakeState?.deposit?.replace(/\.0+$/, "") ?? 0}
                 <sub>/{availableNCG.toNumber().toLocaleString()}</sub>
                 {isMigratable && (

--- a/src/renderer/views/MonsterCollectionOverlay/index.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/index.tsx
@@ -72,14 +72,11 @@ function MonsterCollectionOverlay({ isOpen, onClose }: OverlayProps) {
                 publicKey: loginSession.publicKey.toHex("uncompressed"),
                 amount: amount.toNumber(),
               },
-            });
-            while (loading) {
-              sleep(500);
-            }
-            if (!staked?.actionTxQuery) throw error;
-            return tx(staked.actionTxQuery.stake).then((v) => {
-              if (!v.data) throw error;
-              fetchStatus({ variables: { txId: v.data.stageTransaction } });
+            }).then((v) => {
+              tx(v.data?.actionTxQuery.stake).then((v) => {
+                if (!v.data) throw error;
+                fetchStatus({ variables: { txId: v.data.stageTransaction } });
+              });
             });
           } catch (e) {
             setLoading(false);

--- a/src/renderer/views/MonsterCollectionOverlay/reward.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/reward.tsx
@@ -237,7 +237,7 @@ export const Item = ({
       {children}
       <ItemAmount>
         {amount}
-        {isUpgrade != null && (
+        {isUpgrade != null && isDiff && (
           <ItemUpdatedAmount isUpgrade={isUpgrade} isDiff={isDiff ?? false}>
             {updatedAmount}
           </ItemUpdatedAmount>

--- a/src/renderer/views/TransferAssetOverlay/swap.tsx
+++ b/src/renderer/views/TransferAssetOverlay/swap.tsx
@@ -105,10 +105,6 @@ function SwapPage() {
 
   const handleButton = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
-    setDebounce(true);
-    setTimeout(() => {
-      setDebounce(false);
-    }, 15000);
     ipcRenderer.send("mixpanel-track-event", "Launcher/Swap WNCG");
     if (!addressVerify(recipient, true) || !amount.gte(100)) {
       return;
@@ -119,6 +115,10 @@ function SwapPage() {
     }
 
     setCurrentPhase(TransferPhase.SENDTX);
+    setDebounce(true);
+    setTimeout(() => {
+      setDebounce(false);
+    }, 15000);
 
     const tx = await transfer.swapToWNCG(
       transfer.senderAddress,

--- a/src/renderer/views/TransferAssetOverlay/swap.tsx
+++ b/src/renderer/views/TransferAssetOverlay/swap.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  CircularProgress,
   Container,
   FormControl,
   InputAdornment,
@@ -79,6 +80,7 @@ function SwapPage() {
   const [amountWarning, setAmountWarning] = useState<boolean>(false);
   const [tx, setTx] = useState<string>("");
   const [success, setSuccess] = useState<boolean>(false);
+  const [debounce, setDebounce] = useState<boolean>(false);
   const [currentPhase, setCurrentPhase] = useState<TransferPhase>(
     TransferPhase.READY,
   );
@@ -103,6 +105,10 @@ function SwapPage() {
 
   const handleButton = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
+    setDebounce(true);
+    setTimeout(() => {
+      setDebounce(false);
+    }, 15000);
     ipcRenderer.send("mixpanel-track-event", "Launcher/Swap WNCG");
     if (!addressVerify(recipient, true) || !amount.gte(100)) {
       return;
@@ -126,6 +132,10 @@ function SwapPage() {
 
     await transfer.confirmTransaction(tx, undefined, listener);
   };
+
+  const loading =
+    currentPhase === TransferPhase.SENDTX ||
+    currentPhase === TransferPhase.SENDING;
 
   return (
     <SwapContainer>
@@ -215,8 +225,8 @@ function SwapPage() {
         onClick={handleButton}
         disabled={amountWarning || recipientWarning}
       >
-        {" "}
-        Send{" "}
+        {(loading || debounce) && <CircularProgress />}
+        Send
       </SwapButton>
 
       <SendingDialog

--- a/src/renderer/views/TransferAssetOverlay/transfer.tsx
+++ b/src/renderer/views/TransferAssetOverlay/transfer.tsx
@@ -74,6 +74,7 @@ function TransferPage() {
   const [debounce, setDebounce] = useState<boolean>(false);
   const [recipientWarning, setRecipientWarning] = useState<boolean>(false);
   const [amountWarning, setAmountWarning] = useState<boolean>(false);
+  const [memoWarning, setMemoWarning] = useState<boolean>(false);
   const [tx, setTx] = useState<string>("");
   const [success, setSuccess] = useState<boolean>(false);
   const [currentPhase, setCurrentPhase] = useState<TransferPhase>(
@@ -99,10 +100,6 @@ function TransferPage() {
   };
 
   const handleButton = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    setDebounce(true);
-    setTimeout(() => {
-      setDebounce(false);
-    }, 15000);
     ipcRenderer.send("mixpanel-track-event", "Launcher/Send NCG");
     if (!addressVerify(recipient, true) || !amount.gt(0)) {
       return;
@@ -119,6 +116,11 @@ function TransferPage() {
     }
 
     setCurrentPhase(TransferPhase.SENDTX);
+
+    setDebounce(true);
+    setTimeout(() => {
+      setDebounce(false);
+    }, 15000);
 
     const tx = await transfer.transferAsset(
       transfer.senderAddress,
@@ -139,7 +141,8 @@ function TransferPage() {
     currentPhase === TransferPhase.SENDTX ||
     currentPhase === TransferPhase.SENDING;
 
-  const disabled = amountWarning || recipientWarning || loading || debounce;
+  const disabled =
+    amountWarning || recipientWarning || memoWarning || loading || debounce;
 
   return (
     <TransferContainer>
@@ -207,11 +210,16 @@ function TransferPage() {
         </TransferTitle>
         <TransferSecondTitle>
           <T _str="Enter an additional note." _tags={transifexTags} />
+          &nbsp;
+          <b>{`(${memo.length}/80)`}</b>
         </TransferSecondTitle>
         <FormControl fullWidth>
           <TransferInput
             type="text"
             name="memo"
+            onBlur={() => setMemoWarning(memo.length > 80)}
+            onFocus={() => setAmountWarning(false)}
+            error={memoWarning}
             onChange={(e) => setMemo(e.target.value)}
           />
         </FormControl>

--- a/src/renderer/views/TransferAssetOverlay/transfer.tsx
+++ b/src/renderer/views/TransferAssetOverlay/transfer.tsx
@@ -71,6 +71,7 @@ function TransferPage() {
   const [recipient, setRecipient] = useState<string>("");
   const [memo, setMemo] = useState<string>("");
   const [amount, setAmount] = useState<Decimal>(new Decimal(0));
+  const [debounce, setDebounce] = useState<boolean>(false);
   const [recipientWarning, setRecipientWarning] = useState<boolean>(false);
   const [amountWarning, setAmountWarning] = useState<boolean>(false);
   const [tx, setTx] = useState<string>("");
@@ -98,6 +99,10 @@ function TransferPage() {
   };
 
   const handleButton = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    setDebounce(true);
+    setTimeout(() => {
+      setDebounce(false);
+    }, 15000);
     ipcRenderer.send("mixpanel-track-event", "Launcher/Send NCG");
     if (!addressVerify(recipient, true) || !amount.gt(0)) {
       return;
@@ -134,7 +139,7 @@ function TransferPage() {
     currentPhase === TransferPhase.SENDTX ||
     currentPhase === TransferPhase.SENDING;
 
-  const disabled = amountWarning || recipientWarning || loading;
+  const disabled = amountWarning || recipientWarning || loading || debounce;
 
   return (
     <TransferContainer>
@@ -217,7 +222,7 @@ function TransferPage() {
             onClick={handleButton}
             disabled={disabled}
           >
-            {loading && <CircularProgress />}
+            {(loading || debounce) && <CircularProgress />}
             Send
           </TransferButton>
         </FormControl>


### PR DESCRIPTION
This resolves #2130, #2125, #2281, and other issues.

#2130 - https://github.com/planetarium/9c-launcher/commit/3ccdb5a8df2b91971002901f2782377dfe3ce3e5, This was caused by using async value in sync logic. fixed by using then and blocking-waiting properly.

#2281 - https://github.com/planetarium/9c-launcher/commit/3ccdb5a8df2b91971002901f2782377dfe3ce3e5 Added 15s Debouncer on clicked.

#2125 - https://github.com/planetarium/9c-launcher/commit/b5a3b50dc2d453d1961810460f2cdc75ee983acc, for paste-ease, instead of hard-limiting input, I added byte counter and button disable on < 80 bytes.

Other Fixed Issues.
- block remaining counter is printing negative value (after claimable index) 
- Some issue on diff checking on MC view
- Type Error from unexpected undefined when stake