### PR TITLE
Release 2.8.5 hotfix: Fix signing race (2.8.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "NineChronicles",
   "productName": "Nine Chronicles",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Game Launcher for Nine Chronicles",
   "author": "Planetarium <engineering@planetariumhq.com>",
   "license": "GPL-3.0",

--- a/signing/linux-signing.sh
+++ b/signing/linux-signing.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 ESIGNER_CREDENTIAL_ID=$1
 ESIGNER_USERNAME=$2
@@ -8,26 +9,26 @@ ROOT_DIR_PATH=$5
 INPUT_FILE_PATH=$6
 OUTPUT_DIR_PATH=$7
 
-if [ ! -d "$ROOT_DIR_PATH/tmp/beforeSign" ]; then
-  mkdir "$ROOT_DIR_PATH/tmp/beforeSign"
-fi
+mkdir -p "$ROOT_DIR_PATH/tmp/beforeSign"
+# electron-builder가 x64/arm64를 병렬로 sign할 때 tmp/beforeSign의
+# 공유 경로 충돌로 원본 파일이 사라지는 race를 막기 위해 invocation마다 고유 디렉토리
+BEFORE_SIGN_DIR=$(mktemp -d "$ROOT_DIR_PATH/tmp/beforeSign/sign.XXXXXX")
+trap 'rm -rf "$BEFORE_SIGN_DIR"' EXIT
 
 INPUT_FILE_NAME=$(basename "$INPUT_FILE_PATH")
-BEFORE_SIGN_FILE_NAME="forsigning.${INPUT_FILE_NAME##*.}"
-BEFORE_SIGN_FILE_PATH="$ROOT_DIR_PATH/tmp/beforeSign/$BEFORE_SIGN_FILE_NAME"
+BEFORE_SIGN_FILE_PATH="$BEFORE_SIGN_DIR/$INPUT_FILE_NAME"
 mv "$INPUT_FILE_PATH" "$BEFORE_SIGN_FILE_PATH"
 
-echo "Copy to before folder: $BEFORE_SIGN_FILE_PATH"
-echo ""
+echo "Moved to temp: $BEFORE_SIGN_FILE_PATH"
 
 cd "$ROOT_DIR_PATH/tmp/codesign"
-./CodeSignTool.sh sign -credential_id="$ESIGNER_CREDENTIAL_ID" -username="$ESIGNER_USERNAME" -password="$ESIGNER_PASSWORD" -totp_secret="$ESIGNER_TOTP_SECRET" -output_dir_path="$OUTPUT_DIR_PATH" -input_file_path="$BEFORE_SIGN_FILE_PATH"
+./CodeSignTool.sh sign \
+  -credential_id="$ESIGNER_CREDENTIAL_ID" \
+  -username="$ESIGNER_USERNAME" \
+  -password="$ESIGNER_PASSWORD" \
+  -totp_secret="$ESIGNER_TOTP_SECRET" \
+  -output_dir_path="$OUTPUT_DIR_PATH" \
+  -input_file_path="$BEFORE_SIGN_FILE_PATH"
 
-echo "Finish signing: $OUTPUT_DIR_PATH/$BEFORE_SIGN_FILE_NAME"
-echo ""
-
-AFTER_SIGN_FILE_PATH="$OUTPUT_DIR_PATH/$BEFORE_SIGN_FILE_NAME"
-mv "$AFTER_SIGN_FILE_PATH" "$INPUT_FILE_PATH"
-
-echo "Rename to final file: $AFTER_SIGN_FILE_PATH -> $INPUT_FILE_PATH"
-echo ""
+# CodeSignTool은 OUTPUT_DIR_PATH/<basename(input)>로 출력 → 원본 위치 그대로 복원됨
+echo "Signed: $OUTPUT_DIR_PATH/$INPUT_FILE_NAME"

--- a/signing/linux-signing.sh
+++ b/signing/linux-signing.sh
@@ -7,28 +7,39 @@ ESIGNER_PASSWORD=$3
 ESIGNER_TOTP_SECRET=$4
 ROOT_DIR_PATH=$5
 INPUT_FILE_PATH=$6
-OUTPUT_DIR_PATH=$7
+# 7번째 인자(OUTPUT_DIR_PATH)는 sign.js가 dirname(input)으로 넘기지만,
+# 병렬 호출 시 동일 디렉토리에 출력 충돌이 발생할 수 있어 직접 사용하지 않는다.
 
 mkdir -p "$ROOT_DIR_PATH/tmp/beforeSign"
-# electron-builder가 x64/arm64를 병렬로 sign할 때 tmp/beforeSign의
-# 공유 경로 충돌로 원본 파일이 사라지는 race를 막기 위해 invocation마다 고유 디렉토리
+# invocation별 고유 디렉토리: electron-builder가 같은 파일을 여러 번 부르거나
+# x64/arm64를 병렬로 sign할 때의 tmp/beforeSign 충돌을 차단
 BEFORE_SIGN_DIR=$(mktemp -d "$ROOT_DIR_PATH/tmp/beforeSign/sign.XXXXXX")
+SIGNED_DIR="$BEFORE_SIGN_DIR/signed"
+mkdir -p "$SIGNED_DIR"
 trap 'rm -rf "$BEFORE_SIGN_DIR"' EXIT
 
 INPUT_FILE_NAME=$(basename "$INPUT_FILE_PATH")
-BEFORE_SIGN_FILE_PATH="$BEFORE_SIGN_DIR/$INPUT_FILE_NAME"
-mv "$INPUT_FILE_PATH" "$BEFORE_SIGN_FILE_PATH"
+INPUT_FILE_EXT="${INPUT_FILE_NAME##*.}"
+# 공백 없는 안전한 임시 이름 — CodeSignTool 인자 파싱이 공백에서 split되는 문제 회피
+SAFE_NAME="forsigning.${INPUT_FILE_EXT}"
+BEFORE_SIGN_FILE_PATH="$BEFORE_SIGN_DIR/$SAFE_NAME"
+SIGNED_FILE_PATH="$SIGNED_DIR/$SAFE_NAME"
 
+mv "$INPUT_FILE_PATH" "$BEFORE_SIGN_FILE_PATH"
 echo "Moved to temp: $BEFORE_SIGN_FILE_PATH"
 
 cd "$ROOT_DIR_PATH/tmp/codesign"
 ./CodeSignTool.sh sign \
-  -credential_id="$ESIGNER_CREDENTIAL_ID" \
-  -username="$ESIGNER_USERNAME" \
-  -password="$ESIGNER_PASSWORD" \
-  -totp_secret="$ESIGNER_TOTP_SECRET" \
-  -output_dir_path="$OUTPUT_DIR_PATH" \
-  -input_file_path="$BEFORE_SIGN_FILE_PATH"
+  "-credential_id=$ESIGNER_CREDENTIAL_ID" \
+  "-username=$ESIGNER_USERNAME" \
+  "-password=$ESIGNER_PASSWORD" \
+  "-totp_secret=$ESIGNER_TOTP_SECRET" \
+  "-output_dir_path=$SIGNED_DIR" \
+  "-input_file_path=$BEFORE_SIGN_FILE_PATH"
 
-# CodeSignTool은 OUTPUT_DIR_PATH/<basename(input)>로 출력 → 원본 위치 그대로 복원됨
-echo "Signed: $OUTPUT_DIR_PATH/$INPUT_FILE_NAME"
+# CodeSignTool.sh wrapper가 내부 에러에도 exit 0으로 종료할 수 있어
+# 출력 파일 존재로 명시적 검증 — 실패하면 set -e가 잡아냄
+test -f "$SIGNED_FILE_PATH"
+
+mv "$SIGNED_FILE_PATH" "$INPUT_FILE_PATH"
+echo "Signed: $INPUT_FILE_PATH"

--- a/signing/window-signing.bat
+++ b/signing/window-signing.bat
@@ -1,32 +1,35 @@
 @echo off
+setlocal enabledelayedexpansion
 
-set "ESIGNER_CREDENTIAL_ID=%1"
-set "ESIGNER_USERNAME=%2"
-set "ESIGNER_PASSWORD=%3"
-set "ESIGNER_TOTP_SECRET=%4"
-set "ROOT_DIR_PATH=%5"
-set "INPUT_FILE_PATH=%6"
-set "OUTPUT_DIR_PATH=%7"
+set "ESIGNER_CREDENTIAL_ID=%~1"
+set "ESIGNER_USERNAME=%~2"
+set "ESIGNER_PASSWORD=%~3"
+set "ESIGNER_TOTP_SECRET=%~4"
+set "ROOT_DIR_PATH=%~5"
+set "INPUT_FILE_PATH=%~6"
+set "OUTPUT_DIR_PATH=%~7"
 
 if not exist "%ROOT_DIR_PATH%\tmp\beforeSign" mkdir "%ROOT_DIR_PATH%\tmp\beforeSign"
 
+REM electron-builder가 병렬로 sign 훅을 호출할 때의 path 충돌을 피하기 위해
+REM invocation마다 고유 디렉토리를 만든다 (%RANDOM% 두 번 + %TIME%)
+set "BEFORE_SIGN_DIR=%ROOT_DIR_PATH%\tmp\beforeSign\sign-%RANDOM%-%RANDOM%-%TIME::=%"
+set "BEFORE_SIGN_DIR=%BEFORE_SIGN_DIR: =0%"
+mkdir "%BEFORE_SIGN_DIR%" || exit /b 1
+
 for %%F in ("%INPUT_FILE_PATH%") do set "INPUT_FILE_NAME=%%~nxF"
-set "BEFORE_SIGN_FILE_NAME=forsigning.%INPUT_FILE_NAME%"
-set "BEFORE_SIGN_FILE_PATH=%ROOT_DIR_PATH%\tmp\beforeSign%BEFORE_SIGN_FILE_NAME%"
+set "BEFORE_SIGN_FILE_PATH=%BEFORE_SIGN_DIR%\%INPUT_FILE_NAME%"
 
-move "%INPUT_FILE_PATH%" "%BEFORE_SIGN_FILE_PATH%"
+move "%INPUT_FILE_PATH%" "%BEFORE_SIGN_FILE_PATH%" || exit /b 1
 
-echo Copy to before folder: %BEFORE_SIGN_FILE_PATH%
+echo Moved to temp: %BEFORE_SIGN_FILE_PATH%
 echo.
 
-cd "%ROOT_DIR_PATH%\tmp\codesign"
-CodeSignTool.bat sign -credential_id="%ESIGNER_CREDENTIAL_ID%" -username="%ESIGNER_USERNAME%" -password="%ESIGNER_PASSWORD%" -totp_secret="%ESIGNER_TOTP_SECRET%" -output_dir_path="%OUTPUT_DIR_PATH%" -input_file_path="%BEFORE_SIGN_FILE_PATH%"
+cd /d "%ROOT_DIR_PATH%\tmp\codesign"
+call CodeSignTool.bat sign -credential_id="%ESIGNER_CREDENTIAL_ID%" -username="%ESIGNER_USERNAME%" -password="%ESIGNER_PASSWORD%" -totp_secret="%ESIGNER_TOTP_SECRET%" -output_dir_path="%OUTPUT_DIR_PATH%" -input_file_path="%BEFORE_SIGN_FILE_PATH%"
+if errorlevel 1 exit /b 1
 
-echo Finish signing: %OUTPUT_DIR_PATH%%BEFORE_SIGN_FILE_NAME%
-echo.
+REM CodeSignTool은 OUTPUT_DIR_PATH/<basename(input)>로 출력 → 원본 위치 그대로 복원됨
+echo Signed: %OUTPUT_DIR_PATH%\%INPUT_FILE_NAME%
 
-set "AFTER_SIGN_FILE_PATH=%OUTPUT_DIR_PATH%%BEFORE_SIGN_FILE_NAME%"
-move "%AFTER_SIGN_FILE_PATH%" "%INPUT_FILE_PATH%"
-
-echo Rename to final file: %AFTER_SIGN_FILE_PATH% -> %INPUT_FILE_PATH%
-echo.
+rmdir /s /q "%BEFORE_SIGN_DIR%"


### PR DESCRIPTION
## Summary

긴급 핫픽스 릴리즈. 2.8.5에서 Windows 자동 업데이트 후 사용자 PC에서 launcher 바이너리가 사라지는 회귀를 일으킨 사이닝 race condition을 수정합니다.

### 사고 요약 (2.8.5)

- `signing/linux-signing.sh`가 `tmp/beforeSign/forsigning.<ext>` 단일 경로를 모든 sign 호출에서 공유 → electron-builder가 x64/arm64를 병렬로 sign할 때 입력 파일 충돌 → 일부 .exe가 원래 위치로 복원되지 않은 채 NSIS 패키징 → **155MB → 58MB로 축소된 설치 파일**이 main 채널에 publish됨 → 사용자 업데이트 시 본체 바이너리 누락
- 스크립트에 `set -e`가 없어 mv 실패가 CI를 fail시키지 못해 깨진 산출물이 그대로 ship됨
- 이미 `main/launcher/latest.yml`은 별도로 2.8.4 메타데이터로 롤백 완료

### 이 PR의 변경

- **`signing/linux-signing.sh`** — invocation별 `mktemp -d` 임시 디렉토리, `forsigning.<ext>` 정규화로 공백 회피, 출력도 임시 디렉토리 하위 `signed/`로 라우팅해 호출 간 출력 충돌 차단, `set -euo pipefail` + `test -f`로 silent failure를 즉시 빌드 실패로 surfacing
- **`signing/window-signing.bat`** — 현재 macOS 러너에서 사용되진 않지만 동일 결함이 있어 같은 형태로 보존성 정렬 + 경로 separator 누락 버그도 수정
- **`package.json`** — 2.8.5 → 2.8.6

## 검증

production SSL.com cert로 internal 빌드 환경에서 실제 사인 흐름 확인:

```
sign.HrN8LV → Code signed successfully → Nine Chronicles Internal.exe
sign.ivbQPw → Code signed successfully → Nine Chronicles Internal.exe (재호출)
sign.2CXa4y → Code signed successfully → win-arm64-unpacked/...
... (총 8회 sequential sign)
```

- 각 호출이 고유 temp dir 사용 — race 자체가 발생 불가
- 동일 파일 재사인도 정상 처리
- `mv: No such file` 0건, `Unmatched arguments` 0건

## Test plan

- [ ] 머지 후 태그 `2.8.6` 푸시 → main Release 워크플로 실행
- [ ] Windows `Dist-w` artifact 크기 ~363MB 수준 (2.8.5의 깨진 136MB가 아닌)
- [ ] S3 `main/launcher/Nine Chronicles Setup 2.8.6.exe` 크기 ~155MB
- [ ] CDN `release.nine-chronicles.com/main/launcher/latest.yml` 자동 갱신 후 Windows 사용자 자동 업데이트 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)