### PR TITLE
Fixed Launcher TransferStore Planet selection status not synchronized properly

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,21 +9,18 @@ import "./global.scss";
 import { StoreProvider, useStore } from "src/utils/useStore";
 import { LocaleProvider } from "src/renderer/i18n";
 import { ExternalURLProvider } from "src/utils/useExternalURL";
-import { getSdk } from "src/generated/graphql-request";
-import { GraphQLClient } from "graphql-request";
 import { observer } from "mobx-react";
 import { Planet } from "src/interfaces/registry";
 import { NodeInfo } from "src/config";
 
 function App() {
-  const { transfer, planetary, account } = useStore();
+  const { planetary, account } = useStore();
   const client = useApolloClient();
   useEffect(() => {
     ipcRenderer
       .invoke("get-planetary-info")
       .then((info: [Planet[], NodeInfo]) => {
         planetary.init(info[0], info[1]);
-        transfer.updateSdk(getSdk(new GraphQLClient(planetary.node!.gqlUrl)));
       });
   }, []);
 

--- a/src/renderer/components/core/Layout/UserInfo/index.tsx
+++ b/src/renderer/components/core/Layout/UserInfo/index.tsx
@@ -37,6 +37,8 @@ import { Avatar } from "src/renderer/views/ClaimCollectionRewardsOverlay/ClaimCo
 import { ExportOverlay } from "./ExportOverlay";
 import deepEqual from "deep-equal";
 import { StakeStatusButton } from "./StakeStatus";
+import { useStore } from "src/utils/useStore";
+import Decimal from "decimal.js";
 
 const UserInfoStyled = styled(motion.ul, {
   position: "fixed",
@@ -65,6 +67,7 @@ const UserInfoItem = styled(motion.li, {
 });
 
 export default function UserInfo() {
+  const { transfer } = useStore();
   const loginSession = useLoginSession();
   const { data: latestSheet, refetch: refetchLatest } =
     useLatestStakingSheetQuery();
@@ -156,6 +159,10 @@ export default function UserInfo() {
   const [openDialog, setOpenDialog] = useState<boolean>(false);
 
   const gold = useBalance();
+
+  useEffect(() => {
+    transfer.balance = new Decimal(gold);
+  }, [gold]);
 
   const copyAddress = useCallback(() => {
     if (loginSession) {

--- a/src/renderer/views/LoginView/index.tsx
+++ b/src/renderer/views/LoginView/index.tsx
@@ -74,9 +74,6 @@ function LoginView() {
       ipcRenderer.send("mixpanel-alias", address);
       trackEvent("Launcher/Login");
 
-      await transfer.trySetSenderAddress(address);
-      await transfer.updateBalance(address);
-
       _refiner("setProject", "43e75b10-c10d-11ec-a73a-958e7574f4fc");
       _refiner("identifyUser", {
         id: address,

--- a/src/renderer/views/TransferAssetOverlay/swap.tsx
+++ b/src/renderer/views/TransferAssetOverlay/swap.tsx
@@ -134,12 +134,7 @@ function SwapPage() {
     }
     setCurrentPhase(TransferPhase.SENDTX);
 
-    const tx = await transfer.swapToWNCG(
-      transfer.senderAddress,
-      recipient,
-      amount,
-      loginSession.privateKey,
-    );
+    const tx = await transfer.swapToWNCG(recipient, amount);
     setTx(tx);
 
     setCurrentPhase(TransferPhase.SENDING);
@@ -232,12 +227,6 @@ function SwapPage() {
           ncg={transfer.balance}
         />
       </b>
-      <IconButton
-        size="small"
-        onClick={() => transfer.updateBalance(transfer.senderAddress)}
-      >
-        <Refresh />
-      </IconButton>
       <ul style={{ listStyleType: "none", padding: 0, marginTop: "5px" }}>
         <li>
           <SwapSecondTitle>Bridge Transfer Limit</SwapSecondTitle>

--- a/src/renderer/views/TransferAssetOverlay/transfer.tsx
+++ b/src/renderer/views/TransferAssetOverlay/transfer.tsx
@@ -105,7 +105,7 @@ function TransferPage() {
       return;
     }
 
-    if (recipient === transfer.senderAddress) {
+    if (recipient === transfer.loginSession.address.toString()) {
       const errorMessage = "You can't transfer NCG to yourself.";
       alert(errorMessage);
       return;
@@ -122,13 +122,7 @@ function TransferPage() {
       setDebounce(false);
     }, 15000);
 
-    const tx = await transfer.transferAsset(
-      transfer.senderAddress,
-      recipient,
-      amount,
-      memo,
-      privateKey,
-    );
+    const tx = await transfer.transferAsset(recipient, amount, memo);
     setTx(tx);
 
     setCurrentPhase(TransferPhase.SENDING);
@@ -182,12 +176,6 @@ function TransferPage() {
               ncg={transfer.balance}
             />
           </b>
-          <Button
-            startIcon={<img src={refreshIcon} alt="refresh" />}
-            onClick={async () =>
-              await transfer.updateBalance(transfer.senderAddress)
-            }
-          />
         </TransferSecondTitle>
         <FormControl fullWidth>
           <TransferInput

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -16,8 +16,9 @@ import {
 // this store to the dedicated backend, and inject that into this.
 import fs from "fs";
 import path from "path";
-import { action, observable, makeObservable, computed } from "mobx";
+import { action, observable, computed, makeAutoObservable } from "mobx";
 import { app } from "@electron/remote";
+import { RootStore } from "src/utils/useStore";
 
 export interface ILoginSession {
   address: Address;
@@ -85,6 +86,7 @@ Migrated at: ${new Date().toISOString()}\n`,
 
 export default class AccountStore {
   private _privateKeyToRecovery: RawPrivateKey | null = null;
+  rootStore: RootStore;
 
   @action
   async getKeyStore(passphrase: string | undefined): Promise<Web3KeyStore> {
@@ -119,7 +121,7 @@ export default class AccountStore {
   @observable
   public isInitialized: boolean = false;
 
-  constructor() {
+  constructor(RootStore: RootStore) {
     this.getKeyStore(undefined).then(async (keyStore) => {
       for await (const keyMetadata of keyStore.list()) {
         const address = keyMetadata.metadata.address;
@@ -128,7 +130,8 @@ export default class AccountStore {
       }
       this.isInitialized = true;
     });
-    makeObservable(this);
+    makeAutoObservable(this);
+    this.rootStore = RootStore;
   }
 
   @action

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,15 +1,18 @@
-import { observable, action, computed, makeObservable } from "mobx";
+import { observable, action, computed, makeAutoObservable } from "mobx";
 import { ipcRenderer, IpcRendererEvent } from "electron";
 import { userConfigStore, get as getConfig } from "src/config";
+import { RootStore } from "src/utils/useStore";
 
 export default class GameStore {
   @observable
   private _isGameStarted: boolean = false;
 
   private _language: string;
+  rootStore: RootStore;
 
-  public constructor() {
-    makeObservable(this);
+  public constructor(RootStore: RootStore) {
+    makeAutoObservable(this);
+    this.rootStore = RootStore;
 
     ipcRenderer.on("game closed", (event: IpcRendererEvent) => {
       this._isGameStarted = false;

--- a/src/stores/planetary.ts
+++ b/src/stores/planetary.ts
@@ -1,12 +1,15 @@
-import { action, makeObservable, observable } from "mobx";
+import { action, makeAutoObservable, observable } from "mobx";
 import { NodeInfo, configStore, get } from "src/config";
 import { Planet } from "src/interfaces/registry";
 import { initializeNode } from "src/config";
 import { ipcRenderer } from "electron";
+import { RootStore } from "src/utils/useStore";
 
 export default class PlanetaryStore {
-  public constructor() {
-    makeObservable(this);
+  rootStore: RootStore;
+  public constructor(RootStore: RootStore) {
+    makeAutoObservable(this);
+    this.rootStore = RootStore;
   }
 
   @action

--- a/src/utils/useStore.tsx
+++ b/src/utils/useStore.tsx
@@ -1,21 +1,32 @@
+import { makeAutoObservable } from "mobx";
 import React, { createContext, useContext } from "react";
 import AccountStore from "src/stores/account";
 import GameStore from "src/stores/game";
 import PlanetaryStore from "src/stores/planetary";
 import TransferStore from "src/stores/transfer";
 
-const stores = {
-  account: new AccountStore(),
-  game: new GameStore(),
-  transfer: new TransferStore(),
-  planetary: new PlanetaryStore(),
-} as const;
+export class RootStore {
+  account: AccountStore;
+  game: GameStore;
+  transfer: TransferStore;
+  planetary: PlanetaryStore;
 
-export const StoreContext = createContext<typeof stores>(stores);
+  constructor() {
+    makeAutoObservable(this);
+    this.account = new AccountStore(this);
+    this.game = new GameStore(this);
+    this.transfer = new TransferStore(this);
+    this.planetary = new PlanetaryStore(this);
+  }
+}
+
+const store: RootStore = new RootStore();
+
+export const StoreContext = createContext<RootStore>(store);
 
 export function StoreProvider({ children }: React.PropsWithChildren<{}>) {
   return (
-    <StoreContext.Provider value={stores}>{children}</StoreContext.Provider>
+    <StoreContext.Provider value={store}>{children}</StoreContext.Provider>
   );
 }
 
@@ -26,14 +37,12 @@ export function StoreProvider({ children }: React.PropsWithChildren<{}>) {
  * @param {string=} [store] - The name of the store to return. Optional.
  * @returns {object} The store specified by the store name.
  */
-export function useStore<T extends keyof typeof stores>(
-  store: T,
-): (typeof stores)[T];
+export function useStore<T extends keyof typeof store>(store: T): RootStore[T];
 /**
  * @returns {object} The store object containing all stores.
  */
-export function useStore(): typeof stores;
-export function useStore(store?: keyof typeof stores) {
+export function useStore(): RootStore;
+export function useStore(store?: keyof RootStore) {
   const context = useContext(StoreContext);
   return store ? context[store] : context;
 }


### PR DESCRIPTION
This resolves #2365 and some quirks.
- Change store structure to use RootStore, which make references accessible inter-store. 
- Fixed TransferStore Directly get values from AccountStore and PlanetaryStore, fixes SSoT violation.
- Removed Balance Refresh button on TransferView, since checked this statefully update well with subscription. 