### PR TITLE
Fix Start button disabled after offline retry (PLD-1333)

### DIFF
--- a/__tests__/geoblock-init.test.ts
+++ b/__tests__/geoblock-init.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * PLD-1333 회귀 테스트.
+ *
+ * 오프라인 부팅 시 initGeoBlocking 실패로 geoBlock이 undefined로 남으면
+ * check-geoblock IPC가 영원히 resolve되지 않고, GameStore는 기본값
+ * (KR/non-whitelist)을 유지해 Start 버튼이 disabled된다.
+ *
+ * Electron 의존성을 피하기 위해 src/main/main.ts의 initGeoBlocking 로직을
+ * 동일하게 재현해 fix의 명세를 잠근다.
+ */
+
+const GEOBLOCK_URL = "https://country-checker.nine-chronicles.com/";
+
+type GeoBlock = { ip?: string; country: string; isWhitelist?: boolean };
+
+/**
+ * src/main/main.ts:594 initGeoBlocking 구현을 재현.
+ * fetch 실패 시에도 geoBlock이 정의된 상태로 끝나야 한다.
+ */
+function makeInitGeoBlocking(deps: {
+  localStorageGetItem: (key: string) => Promise<string | null>;
+}) {
+  let geoBlock: GeoBlock | undefined;
+
+  async function initGeoBlocking(): Promise<void> {
+    try {
+      const response = await fetch(GEOBLOCK_URL);
+      geoBlock = (await response.json()) as GeoBlock;
+    } catch {
+      const stored = await deps
+        .localStorageGetItem("country")
+        .catch(() => null);
+      geoBlock = {
+        country: stored ?? "KR",
+        isWhitelist: false,
+      };
+    }
+  }
+
+  return {
+    initGeoBlocking,
+    getGeoBlock: () => geoBlock,
+    resetGeoBlock: () => {
+      geoBlock = undefined;
+    },
+  };
+}
+
+describe("PLD-1333: initGeoBlocking", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("offline (fetch 실패)", () => {
+    beforeEach(() => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error("network down")),
+      );
+    });
+
+    it("localStorage 값이 있으면 그 값으로 geoBlock 초기화", async () => {
+      const { initGeoBlocking, getGeoBlock } = makeInitGeoBlocking({
+        localStorageGetItem: vi.fn().mockResolvedValue("US"),
+      });
+      await initGeoBlocking();
+      expect(getGeoBlock()).toEqual({ country: "US", isWhitelist: false });
+    });
+
+    it("localStorage가 비어있으면 KR로 fallback (가장 엄격)", async () => {
+      const { initGeoBlocking, getGeoBlock } = makeInitGeoBlocking({
+        localStorageGetItem: vi.fn().mockResolvedValue(null),
+      });
+      await initGeoBlocking();
+      expect(getGeoBlock()).toEqual({ country: "KR", isWhitelist: false });
+    });
+
+    it("localStorage 조회 자체가 reject해도 KR로 fallback", async () => {
+      const { initGeoBlocking, getGeoBlock } = makeInitGeoBlocking({
+        localStorageGetItem: vi.fn().mockRejectedValue(new Error("no win")),
+      });
+      await initGeoBlocking();
+      expect(getGeoBlock()).toEqual({ country: "KR", isWhitelist: false });
+    });
+
+    it("초기화 후 geoBlock은 항상 정의됨 (check-geoblock 무한 대기 방지)", async () => {
+      const { initGeoBlocking, getGeoBlock } = makeInitGeoBlocking({
+        localStorageGetItem: vi.fn().mockResolvedValue(null),
+      });
+      await initGeoBlocking();
+      expect(getGeoBlock()).toBeDefined();
+    });
+  });
+
+  describe("online (fetch 성공)", () => {
+    it("응답 값으로 geoBlock 설정", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          json: async () => ({
+            ip: "1.2.3.4",
+            country: "JP",
+            isWhitelist: true,
+          }),
+        }),
+      );
+      const { initGeoBlocking, getGeoBlock } = makeInitGeoBlocking({
+        localStorageGetItem: vi.fn().mockResolvedValue(null),
+      });
+      await initGeoBlocking();
+      expect(getGeoBlock()).toEqual({
+        ip: "1.2.3.4",
+        country: "JP",
+        isWhitelist: true,
+      });
+    });
+  });
+
+  describe("retry 시나리오", () => {
+    it("오프라인 → 온라인 재시도 시 새 응답으로 갱신", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+      const { initGeoBlocking, getGeoBlock, resetGeoBlock } =
+        makeInitGeoBlocking({
+          localStorageGetItem: vi.fn().mockResolvedValue(null),
+        });
+
+      // 1차: offline → KR fallback
+      await initGeoBlocking();
+      expect(getGeoBlock()).toEqual({ country: "KR", isWhitelist: false });
+
+      // 2차: 온라인 복귀 후 retry → 새 응답
+      vi.unstubAllGlobals();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          json: async () => ({
+            ip: "1.2.3.4",
+            country: "JP",
+            isWhitelist: true,
+          }),
+        }),
+      );
+      resetGeoBlock(); // main.ts의 retry-planetary-init이 하는 일을 재현
+      await initGeoBlocking();
+      expect(getGeoBlock()).toEqual({
+        ip: "1.2.3.4",
+        country: "JP",
+        isWhitelist: true,
+      });
+    });
+  });
+});
+
+describe("PLD-1333: GameStore isGameBlocked 게이팅", () => {
+  // src/stores/game.ts:46
+  function isGameBlocked(country: string, whitelist: boolean): boolean {
+    return ["KR"].includes(country) && !whitelist;
+  }
+
+  it("setGeoBlock이 한 번도 호출되지 않으면 KR/false 기본값으로 Start disabled", () => {
+    // 기본값: _country="KR", _whitelist=false
+    expect(isGameBlocked("KR", false)).toBe(true);
+  });
+
+  it("오프라인 fallback (KR/false)도 동일하게 Start disabled", () => {
+    expect(isGameBlocked("KR", false)).toBe(true);
+  });
+
+  it("온라인 재시도 후 정상 country면 Start enabled", () => {
+    expect(isGameBlocked("JP", true)).toBe(false);
+    expect(isGameBlocked("US", false)).toBe(false);
+  });
+});

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -69,7 +69,7 @@ const client = new NTPClient("time.google.com", 123, { timeout: 5000 });
 let registry: Planet[];
 let accessiblePlanets: Planet[];
 let remoteNode: NodeInfo;
-let geoBlock: { ip: string; country: string; isWhitelist?: boolean };
+let geoBlock: { ip?: string; country: string; isWhitelist?: boolean };
 // eslint-disable-next-line prefer-const
 let configInitError: string | null = null;
 
@@ -411,7 +411,11 @@ function initializeIpc() {
   ipcMain.handle("retry-planetary-init", async () => {
     configInitError = null;
     remoteNode = undefined as unknown as NodeInfo;
+    // 첫 부팅이 오프라인이었다면 geoBlock은 fallback 값으로 채워져 있다.
+    // 재연결된 시점에 정확한 country 정보를 받아오기 위해 다시 시도.
+    geoBlock = undefined as unknown as typeof geoBlock;
     await initializeConfig();
+    await initGeoBlocking();
     if (remoteNode && registry && accessiblePlanets) {
       return { data: [registry, remoteNode, accessiblePlanets] };
     }
@@ -603,14 +607,13 @@ async function initGeoBlocking() {
     console.error("Failed to fetch geo data:", error);
     // Fallback to latest result stored in renderer-side local storage.
     // defaults to the most strict condition if both remote and local value not exists.
-    win?.webContents
+    const stored = await (win?.webContents
       .executeJavaScript('localStorage.getItem("country")')
-      .then((result) => {
-        geoBlock.isWhitelist = false;
-        if (result == null) {
-          geoBlock.country = "KR";
-        } else geoBlock.country = result;
-      });
+      .catch(() => null) ?? Promise.resolve(null));
+    geoBlock = {
+      country: stored ?? "KR",
+      isWhitelist: false,
+    };
   }
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -85,11 +85,15 @@ function App() {
     }
   };
 
-  useEffect(() => {
-    ipcRenderer.invoke("get-planetary-info").then(handlePlanetaryResult);
+  const refreshGeoBlock = () => {
     ipcRenderer
       .invoke("check-geoblock")
       .then((v) => game.setGeoBlock(v.country, v.isWhitelist ?? false));
+  };
+
+  useEffect(() => {
+    ipcRenderer.invoke("get-planetary-info").then(handlePlanetaryResult);
+    refreshGeoBlock();
   }, []);
 
   if (initError) {
@@ -97,9 +101,10 @@ function App() {
       <ConnectionErrorView
         error={initError}
         onRetry={() => {
-          ipcRenderer
-            .invoke("retry-planetary-init")
-            .then(handlePlanetaryResult);
+          ipcRenderer.invoke("retry-planetary-init").then((result) => {
+            handlePlanetaryResult(result);
+            if (!result.error) refreshGeoBlock();
+          });
         }}
         key={retryCount}
       />


### PR DESCRIPTION
## Summary

오프라인 부팅 후 Retry로 재연결한 사용자가 로그인까지 마쳐도 Start 버튼이 비활성화되는 회귀를 수정. ([PLD-1333](https://ninecorporation.atlassian.net/browse/PLD-1333))

근본 원인은 `initGeoBlocking`의 catch 브랜치가 `geoBlock`이 undefined인 상태에서 프로퍼티에 대입하다가 TypeError를 unhandled rejection으로 흘리는 것. 결과적으로 `geoBlock`이 영영 설정되지 않고 `check-geoblock` IPC가 무한 대기 → `GameStore`가 기본값 (`country=KR`, `whitelist=false`)을 유지 → `isGameBlocked=true` → Start disabled. retry 경로도 `initGeoBlocking`을 재호출하지 않아 재연결해도 회복되지 않음. 런쳐 재실행 시에만 정상 동작.

- `initGeoBlocking` catch 브랜치를 await 동기화 + fallback 객체를 통째로 대입 (`{ country: stored ?? "KR", isWhitelist: false }`)
- `retry-planetary-init`이 `geoBlock`을 리셋하고 `initGeoBlocking()`을 재호출
- `App.tsx`가 retry 성공 후 `check-geoblock`을 다시 호출해 store에 반영
- 회귀 테스트 `__tests__/geoblock-init.test.ts` 추가 (offline fallback, retry 갱신, gating 동작)

## Test plan

- [ ] `yarn vitest run __tests__/geoblock-init.test.ts` — 9 tests pass
- [ ] 오프라인 상태로 런쳐 실행 → "Connection Failed" 팝업 확인
- [ ] 인터넷 재연결 후 Retry → 로그인 화면 진입
- [ ] 로그인 완료 후 Start 버튼이 활성화되는지 확인 (한국 외 지역 계정 기준)
- [ ] 한국 계정으로 로그인 시 기존 정책대로 Start disabled가 유지되는지 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)