### PR TITLE
Add RTT-based node selection

### DIFF
--- a/__tests__/node-selection-integration.test.ts
+++ b/__tests__/node-selection-integration.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createServer, Server } from "http";
 import { AddressInfo } from "net";
-import { rttClientWeightedSelector } from "src/utils/nodeSelector";
+import {
+  rttClientWeightedSelector,
+  waitFirstThenGrace,
+} from "src/utils/nodeSelector";
 
 interface FakeNode {
   server: Server;
@@ -52,13 +55,11 @@ interface ProbedNode {
 
 /**
  * src/config.ts의 NodeList(quick=true) + PreloadEnded 흐름을 재현합니다.
- * - performance.now()로 RTT 측정
- * - Promise.any로 첫 응답 대기
- * - 500ms grace period로 추가 후보 수집
+ * 대기 패턴은 production helper(waitFirstThenGrace)를 직접 사용.
  */
 async function probeWithGrace(
   urls: string[],
-  graceMs: number = 500,
+  graceMs?: number,
 ): Promise<ProbedNode[]> {
   const results: ProbedNode[] = [];
 
@@ -81,8 +82,8 @@ async function probeWithGrace(
             rpcInformation: { totalCount: number };
           };
         };
-        const rttMs = performance.now() - started;
         if (data?.data?.nodeStatus?.preloadEnded) {
+          const rttMs = performance.now() - started;
           results.push({
             url,
             rttMs,
@@ -96,11 +97,7 @@ async function probeWithGrace(
     }
   });
 
-  await Promise.any(probes).catch(() => undefined);
-  await Promise.race([
-    Promise.all(probes).catch(() => undefined),
-    new Promise((resolve) => setTimeout(resolve, graceMs)),
-  ]);
+  await waitFirstThenGrace(probes, graceMs);
   return [...results];
 }
 

--- a/__tests__/node-selection-integration.test.ts
+++ b/__tests__/node-selection-integration.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, Server } from "http";
+import { AddressInfo } from "net";
+import { rttClientWeightedSelector } from "src/utils/nodeSelector";
+
+interface FakeNode {
+  server: Server;
+  url: string;
+  delayMs: number;
+}
+
+async function createFakeNode(
+  delayMs: number,
+  opts: { clientCount?: number; tip?: number } = {},
+): Promise<FakeNode> {
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            data: {
+              nodeStatus: {
+                preloadEnded: true,
+                tip: { index: opts.tip ?? 100 },
+                appProtocolVersion: { version: 1 },
+              },
+              rpcInformation: { totalCount: opts.clientCount ?? 1 },
+            },
+          }),
+        );
+      }, delayMs);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${port}/graphql`, delayMs };
+}
+
+async function closeFakeNode(node: FakeNode): Promise<void> {
+  await new Promise<void>((resolve) => node.server.close(() => resolve()));
+}
+
+interface ProbedNode {
+  url: string;
+  rttMs: number;
+  clientCount: number;
+  tip: number;
+}
+
+/**
+ * src/config.ts의 NodeList(quick=true) + PreloadEnded 흐름을 재현합니다.
+ * - performance.now()로 RTT 측정
+ * - Promise.any로 첫 응답 대기
+ * - 500ms grace period로 추가 후보 수집
+ */
+async function probeWithGrace(
+  urls: string[],
+  graceMs: number = 500,
+): Promise<ProbedNode[]> {
+  const results: ProbedNode[] = [];
+
+  const probes = urls.map(async (url) => {
+    const started = performance.now();
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5000);
+      const response = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: "{ nodeStatus { preloadEnded } }" }),
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+      if (response.status === 200) {
+        const data = (await response.json()) as {
+          data?: {
+            nodeStatus: { preloadEnded: boolean; tip: { index: number } };
+            rpcInformation: { totalCount: number };
+          };
+        };
+        const rttMs = performance.now() - started;
+        if (data?.data?.nodeStatus?.preloadEnded) {
+          results.push({
+            url,
+            rttMs,
+            clientCount: data.data.rpcInformation.totalCount,
+            tip: data.data.nodeStatus.tip.index,
+          });
+        }
+      }
+    } catch {
+      // NodeList와 동일하게 실패는 무시
+    }
+  });
+
+  await Promise.any(probes).catch(() => undefined);
+  await Promise.race([
+    Promise.all(probes).catch(() => undefined),
+    new Promise((resolve) => setTimeout(resolve, graceMs)),
+  ]);
+  return [...results];
+}
+
+describe("노드 선택 통합 테스트 (HTTP 서버)", () => {
+  let fast: FakeNode;
+  let medium: FakeNode;
+  let slow: FakeNode;
+
+  beforeAll(async () => {
+    fast = await createFakeNode(50, { clientCount: 5 });
+    medium = await createFakeNode(150, { clientCount: 5 });
+    slow = await createFakeNode(400, { clientCount: 5 });
+  }, 10000);
+
+  afterAll(async () => {
+    await Promise.all([fast, medium, slow].map(closeFakeNode));
+  });
+
+  it("probe 후 grace period 내 응답한 후보들이 수집됨", async () => {
+    const probed = await probeWithGrace([fast.url, medium.url, slow.url]);
+    // fast(50) + medium(150)은 확실히, slow(400)는 grace(500ms)에 경계
+    expect(probed.length).toBeGreaterThanOrEqual(2);
+    expect(probed.some((p) => p.url === fast.url)).toBe(true);
+    // RTT가 실제 지연을 반영하는지
+    const fastProbe = probed.find((p) => p.url === fast.url);
+    expect(fastProbe!.rttMs).toBeGreaterThan(40);
+    expect(fastProbe!.rttMs).toBeLessThan(200);
+  }, 10000);
+
+  it("동일 clientCount에서 빠른 노드가 반복적으로 더 많이 선택됨", async () => {
+    const selections: string[] = [];
+    const iterations = 30;
+
+    for (let i = 0; i < iterations; i++) {
+      const probed = await probeWithGrace([fast.url, medium.url, slow.url]);
+      if (probed.length === 0) continue;
+      const selected = rttClientWeightedSelector(probed);
+      selections.push(selected.url);
+    }
+
+    const fastCount = selections.filter((s) => s === fast.url).length;
+    const slowCount = selections.filter((s) => s === slow.url).length;
+
+    // 빠른 노드가 느린 노드보다 확실히 더 많이 선택되어야 함
+    expect(fastCount).toBeGreaterThan(slowCount);
+    // fast는 절반 이상
+    expect(fastCount).toBeGreaterThan(iterations / 3);
+  }, 45000);
+
+  it("응답 없는 서버는 후보에서 제외됨", async () => {
+    // 닫힌 포트로 요청 → 즉시 연결 거부
+    const probed = await probeWithGrace([
+      fast.url,
+      "http://127.0.0.1:1/graphql",
+    ]);
+    expect(probed.map((p) => p.url)).toEqual([fast.url]);
+  }, 10000);
+});

--- a/__tests__/node-selection.test.ts
+++ b/__tests__/node-selection.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  NODE_GRACE_PERIOD_MS,
   rttClientWeightedSelector,
+  waitFirstThenGrace,
   WeightedNode,
 } from "src/utils/nodeSelector";
 
@@ -106,7 +108,7 @@ describe("rttClientWeightedSelector", () => {
   });
 });
 
-describe("NodeList grace period 로직", () => {
+describe("waitFirstThenGrace", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -114,61 +116,68 @@ describe("NodeList grace period 로직", () => {
     vi.useRealTimers();
   });
 
-  async function nodeListQuick(
-    delays: number[], // 각 엔드포인트의 응답 지연 (ms), 음수면 실패
-    graceMs: number = 500,
-  ): Promise<number[]> {
-    const nodeList: number[] = [];
-
-    const connectionCheck = delays.map(
+  // 각 엔드포인트의 응답 지연(ms). 음수면 reject. NodeList의
+  // connectionCheck 셰이프(성공 시 nodeList push)를 시뮬레이션한다.
+  function simulateConnections(delays: number[]): {
+    promises: Promise<void>[];
+    collected: number[];
+  } {
+    const collected: number[] = [];
+    const promises = delays.map(
       (delay, i) =>
         new Promise<void>((resolve, reject) => {
           if (delay < 0) {
             setTimeout(() => reject(new Error("fail")), -delay);
           } else {
             setTimeout(() => {
-              nodeList.push(i);
+              collected.push(i);
               resolve();
             }, delay);
           }
         }),
     );
-
-    await Promise.any(connectionCheck).catch(() => undefined);
-    await Promise.race([
-      Promise.all(connectionCheck).catch(() => undefined),
-      new Promise((resolve) => setTimeout(resolve, graceMs)),
-    ]);
-    return [...nodeList];
+    return { promises, collected };
   }
 
+  it("grace 상수가 500ms로 노출", () => {
+    expect(NODE_GRACE_PERIOD_MS).toBe(500);
+  });
+
   it("두 엔드포인트 100ms 응답 → 둘 다 수집", async () => {
-    const promise = nodeListQuick([100, 100]);
+    const { promises, collected } = simulateConnections([100, 100]);
+    const done = waitFirstThenGrace(promises);
     await vi.advanceTimersByTimeAsync(150);
-    const result = await promise;
-    expect(result).toHaveLength(2);
+    await done;
+    expect(collected).toHaveLength(2);
   });
 
   it("50ms + 3000ms → 빠른 것만, grace 만료로 탈출", async () => {
-    const promise = nodeListQuick([50, 3000]);
+    const { promises, collected } = simulateConnections([50, 3000]);
+    const done = waitFirstThenGrace(promises);
     // 50ms 응답 + 500ms grace
     await vi.advanceTimersByTimeAsync(600);
-    const result = await promise;
-    expect(result).toHaveLength(1);
-    expect(result[0]).toBe(0);
+    await done;
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toBe(0);
   });
 
   it("단일 엔드포인트 성공 → 즉시 반환", async () => {
-    const promise = nodeListQuick([100]);
+    const { promises, collected } = simulateConnections([100]);
+    const done = waitFirstThenGrace(promises);
     await vi.advanceTimersByTimeAsync(150);
-    const result = await promise;
-    expect(result).toEqual([0]);
+    await done;
+    expect(collected).toEqual([0]);
   });
 
-  it("전부 실패 → 빈 배열", async () => {
-    const promise = nodeListQuick([-100, -200]);
+  it("전부 reject해도 throw하지 않음", async () => {
+    const { promises, collected } = simulateConnections([-100, -200]);
+    const done = waitFirstThenGrace(promises);
     await vi.advanceTimersByTimeAsync(300);
-    const result = await promise;
-    expect(result).toHaveLength(0);
+    await expect(done).resolves.toBeUndefined();
+    expect(collected).toHaveLength(0);
+  });
+
+  it("빈 promise 배열 → 즉시 반환", async () => {
+    await expect(waitFirstThenGrace([])).resolves.toBeUndefined();
   });
 });

--- a/__tests__/node-selection.test.ts
+++ b/__tests__/node-selection.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  rttClientWeightedSelector,
+  WeightedNode,
+} from "src/utils/nodeSelector";
+
+interface MockNode extends WeightedNode {
+  gqlUrl: string;
+}
+
+function sample(fn: () => MockNode, n: number): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (let i = 0; i < n; i++) {
+    const node = fn();
+    counts[node.gqlUrl] = (counts[node.gqlUrl] ?? 0) + 1;
+  }
+  return counts;
+}
+
+describe("rttClientWeightedSelector", () => {
+  it("노드 1개면 그대로 반환", () => {
+    const node: MockNode = { rttMs: 100, clientCount: 5, gqlUrl: "a" };
+    expect(rttClientWeightedSelector([node])).toBe(node);
+  });
+
+  it("동일 조건 3노드는 균등 분포", () => {
+    const nodes: MockNode[] = [
+      { rttMs: 50, clientCount: 10, gqlUrl: "a" },
+      { rttMs: 50, clientCount: 10, gqlUrl: "b" },
+      { rttMs: 50, clientCount: 10, gqlUrl: "c" },
+    ];
+    const counts = sample(() => rttClientWeightedSelector(nodes), 10000);
+    // 각 ~33% ± 3%
+    expect(counts["a"]).toBeGreaterThan(3000);
+    expect(counts["a"]).toBeLessThan(3700);
+    expect(counts["b"]).toBeGreaterThan(3000);
+    expect(counts["b"]).toBeLessThan(3700);
+    expect(counts["c"]).toBeGreaterThan(3000);
+    expect(counts["c"]).toBeLessThan(3700);
+  });
+
+  it("RTT 차이 큰 경우 빠른 노드가 압도적으로 선택", () => {
+    const nodes: MockNode[] = [
+      { rttMs: 10, clientCount: 5, gqlUrl: "fast" },
+      { rttMs: 200, clientCount: 5, gqlUrl: "slow" },
+    ];
+    const counts = sample(() => rttClientWeightedSelector(nodes), 10000);
+    // fast는 약 20ms floor 적용, slow는 200ms → fast가 ~10배 가중치
+    expect(counts["fast"]).toBeGreaterThan(counts["slow"] * 5);
+  });
+
+  it("동일 RTT, clientCount 차이 → 적은 쪽 더 많이", () => {
+    const nodes: MockNode[] = [
+      { rttMs: 50, clientCount: 1, gqlUrl: "empty" },
+      { rttMs: 50, clientCount: 10, gqlUrl: "busy" },
+    ];
+    const counts = sample(() => rttClientWeightedSelector(nodes), 10000);
+    // empty가 ~10배 자주 선택
+    expect(counts["empty"]).toBeGreaterThan(counts["busy"] * 5);
+  });
+
+  it("가깝지만 포화 vs 멀지만 여유 트레이드오프", () => {
+    const nodes: MockNode[] = [
+      // 10ms(floor=20 적용), 20 clients → rttTerm=1.0, clientTerm=1/20, weight=0.05
+      { rttMs: 10, clientCount: 20, gqlUrl: "close-busy" },
+      // 200ms, 1 client → rttTerm=0.1, clientTerm=1.0, weight=0.1
+      { rttMs: 200, clientCount: 1, gqlUrl: "far-empty" },
+    ];
+    const counts = sample(() => rttClientWeightedSelector(nodes), 10000);
+    // far-empty가 더 많이 선택되어야 함 (0.1 vs 0.05)
+    expect(counts["far-empty"]).toBeGreaterThan(counts["close-busy"]);
+  });
+
+  it("RTT floor 이하는 동일 취급", () => {
+    const nodes: MockNode[] = [
+      { rttMs: 1, clientCount: 10, gqlUrl: "a" },
+      { rttMs: 15, clientCount: 10, gqlUrl: "b" },
+    ];
+    const counts = sample(() => rttClientWeightedSelector(nodes), 10000);
+    // 둘 다 rttTerm=1.0, clientTerm 동일 → ~50:50
+    expect(counts["a"]).toBeGreaterThan(4500);
+    expect(counts["a"]).toBeLessThan(5500);
+  });
+
+  it("모든 노드 RTT=Infinity면 균등 랜덤 fallback", () => {
+    const nodes: MockNode[] = [
+      { rttMs: Infinity, clientCount: 1, gqlUrl: "a" },
+      { rttMs: Infinity, clientCount: 10, gqlUrl: "b" },
+      { rttMs: Infinity, clientCount: 100, gqlUrl: "c" },
+    ];
+    const counts = sample(() => rttClientWeightedSelector(nodes), 10000);
+    // 세 노드 모두 비슷하게 선택 (균등 랜덤)
+    expect(counts["a"]).toBeGreaterThan(3000);
+    expect(counts["b"]).toBeGreaterThan(3000);
+    expect(counts["c"]).toBeGreaterThan(3000);
+  });
+
+  it("가중치 합 0이어도 throw하지 않음", () => {
+    const nodes: MockNode[] = [
+      { rttMs: Infinity, clientCount: 1, gqlUrl: "a" },
+      { rttMs: Infinity, clientCount: 1, gqlUrl: "b" },
+    ];
+    expect(() => rttClientWeightedSelector(nodes)).not.toThrow();
+    const result = rttClientWeightedSelector(nodes);
+    expect(["a", "b"]).toContain(result.gqlUrl);
+  });
+});
+
+describe("NodeList grace period 로직", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function nodeListQuick(
+    delays: number[], // 각 엔드포인트의 응답 지연 (ms), 음수면 실패
+    graceMs: number = 500,
+  ): Promise<number[]> {
+    const nodeList: number[] = [];
+
+    const connectionCheck = delays.map(
+      (delay, i) =>
+        new Promise<void>((resolve, reject) => {
+          if (delay < 0) {
+            setTimeout(() => reject(new Error("fail")), -delay);
+          } else {
+            setTimeout(() => {
+              nodeList.push(i);
+              resolve();
+            }, delay);
+          }
+        }),
+    );
+
+    await Promise.any(connectionCheck).catch(() => undefined);
+    await Promise.race([
+      Promise.all(connectionCheck).catch(() => undefined),
+      new Promise((resolve) => setTimeout(resolve, graceMs)),
+    ]);
+    return [...nodeList];
+  }
+
+  it("두 엔드포인트 100ms 응답 → 둘 다 수집", async () => {
+    const promise = nodeListQuick([100, 100]);
+    await vi.advanceTimersByTimeAsync(150);
+    const result = await promise;
+    expect(result).toHaveLength(2);
+  });
+
+  it("50ms + 3000ms → 빠른 것만, grace 만료로 탈출", async () => {
+    const promise = nodeListQuick([50, 3000]);
+    // 50ms 응답 + 500ms grace
+    await vi.advanceTimersByTimeAsync(600);
+    const result = await promise;
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(0);
+  });
+
+  it("단일 엔드포인트 성공 → 즉시 반환", async () => {
+    const promise = nodeListQuick([100]);
+    await vi.advanceTimersByTimeAsync(150);
+    const result = await promise;
+    expect(result).toEqual([0]);
+  });
+
+  it("전부 실패 → 빈 배열", async () => {
+    const promise = nodeListQuick([-100, -200]);
+    await vi.advanceTimersByTimeAsync(300);
+    const result = await promise;
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,10 @@ import path from "path";
 import { getSdk } from "./generated/graphql-request";
 import { IConfig } from "./interfaces/config";
 import { RpcEndpoints } from "./interfaces/registry";
-import { rttClientWeightedSelector } from "./utils/nodeSelector";
+import {
+  rttClientWeightedSelector,
+  waitFirstThenGrace,
+} from "./utils/nodeSelector";
 
 export const { app } =
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -76,10 +79,11 @@ export class NodeInfo {
         ),
       ]);
       if (ended.status === 200) {
-        this.rttMs = performance.now() - started;
         this.clientCount = ended.data!.rpcInformation.totalCount;
         this.tip = ended.data!.nodeStatus.tip.index;
         this.apv = ended.data!.nodeStatus.appProtocolVersion?.version ?? 0;
+        // 파싱이 끝난 뒤 대입 — 중간에 throw하면 rttMs는 Infinity로 남는다
+        this.rttMs = performance.now() - started;
         return ended.data!.nodeStatus.preloadEnded;
       }
     } catch (e) {
@@ -157,12 +161,7 @@ const NodeList = async (
   });
 
   if (quick) {
-    // 첫 응답 후 grace period 동안 추가 후보를 수집
-    await Promise.any(connectionCheck);
-    await Promise.race([
-      Promise.all(connectionCheck).catch(() => undefined),
-      new Promise((resolve) => setTimeout(resolve, 500)),
-    ]);
+    await waitFirstThenGrace(connectionCheck);
     return [...nodeList];
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { getSdk } from "./generated/graphql-request";
 import { IConfig } from "./interfaces/config";
 import { RpcEndpoints } from "./interfaces/registry";
+import { rttClientWeightedSelector } from "./utils/nodeSelector";
 
 export const { app } =
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -58,6 +59,7 @@ export class NodeInfo {
   apv = 0;
   clientCount = 0;
   tip = 0;
+  rttMs = Infinity;
 
   public GraphqlClient(): GraphQLClient {
     return new GraphQLClient(this.gqlUrl);
@@ -65,6 +67,7 @@ export class NodeInfo {
 
   public async PreloadEnded(): Promise<boolean> {
     const headlessGraphQLSDK = getSdk(this.GraphqlClient());
+    const started = performance.now();
     try {
       const ended = await Promise.race([
         headlessGraphQLSDK.PreloadEnded(),
@@ -73,6 +76,7 @@ export class NodeInfo {
         ),
       ]);
       if (ended.status === 200) {
+        this.rttMs = performance.now() - started;
         this.clientCount = ended.data!.rpcInformation.totalCount;
         this.tip = ended.data!.nodeStatus.tip.index;
         this.apv = ended.data!.nodeStatus.appProtocolVersion?.version ?? 0;
@@ -153,12 +157,17 @@ const NodeList = async (
   });
 
   if (quick) {
-    await Promise.any(connectionCheck); // Grab the first node succes to cunnect and throw
-    return nodeList;
+    // 첫 응답 후 grace period 동안 추가 후보를 수집
+    await Promise.any(connectionCheck);
+    await Promise.race([
+      Promise.all(connectionCheck).catch(() => undefined),
+      new Promise((resolve) => setTimeout(resolve, 500)),
+    ]);
+    return [...nodeList];
   }
 
   await Promise.all(connectionCheck);
-  return nodeList;
+  return [...nodeList];
 };
 
 const NonStaleNodeList = (
@@ -170,26 +179,6 @@ const NonStaleNodeList = (
   }
   const maxTip = Math.max(...nodeList.map((node) => node.tip));
   return nodeList.filter((node) => node.tip >= maxTip - staleThreshold);
-};
-
-const clientWeightedSelector = (nodeList: NodeInfo[]): NodeInfo => {
-  if (nodeList.length <= 1) {
-    return nodeList[0];
-  }
-  const sum = nodeList
-    .map((node) => node.clientCount)
-    .reduce((p, c) => p + c, 0);
-  if (sum < nodeList.length) {
-    return nodeList[Math.floor(Math.random() * nodeList.length)];
-  }
-  const weightList = nodeList.map((node) => sum / node.clientCount);
-  const target = Math.random() * weightList.reduce((p, v) => p + v, 0);
-  let weightSum = 0;
-  return nodeList[
-    weightList.findIndex(
-      (weight) => (weightSum += weight) && weightSum >= target,
-    )
-  ];
 };
 
 const RpcServerHost = (): { host: string; notDefault: boolean } => {
@@ -329,9 +318,11 @@ export async function initializeNode(
   if (nodeList.length < 1) {
     throw Error("can't find available remote node.");
   }
-  const nodeInfo = clientWeightedSelector(nodeList);
+  const nodeInfo = rttClientWeightedSelector(nodeList);
   console.log(
-    `selected node: ${nodeInfo.gqlUrl})}, clients: ${nodeInfo.clientCount}`,
+    `selected node: ${nodeInfo.gqlUrl}, clients: ${
+      nodeInfo.clientCount
+    }, rtt: ${nodeInfo.rttMs.toFixed(0)}ms`,
   );
   return nodeInfo;
 }

--- a/src/utils/nodeSelector.ts
+++ b/src/utils/nodeSelector.ts
@@ -1,0 +1,50 @@
+export interface WeightedNode {
+  rttMs: number;
+  clientCount: number;
+}
+
+export interface NodeSelectorOptions {
+  rttAlpha?: number;
+  rttFloorMs?: number;
+}
+
+export const RTT_FLOOR_MS = 20;
+export const RTT_ALPHA = 1.0;
+
+export function rttClientWeightedSelector<T extends WeightedNode>(
+  nodeList: T[],
+  opts: NodeSelectorOptions = {},
+): T {
+  if (nodeList.length <= 1) {
+    return nodeList[0];
+  }
+
+  const rttAlpha = opts.rttAlpha ?? RTT_ALPHA;
+  const rttFloor = opts.rttFloorMs ?? RTT_FLOOR_MS;
+
+  const weights = nodeList.map((node) => {
+    const effectiveRtt = Math.max(node.rttMs, rttFloor);
+    const rttTerm = Number.isFinite(effectiveRtt)
+      ? Math.pow(rttFloor / effectiveRtt, rttAlpha)
+      : 0;
+    const clientTerm = 1 / Math.max(1, node.clientCount);
+    return rttTerm * clientTerm;
+  });
+
+  const totalWeight = weights.reduce((p, v) => p + v, 0);
+
+  // 모든 가중치 0 (예: 전부 Infinity RTT) → 균등 랜덤
+  if (totalWeight <= 0) {
+    return nodeList[Math.floor(Math.random() * nodeList.length)];
+  }
+
+  const target = Math.random() * totalWeight;
+  let cumulative = 0;
+  for (let i = 0; i < weights.length; i++) {
+    cumulative += weights[i];
+    if (cumulative >= target) {
+      return nodeList[i];
+    }
+  }
+  return nodeList[nodeList.length - 1];
+}

--- a/src/utils/nodeSelector.ts
+++ b/src/utils/nodeSelector.ts
@@ -8,7 +8,9 @@ export interface NodeSelectorOptions {
   rttFloorMs?: number;
 }
 
+// 20ms 미만 RTT 차이는 측정 노이즈로 간주, 동등 취급
 export const RTT_FLOOR_MS = 20;
+// 1.0이면 선형(rtt 2배 → 가중치 1/2). >1이면 빠른 노드 편중 강화.
 export const RTT_ALPHA = 1.0;
 
 export function rttClientWeightedSelector<T extends WeightedNode>(
@@ -27,6 +29,7 @@ export function rttClientWeightedSelector<T extends WeightedNode>(
     const rttTerm = Number.isFinite(effectiveRtt)
       ? Math.pow(rttFloor / effectiveRtt, rttAlpha)
       : 0;
+    // clientCount=0(데이터 부재)도 1로 클램프해 RTT 가중치만 효과적으로 적용
     const clientTerm = 1 / Math.max(1, node.clientCount);
     return rttTerm * clientTerm;
   });
@@ -42,9 +45,28 @@ export function rttClientWeightedSelector<T extends WeightedNode>(
   let cumulative = 0;
   for (let i = 0; i < weights.length; i++) {
     cumulative += weights[i];
-    if (cumulative >= target) {
+    // strict >: target=0일 때 weight=0 노드가 선택되는 invariant 위반 방지
+    if (cumulative > target) {
       return nodeList[i];
     }
   }
   return nodeList[nodeList.length - 1];
+}
+
+// 첫 응답 후 추가 후보 수집을 위해 기다리는 시간
+export const NODE_GRACE_PERIOD_MS = 500;
+
+// 첫 응답까지 대기한 후 graceMs 동안 추가 응답을 수집한다.
+// promise가 reject하더라도 throw하지 않는다.
+export async function waitFirstThenGrace(
+  promises: Promise<unknown>[],
+  graceMs: number = NODE_GRACE_PERIOD_MS,
+): Promise<void> {
+  if (promises.length === 0) return;
+  const safe = promises.map((p) => p.catch(() => undefined));
+  await Promise.race(safe);
+  await Promise.race([
+    Promise.all(safe),
+    new Promise<void>((resolve) => setTimeout(resolve, graceMs)),
+  ]);
 }


### PR DESCRIPTION
## Summary
- 노드 선택 시 RTT(왕복 지연시간)를 고려하여 가까운 노드 우선, 로드밸런싱 유지
- `NodeInfo.rttMs` 필드 추가, `PreloadEnded`에서 `performance.now()`로 RTT 측정
- `NodeList` quick 모드에 500ms grace period 추가 — 첫 응답 후 추가 후보 수집
- `rttClientWeightedSelector` 추가: 가중치 = `(rttFloor/rtt)^alpha × 1/clientCount`
- 순수 함수를 `src/utils/nodeSelector.ts`로 분리하여 테스트에서 실제 구현 import

## 변경 파일
- `src/config.ts` — NodeInfo에 rttMs 필드, PreloadEnded RTT 측정, NodeList grace period
- `src/utils/nodeSelector.ts` (신규) — 가중치 선택 로직
- `__tests__/node-selection.test.ts` (신규) — 선택 로직 8개 + grace period 4개 테스트

## 동작 변화
- 이전: `Promise.any`로 첫 응답 노드 선택 (RTT 미고려)
- 이후: 첫 응답 후 500ms 대기해 후보 풀 구성 → RTT+clientCount 복합 스코어로 선택
- 시작 시간: 대부분 +500ms 이하, 전부 실패 시 동일

## 주의사항
- `NonStaleNodeList`(tip 기준 필터)와 RTT 우선순위가 충돌할 수 있음 — tip 20 블록 이상 뒤쳐진 가까운 노드는 stale로 제거됨. 운영 로그로 모니터링 권장.
- `planetary.ts`의 fallback 경로(planet switch)에도 quick=true grace가 적용되어 +500ms

## Test plan
- [ ] \`yarn tsc --noEmit\` 통과
- [ ] \`yarn eslint ./src --quiet\` 통과
- [ ] \`yarn test --run __tests__/node-selection.test.ts\` — 12개 테스트 통과
- [ ] \`yarn test --run __tests__/node-retry.test.ts\` — 회귀 없음 (6개)
- [ ] \`yarn dev\` 실행 후 로그에서 \`selected node: ..., rtt: XXms\` 출력 확인
- [ ] Network Link Conditioner 등으로 엔드포인트 지연 시뮬레이션 → 빠른 노드가 더 자주 선택되는지 로그 샘플링

🤖 Generated with [Claude Code](https://claude.com/claude-code)