### PR TITLE
Feat: AArch64 Rosetta detection / install logic on initialization of launcher.

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,7 +23,7 @@ import { NotSupportedPlatformError } from "src/main/exceptions/not-supported-pla
 import { PLATFORM2OS_MAP } from "src/utils/os";
 import path from "path";
 import fs from "fs";
-import { ChildProcessWithoutNullStreams } from "child_process";
+import { ChildProcessWithoutNullStreams, spawn, exec } from "child_process";
 import logoImage from "./resources/logo.png";
 import "core-js";
 import log from "electron-log";
@@ -125,6 +125,20 @@ if (!app.requestSingleInstanceLock()) {
   });
 
   cleanUp();
+
+  if (process.platform === "darwin" && process.arch == "arm64") {
+    exec("/usr/bin/arch -arch x86_64 uname -m", (error) => {
+      if (error) {
+        console.log("ARM64: Rosetta Not Installed, Try Installation...");
+        utils.execute("/usr/sbin/softwareupdate", [
+          "--install-rosetta",
+          "--agree-to-license",
+        ]);
+      } else {
+        console.log("ARM64: Rosetta Installed, Skip Installation...");
+      }
+    });
+  }
 
   initializeConfig();
   initializeApp();


### PR DESCRIPTION
This whole rosetta check logic will be triggered only on macOS, Apple Silicon 
using node.js process API (process.platform, process.arch)

[exec will return error code on any failure](https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback) circumstances. and will be null command success. so by using [this](https://apple.stackexchange.com/a/464165), if x86_64 failed to execute on aarch64, rosetta can be considered absent.

Installation process deemed to be working, as I tested on Fresh macOS 14.1.2 VM without rosetta installed.

Of course I don't like that position of logic placed in main.ts, but welp. It should fail fast, and nothing is blocking anything. so there's that. 

On the other hand, the reason I didn't make that whole logic external .sh file and using execFile is to minimize RCE risk & code signing problem.