### PR TITLE
Automatically Add Github Release when main release occurs.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,15 @@ jobs:
           fi
           curl -X POST -H 'Content-type: application/json' --data '{"text":"[Launcher] Had success releasing with '${{ matrix.packCmd }}' pack-cmd"}' ${{ secrets.SLACK_WEBHOOK }}
 
-          
           rm -fR ./dist/*-unpacked
           rm -fR ./dist/mac
           rm -fR ./dist/mac-arm64
+          
+          for file in ./dist/NineChronicles*.zip; do
+            new_file=$(echo ${file%.*}-linux.${file##*.} | sed 's/eC/e C/')
+            mv "$file" "{$new_file%.zip}"
+          done
+
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/setup-node@v3.8.1
         with:
           node-version: 20
-          cache: 'yarn'
+          cache: "yarn"
 
       - name: Install
         shell: bash
@@ -107,6 +107,7 @@ jobs:
           fi
           curl -X POST -H 'Content-type: application/json' --data '{"text":"[Launcher] Had success releasing with '${{ matrix.packCmd }}' pack-cmd"}' ${{ secrets.SLACK_WEBHOOK }}
 
+          
           rm -fR ./dist/*-unpacked
           rm -fR ./dist/mac
           rm -fR ./dist/mac-arm64
@@ -124,3 +125,9 @@ jobs:
           name: Dist-${{ matrix.packCmd }}
           retention-days: 3
           if-no-files-found: error
+      - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*.{zip|exe|dmg}


### PR DESCRIPTION
- Rename Linux target files in more formatted way 
("NineChronicles.x.y.z.zip -> Nine Chronicles.x.y.z-linux.zip)
- Uses softprops/action-gh-release@v1