### PR TITLE
fix(launcher): defend against white screen on bad-node connection (PLD-1358)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -173,11 +173,15 @@ const NonStaleNodeList = (
   nodeList: NodeInfo[],
   staleThreshold: number,
 ): NodeInfo[] => {
-  if (staleThreshold < 0) {
-    return nodeList;
+  // tip이 0(genesis/미싱크) 이하인 노드는 죽은 것으로 간주하고 후보에서 제외한다.
+  // 이렇게 하지 않으면 응답 노드가 전부 tip=0일 때 maxTip=0이 되어
+  // 상대 임계치(maxTip - staleThreshold)가 음수가 되고 죽은 노드가 통과한다.
+  const liveNodes = nodeList.filter((node) => node.tip > 0);
+  if (staleThreshold < 0 || liveNodes.length === 0) {
+    return liveNodes;
   }
-  const maxTip = Math.max(...nodeList.map((node) => node.tip));
-  return nodeList.filter((node) => node.tip >= maxTip - staleThreshold);
+  const maxTip = Math.max(...liveNodes.map((node) => node.tip));
+  return liveNodes.filter((node) => node.tip >= maxTip - staleThreshold);
 };
 
 const RpcServerHost = (): { host: string; notDefault: boolean } => {

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -17,6 +17,7 @@ export interface IConfig {
   LaunchPlayer: boolean;
   RemoteNodeList: string[];
   RemoteClientStaleTipLimit: number;
+  NodeHealthStaleMs: number;
   DownloadBaseURL: string;
   UseUpdate: boolean;
   ActivationCodeUrl: string;

--- a/src/main/application.ts
+++ b/src/main/application.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, shell } from "electron";
 import { enable as remoteEnable } from "@electron/remote/main";
 import { join } from "path";
+import log from "electron-log";
 import logoImage from "src/renderer/resources/launcher-logo.png";
 
 export let isQuitting = false;
@@ -24,6 +25,31 @@ export async function createWindow(): Promise<BrowserWindow> {
     icon: join(app.getAppPath(), logoImage),
   });
   remoteEnable(win.webContents);
+
+  // 렌더러가 죽거나(흰화면) 멈추는 상황을 main.log에 남긴다.
+  // 렌더러가 hang이면 renderer.log에는 아무것도 안 남으므로 여기서 잡는 것이 핵심.
+  win.webContents.on("render-process-gone", (_event, details) => {
+    log.error(
+      `[renderer] render-process-gone: reason=${details.reason}, exitCode=${details.exitCode}`,
+    );
+  });
+  win.webContents.on("unresponsive", () => {
+    log.error("[renderer] webContents became unresponsive (possible hang)");
+  });
+  win.webContents.on("responsive", () => {
+    log.info("[renderer] webContents responsive again");
+  });
+  win.webContents.on(
+    "did-fail-load",
+    (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      // -3(ERR_ABORTED)은 정상 취소(리다이렉트 등)이므로 무시.
+      if (!isMainFrame || errorCode === -3) return;
+      log.error(
+        `[renderer] did-fail-load: code=${errorCode}, desc=${errorDescription}, url=${validatedURL}`,
+      );
+    },
+  );
+
   win.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith("https://stately.ai/viz?inspect")) {
       return {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import { ApolloProvider } from "@apollo/client";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { ipcRenderer } from "electron";
 import { HashRouter as Router } from "react-router-dom";
 import Routes from "./Routes";
@@ -12,56 +12,18 @@ import { ExternalURLProvider } from "src/utils/useExternalURL";
 import { observer } from "mobx-react";
 import { Planet } from "src/interfaces/registry";
 import { NodeInfo } from "src/config";
+import ConnectionErrorView from "src/renderer/components/core/ConnectionErrorView";
+import { useNodeHealth } from "src/utils/useNodeHealth";
 
-function ConnectionErrorView({
-  error,
-  onRetry,
-}: {
-  error: string;
-  onRetry: () => void;
-}) {
-  const [retrying, setRetrying] = useState(false);
-  return (
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "#1d1e1f",
-        color: "white",
-        fontFamily: "sans-serif",
-      }}
-    >
-      <h1 style={{ color: "#74f4bc", marginBottom: 16 }}>Connection Failed</h1>
-      <p style={{ maxWidth: 400, textAlign: "center", marginBottom: 24 }}>
-        Unable to connect to the Nine Chronicles network. Please check your
-        internet connection.
-      </p>
-      <p style={{ fontSize: 12, color: "#888", marginBottom: 24 }}>{error}</p>
-      <button
-        onClick={() => {
-          setRetrying(true);
-          onRetry();
-        }}
-        disabled={retrying}
-        style={{
-          backgroundColor: retrying ? "#555" : "#3e2a8d",
-          color: "white",
-          border: "none",
-          padding: "12px 36px",
-          fontSize: 16,
-          fontWeight: "bold",
-          cursor: retrying ? "default" : "pointer",
-          borderRadius: 4,
-        }}
-      >
-        {retrying ? "Retrying..." : "Retry"}
-      </button>
-    </div>
-  );
+// ApolloProvider 하위에서 돌면서 붙어 있는 노드의 tip 진행을 감시한다.
+// 노드가 런타임에 블록을 더 이상 안 먹여주면(desync/hang) onUnhealthy를 호출해
+// 상위(App)의 연결에러 경로 = ConnectionErrorView + retry-planetary-init 로 넘긴다.
+function NodeHealthMonitor({ onUnhealthy }: { onUnhealthy: () => void }) {
+  const { healthy } = useNodeHealth();
+  useEffect(() => {
+    if (!healthy) onUnhealthy();
+  }, [healthy, onUnhealthy]);
+  return null;
 }
 
 function App() {
@@ -91,6 +53,12 @@ function App() {
       .then((v) => game.setGeoBlock(v.country, v.isWhitelist ?? false));
   };
 
+  // 런타임에 노드 연결이 끊긴 것으로 판단되면 초기 init 실패와 동일한 에러 경로로 보낸다.
+  const handleNodeUnhealthy = useCallback(() => {
+    setInitError((prev) => prev ?? "Connection to the node was lost.");
+    setRetryCount((c) => c + 1);
+  }, []);
+
   useEffect(() => {
     ipcRenderer.invoke("get-planetary-info").then(handlePlanetaryResult);
     refreshGeoBlock();
@@ -118,6 +86,7 @@ function App() {
   return (
     <LocaleProvider>
       <ApolloProvider client={client}>
+        <NodeHealthMonitor onUnhealthy={handleNodeUnhealthy} />
         <StoreProvider>
           <APVSubscriptionProvider>
             <ExternalURLProvider>

--- a/src/renderer/components/core/ConnectionErrorView/index.tsx
+++ b/src/renderer/components/core/ConnectionErrorView/index.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+
+interface ConnectionErrorViewProps {
+  error: string;
+  onRetry: () => void;
+  title?: string;
+  description?: string;
+}
+
+// 노드 연결 실패 / 런타임 연결 손실 / 렌더 예외 등에서 공통으로 쓰는 폴백 화면.
+// App(초기 init 실패), ErrorBoundary(렌더 예외), NodeHealthMonitor(런타임 연결 손실)에서 재사용한다.
+function ConnectionErrorView({
+  error,
+  onRetry,
+  title = "Connection Failed",
+  description = "Unable to connect to the Nine Chronicles network. Please check your internet connection.",
+}: ConnectionErrorViewProps) {
+  const [retrying, setRetrying] = useState(false);
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "#1d1e1f",
+        color: "white",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <h1 style={{ color: "#74f4bc", marginBottom: 16 }}>{title}</h1>
+      <p style={{ maxWidth: 400, textAlign: "center", marginBottom: 24 }}>
+        {description}
+      </p>
+      <p style={{ fontSize: 12, color: "#888", marginBottom: 24 }}>{error}</p>
+      <button
+        onClick={() => {
+          setRetrying(true);
+          onRetry();
+        }}
+        disabled={retrying}
+        style={{
+          backgroundColor: retrying ? "#555" : "#3e2a8d",
+          color: "white",
+          border: "none",
+          padding: "12px 36px",
+          fontSize: 16,
+          fontWeight: "bold",
+          cursor: retrying ? "default" : "pointer",
+          borderRadius: 4,
+        }}
+      >
+        {retrying ? "Retrying..." : "Retry"}
+      </button>
+    </div>
+  );
+}
+
+export default ConnectionErrorView;

--- a/src/renderer/components/core/ErrorBoundary/index.tsx
+++ b/src/renderer/components/core/ErrorBoundary/index.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { ipcRenderer } from "electron";
+import ConnectionErrorView from "../ConnectionErrorView";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+// 렌더 트리에서 던져진 예외를 잡아 흰화면 대신 폴백 UI를 띄우고 로그를 남긴다.
+// 이게 없으면 렌더 예외 시 React가 트리를 통째로 언마운트해 빈 흰 화면이 된다.
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // console.* 는 electron-log로 연결되어 renderer.log에 기록된다.
+    console.error(
+      "[ErrorBoundary] Uncaught render error:",
+      error,
+      info.componentStack,
+    );
+  }
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      return (
+        <ConnectionErrorView
+          title="Something went wrong"
+          description="The launcher ran into an unexpected error. Retrying will restart the launcher."
+          error={error.message}
+          // 노드를 다시 고른 뒤(retry-planetary-init) 렌더러를 재시작해
+          // 같은 불량 노드로 재접속하는 것을 피한다.
+          onRetry={() => {
+            ipcRenderer
+              .invoke("retry-planetary-init")
+              .finally(() => location.reload());
+          }}
+        />
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/renderer/render.tsx
+++ b/src/renderer/render.tsx
@@ -6,12 +6,21 @@ import "core-js";
 import "core-js/proposals/array-find-from-last";
 import "remove-focus-outline";
 import App from "./App";
+import ErrorBoundary from "./components/core/ErrorBoundary";
 
 import { getCurrentWindow } from "@electron/remote";
 import _refiner from "refiner-js";
 import { t } from "@transifex/native";
 
 Object.assign(console, electronLog.functions);
+
+// React가 못 잡는 비동기/전역 예외까지 renderer.log에 남긴다.
+window.addEventListener("error", (event) => {
+  console.error("[window.onerror]", event.error ?? event.message);
+});
+window.addEventListener("unhandledrejection", (event) => {
+  console.error("[unhandledrejection]", event.reason);
+});
 
 _refiner("onShow", () => {
   if (getCurrentWindow().isVisible() && getCurrentWindow().isFocused()) return;
@@ -25,4 +34,9 @@ _refiner("onShow", () => {
   });
 });
 
-DOM.render(<App />, document.getElementById("root"));
+DOM.render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>,
+  document.getElementById("root"),
+);

--- a/src/utils/useNodeHealth.ts
+++ b/src/utils/useNodeHealth.ts
@@ -1,0 +1,86 @@
+import { useApolloClient } from "@apollo/client";
+import { useEffect, useState } from "react";
+import { get } from "src/config";
+import { TipDocument, TipSubscription } from "src/generated/graphql";
+
+// 마지막 tip 갱신 이후 이 시간(ms) 동안 새 블록이 안 오면 노드가 죽은 것으로 간주.
+// 블록 간격(~8s) 기준 약 3~4블록 → 정상 지연(1~2블록 jitter) 오탐은 피하면서
+// 무소식은 빠르게 감지. get-planetary-info / graphql 재시도의 30s 상한과도 일관.
+export const NODE_HEALTH_STALE_MS = 30_000;
+
+// 설정(NodeHealthStaleMs)에 유효한 양수가 있으면 그 값을, 없으면 기본 30s를 쓴다.
+// 배포 후에도 재빌드 없이 원격 config로 임계값을 조절할 수 있게 한다.
+function resolveStaleMs(): number {
+  const configured = get("NodeHealthStaleMs", NODE_HEALTH_STALE_MS);
+  return typeof configured === "number" && configured > 0
+    ? configured
+    : NODE_HEALTH_STALE_MS;
+}
+
+// 붙어 있는 노드가 런타임에 블록을 더 이상 안 먹여주면(desync/hang) unhealthy로 전환한다.
+// 첫 tip이 staleMs 안에 한 번도 안 오면(=죽은 노드에 붙은 채 시작) 그것도 unhealthy.
+//
+// 오탐 방지:
+// - blind setTimeout 대신 "마지막 tip 이후 실제 경과 시간(wall-clock)"으로 판정한다.
+//   랩탑 sleep/백그라운드 타이머 스로틀로 프로세스가 멈췄다 깨어나도 잘못 만료되지 않는다.
+// - 백그라운드(hidden) 구간에는 판정을 보류하고, 화면 복귀/네트워크 복구 시 기준 시각을
+//   리셋해 재연결된 구독이 tip을 받을 새 window를 준다.
+// - 구독 error는 로그만 남기고 stale 판정에 위임한다(일시적 WS 오류에 즉시 튕기지 않도록).
+export function useNodeHealth(staleMs: number = resolveStaleMs()): {
+  healthy: boolean;
+} {
+  const client = useApolloClient();
+  const [healthy, setHealthy] = useState(true);
+
+  useEffect(() => {
+    let lastTipAt = Date.now();
+
+    // 화면 복귀/온라인 복구: 그동안 tip을 못 받은 건 노드 탓이 아니므로 window를 리셋.
+    const resetWindow = () => {
+      lastTipAt = Date.now();
+      setHealthy(true);
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") resetWindow();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("online", resetWindow);
+
+    const checkInterval = setInterval(
+      () => {
+        // 백그라운드면 판정 보류(복귀 시 resetWindow가 새 window를 준다).
+        if (document.visibilityState !== "visible") return;
+        if (Date.now() - lastTipAt >= staleMs) {
+          console.error(
+            `[useNodeHealth] no tip update for ${staleMs}ms — treating node as unhealthy`,
+          );
+          setHealthy(false);
+        }
+      },
+      Math.min(staleMs, 5000),
+    );
+
+    const subscription = client
+      .subscribe<TipSubscription>({ query: TipDocument })
+      .subscribe({
+        next(result) {
+          if (!result.data || !result.data.tipChanged) return;
+          lastTipAt = Date.now();
+          setHealthy(true);
+        },
+        // 일시적 오류는 로그만 — 진짜 죽은 노드는 위 stale 판정이 잡는다.
+        error(error) {
+          console.error("[useNodeHealth] tip subscription error:", error);
+        },
+      });
+
+    return () => {
+      clearInterval(checkInterval);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("online", resetWindow);
+      subscription.unsubscribe();
+    };
+  }, [client, staleMs]);
+
+  return { healthy };
+}


### PR DESCRIPTION
## Summary
런쳐가 런타임에 desync/hang 된 RPC 노드(예: tip이 0에 멈춘 커뮤니티 노드 odin6/heimdall6)에 붙어 있을 때 **흰화면**이 뜨던 문제를 방어합니다. 기존 방어(PLD-1237)는 init 시점 "붙을 노드가 아예 없음"만 커버했고, 붙은 노드가 런타임에 맛이 가거나 렌더 예외가 나는 케이스는 폴백도 로그도 없었습니다.

- **ErrorBoundary** 추가 (`src/renderer/components/core/ErrorBoundary`): 렌더 예외 시 흰화면 대신 폴백 UI + error/componentStack을 renderer.log에 기록. Retry는 노드 재선택(`retry-planetary-init`) 후 reload.
- **전역 에러 핸들러** (`render.tsx`): `window.error` / `unhandledrejection` → renderer.log (비-React 예외).
- **메인 프로세스 렌더러 상태 로깅** (`application.ts`): `render-process-gone` / `unresponsive` / `did-fail-load` → main.log. 렌더러 hang 시 renderer.log엔 안 남으므로 이게 핵심 신호.
- **노드 헬스 워치독** (`src/utils/useNodeHealth.ts` + `App.tsx`의 `NodeHealthMonitor`): 마지막 `TipChanged` 이후 임계 시간 갱신 없거나 구독 에러 → 기존 `ConnectionErrorView` + `retry-planetary-init`(노드 재선택) 경로로 연결. 임계값 기본 **30초(≈3~4블록)**, `NodeHealthStaleMs` config 키로 재빌드 없이 원격 조절 가능.
- **선택 단계 강화** (`config.ts` `NonStaleNodeList`): tip ≤ 0(genesis/미싱크) 노드를 후보에서 제외 + 빈 리스트 `Math.max` 가드.
- 리팩터: `ConnectionErrorView`를 App.tsx 인라인 → 공용 컴포넌트로 분리.

## Test plan
- [x] `yarn tsc --noEmit` 통과
- [x] `yarn eslint ./src --quiet` 통과
- [x] `yarn prettier --check` 통과
- [x] `yarn test --run` — 38 pass (기존 실패인 main.spec.ts는 .env PASSWORD 필요로 무관)
- [ ] 실제 desync 노드로 재현하여 (a) 흰화면 대신 ConnectionErrorView 노출, (b) 워치독 30초 임계 오탐 없음 확인
- [ ] 정상 접속 시 회귀 없음 (로그인 → 로비 정상)

관련: PLD-1358
