### PR TITLE
Don't update Available NCG after initial render

### DIFF
--- a/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
+++ b/src/renderer/views/MonsterCollectionOverlay/MonsterCollectionContent.tsx
@@ -172,7 +172,7 @@ export function MonsterCollectionContent({
 
   const availableNCG = useMemo(
     () => deposit?.add(currentNCG) ?? new Decimal(currentNCG),
-    [currentNCG],
+    [],
   );
 
   useEffect(() => {


### PR DESCRIPTION
After all, total NCG user holding doesn't change unless user transfer or use it.

so just stop update that value seems logical.