### PR TITLE
feat: 설정 파일 직접 열람 기능 추가

### DIFF
--- a/src/renderer/views/SettingsOverlay/index.tsx
+++ b/src/renderer/views/SettingsOverlay/index.tsx
@@ -33,6 +33,7 @@ import { getKeyStorePath } from "src/stores/account";
 import { ExportOverlay } from "src/renderer/components/core/Layout/UserInfo/ExportOverlay";
 import { useStore } from "src/utils/useStore";
 import { useLoginSession } from "src/utils/useLoginSession";
+import { CONFIG_FILE_PATH } from "src/config";
 
 declare const CURRENT_VERSION: string;
 
@@ -110,6 +111,11 @@ function handleOpenLogPath() {
   const openpath = path.dirname(log.transports.file.getFile().path);
   console.log(`Open log folder. ${openpath}`);
   shell.openPath(openpath);
+}
+
+function handleOpenConfigFile() {
+  console.log(`Open config file: ${CONFIG_FILE_PATH}`);
+  shell.openPath(CONFIG_FILE_PATH);
 }
 
 async function handlePlayerUpdate() {
@@ -242,6 +248,13 @@ function SettingsOverlay({ onClose, isOpen }: OverlayProps) {
                 onClick={handleOpenKeyStorePath}
                 text={t("Open keystore Folder")}
               />
+              {isLogin && (
+                <AdvancedAction
+                  link
+                  onClick={handleOpenConfigFile}
+                  text={t("Open config file")}
+                />
+              )}
               {isLogin && (
                 <AdvancedAction
                   icon={<AccountBoxIcon />}


### PR DESCRIPTION
- 설정 화면의 고급 옵션에 설정 파일 열기 버튼 추가
- electron shell API를 사용하여 시스템 기본 텍스트 에디터로 설정 파일 오픈

## 🔍 변경사항
- 설정 화면의 고급 옵션에 "설정 파일 열기" 버튼 추가
- 버튼 클릭 시 시스템 기본 텍스트 에디터로 config.json 파일 오픈

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/8f43f848-6efa-4a5f-82e6-78c2e363773e)
![image](https://github.com/user-attachments/assets/61ac1076-9b2c-4a2f-851e-fc93b589b020)
