### PR TITLE
Fix claimLoading set late causing duplicated tx request

### DIFF
--- a/src/renderer/components/core/Layout/UserInfo/index.tsx
+++ b/src/renderer/components/core/Layout/UserInfo/index.tsx
@@ -148,7 +148,6 @@ export default function UserInfo() {
           txId,
           avatar: avatar.address,
         });
-        setClaimLoading(true);
       });
     },
   });
@@ -228,7 +227,9 @@ export default function UserInfo() {
         {canClaim && (
           <ClaimButton
             loading={claimLoading}
-            onClick={() => setOpenDialog(true)}
+            onClick={() => {
+              setOpenDialog(true);
+            }}
           />
         )}
         {isCollecting && !canClaim && isMigratable && (
@@ -242,6 +243,7 @@ export default function UserInfo() {
           onClose={() => setOpenDialog(false)}
           tip={tip}
           onConfirm={(avatar) => {
+            setClaimLoading(true);
             if (loginSession.publicKey) {
               claimedAvatar.current = avatar;
               requestClaimStakeRewardTx({


### PR DESCRIPTION
It seems claim reward button loading state is setted too lately, which make users able to create multiple duplicated tx request. although one of them would probably success, this is regarded as eventual failure, which causing confusing error message. 

this fixes that by setting loading state on confirming, not on send tx.