### PR TITLE
Use the patronAddress from the pladge states

### DIFF
--- a/src/api.graphql
+++ b/src/api.graphql
@@ -392,8 +392,8 @@ query CheckContracted($agentAddress: Address!) {
   }
 }
 
-query approvePledge($publicKey: String!) {
+query approvePledge($publicKey: String!, $patronAddress: Address!) {
   actionTxQuery(publicKey: $publicKey) {
-    approvePledge(patronAddress: "0xc64c7cBf29BF062acC26024D5b9D1648E8f8D2e1")
+    approvePledge(patronAddress: $patronAddress)
   }
 }


### PR DESCRIPTION
This PR adds the argument for `approvePledge` on GQL API, to support other patrons than hardcoded one.