### PR TITLE
fix(import): create keystore dir on QR/keyfile import (PLD-1393)

### DIFF
--- a/__tests__/qrDecode.test.ts
+++ b/__tests__/qrDecode.test.ts
@@ -1,0 +1,56 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { checkAndSaveFile } from "src/utils/qrDecode";
+
+const SAMPLE_KEYSTORE = JSON.stringify({
+  version: 3,
+  id: "00000000-0000-0000-0000-000000000000",
+  address: "0000000000000000000000000000000000000000",
+});
+const SAMPLE_UUID = "00000000-0000-0000-0000-000000000000";
+
+describe("checkAndSaveFile", () => {
+  let baseDir: string;
+
+  beforeEach(() => {
+    baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "qr-decode-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it("creates the keystore directory when it does not exist (PLD-1393)", async () => {
+    // Simulate a PC that has never created an account: the keystore folder
+    // does not exist yet.
+    const keyStorePath = path.join(baseDir, "planetarium", "keystore");
+    expect(fs.existsSync(keyStorePath)).toBe(false);
+
+    await expect(
+      checkAndSaveFile(keyStorePath, SAMPLE_KEYSTORE, SAMPLE_UUID),
+    ).resolves.toBeUndefined();
+
+    expect(fs.existsSync(keyStorePath)).toBe(true);
+    const files = fs.readdirSync(keyStorePath);
+    expect(files.some((f) => f.includes(SAMPLE_UUID))).toBe(true);
+  });
+
+  it("saves into an already-existing directory", async () => {
+    await expect(
+      checkAndSaveFile(baseDir, SAMPLE_KEYSTORE, SAMPLE_UUID),
+    ).resolves.toBeUndefined();
+
+    const files = fs.readdirSync(baseDir);
+    expect(files.some((f) => f.includes(SAMPLE_UUID))).toBe(true);
+  });
+
+  it("rejects when a key with the same uuid already exists", async () => {
+    await checkAndSaveFile(baseDir, SAMPLE_KEYSTORE, SAMPLE_UUID);
+
+    await expect(
+      checkAndSaveFile(baseDir, SAMPLE_KEYSTORE, SAMPLE_UUID),
+    ).rejects.toThrow("This key already exists.");
+  });
+});

--- a/src/utils/qrDecode.ts
+++ b/src/utils/qrDecode.ts
@@ -54,6 +54,12 @@ export async function checkAndSaveFile(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     try {
+      // Ensure the keystore directory exists. On a PC that has never created
+      // an account (e.g. a mobile-only user importing via QR for the first
+      // time), the keystore folder is missing and readdirSync/writeFileSync
+      // would throw ENOENT. This mirrors Web3KeyStore.import's behavior.
+      fs.mkdirSync(dirPath, { recursive: true });
+
       const files = fs.readdirSync(dirPath);
 
       const fileExists = files.some((file) => file.includes(uuid));


### PR DESCRIPTION
## 개요

모바일에서만 플레이하던 유저가 처음으로 PC(Windows) 런처로 넘어와 QR 코드(또는 키스토어 JSON 파일)로 키를 임포트할 때, PC에 keystore 폴더가 아직 생성되어 있지 않으면(= PC에서 계정을 한 번도 만든 적 없는 상태) 폴더를 만들지 못하고 `ENOENT` 에러만 노출하며 임포트가 실패하던 문제를 수정합니다.

Jira: [PLD-1393](https://ninecorporation.atlassian.net/browse/PLD-1393)
Slack: https://planetariumhq.slack.com/archives/CC7BWJYTZ/p1782798816496989

## 원인

QR/키파일 임포트 경로는 `Web3KeyStore.import`를 거치지 않고 `checkAndSaveFile()`(`src/utils/qrDecode.ts`)을 직접 호출합니다. 이 함수가 keystore 디렉토리 존재를 가정하고 `fs.readdirSync()`를 바로 호출하기 때문에, 폴더가 없으면 `ENOENT`가 발생합니다. (raw private key 직접 입력 경로는 `Web3KeyStore.import`가 폴더를 자동 생성해 정상 동작)

## 변경 사항

- `checkAndSaveFile()`에서 `readdirSync` 호출 전에 `fs.mkdirSync(dirPath, { recursive: true })`로 디렉토리를 보장. `Web3KeyStore.import`이 사용하는 패턴과 동일.
- 회귀 방지 단위 테스트 추가 (`__tests__/qrDecode.test.ts`): 폴더 부재 시 생성 / 기존 폴더 / 중복 키 거부.

## 테스트

- [x] `yarn test --run __tests__/qrDecode.test.ts` (3 passed)
- [x] `yarn tsc --noEmit`
- [x] `yarn eslint` / `yarn prettier --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)