### PR TITLE
Handle accessible planets when init launcher

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -30,8 +30,8 @@ function App() {
   useEffect(() => {
     ipcRenderer
       .invoke("get-planetary-info")
-      .then((info: [Planet[], NodeInfo]) => {
-        planetary.init(info[0], info[1]);
+      .then((info: [Planet[], NodeInfo, Planet[]]) => {
+        planetary.init(info[0], info[1], info[2]);
       });
     ipcRenderer
       .invoke("check-geoblock")

--- a/src/renderer/views/LoginView/index.tsx
+++ b/src/renderer/views/LoginView/index.tsx
@@ -102,7 +102,13 @@ function LoginView() {
           label="Planet"
         >
           {planetary.registry.map((entry) => (
-            <SelectOption key={entry.id} value={entry.id}>
+            <SelectOption
+              key={entry.id}
+              value={entry.id}
+              disabled={
+                !planetary.accessiblePlanets.some((p) => p.id === entry.id)
+              }
+            >
               {entry.name}
             </SelectOption>
           ))}

--- a/src/renderer/views/RegisterView/GetPatronView.tsx
+++ b/src/renderer/views/RegisterView/GetPatronView.tsx
@@ -71,7 +71,13 @@ function GetPatronView() {
           label="Planet"
         >
           {planetary.registry.map((entry) => (
-            <SelectOption key={entry.id} value={entry.id}>
+            <SelectOption
+              key={entry.id}
+              value={entry.id}
+              disabled={
+                !planetary.accessiblePlanets.some((p) => p.id === entry.id)
+              }
+            >
               {entry.name}
             </SelectOption>
           ))}

--- a/src/stores/planetary.ts
+++ b/src/stores/planetary.ts
@@ -13,8 +13,9 @@ export default class PlanetaryStore {
   }
 
   @action
-  public init(registry: Planet[], node: NodeInfo) {
+  public init(registry: Planet[], node: NodeInfo, accessiblePlanets: Planet[]) {
     this.registry = registry;
+    this.accessiblePlanets = accessiblePlanets;
     this.setPlanet(get("Planet", "0x000000000000"));
     this.setNode(node);
   }
@@ -25,6 +26,8 @@ export default class PlanetaryStore {
   registry!: Planet[];
   @observable
   planet!: Planet;
+  @observable
+  accessiblePlanets!: Planet[];
 
   @action
   public setRegistry(registry: Planet[]) {
@@ -67,7 +70,7 @@ export default class PlanetaryStore {
     const planet = this.getPlanetById(planetID);
     if (planet === undefined) {
       console.error("No matching planet ID found, Using Default.");
-      this.planet = this.registry[0];
+      this.planet = this.accessiblePlanets[0];
     } else this.planet = planet;
     this.updateConfigToPlanet();
   }
@@ -129,10 +132,7 @@ export default class PlanetaryStore {
       } else {
         configStore.delete("GuildServiceUrl");
       }
-      configStore.set(
-        "ArenaServiceUrl",
-        this.planet.rpcEndpoints["arena.rest"],
-      );
+      configStore.set("ArenaServiceUrl", this.planet.rpcEndpoints["arena.gql"]);
     }
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2449b983-14e4-40fa-ada5-6884bdc5ce9e)

- resolve #2516 
- planet registry 를 받아온 후 접속가능한 accessiblePlanets 목록을 필터링한 후 registry대신 해당 목록을 사용합니다.
- 드랍다운 목록에서 접속불가능한 노드는 비활성화상태로 표시합니다.